### PR TITLE
Support for "aliases"

### DIFF
--- a/itests/test_suite.sh
+++ b/itests/test_suite.sh
@@ -43,7 +43,7 @@ assert_stderr(){
 export NL=$'\n'
 
 echo "Cleaning JBANG_CACHE"
-rm -rf ~/.jbang
+rm -rf ~/.jbang/cache
 
 echo Testing with `which jbang`
 
@@ -79,7 +79,7 @@ esac
 export JBANG_REPO=$SCRATCH/testrepo
 assert_stderr "jbang classpath_log.java" "[jbang] Resolving dependencies...\n[jbang]     Resolving log4j:log4j:1.2.17...Done\n[jbang] Dependencies resolved\n[jbang] Building jar..."
 assert_raises "test -d $SCRATCH/testrepo" 0
-assert "grep -c $SCRATCH/testrepo ~/.jbang/dependency_cache.txt" 1
+assert "grep -c $SCRATCH/testrepo ~/.jbang/cache/dependency_cache.txt" 1
 # run it 2nd time and no resolution should happen
 assert_stderr "jbang classpath_log.java" ""
 

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -159,6 +159,10 @@ public class Main implements Callable<Integer> {
 			"-n", "--native" }, description = "Build via native-image and run", defaultValue = "false")
 	boolean nativeImage;
 
+	@Option(names = { "-a",
+			"--alias" }, description = "Stores the current script URL/path as an alias with the given name.")
+	String alias;
+
 	public int completion() throws IOException {
 		String script = AutoComplete.bash(
 				spec.name(),
@@ -314,6 +318,10 @@ public class Main implements Callable<Integer> {
 					info("run: " + cmdline);
 				}
 				out.println(cmdline);
+
+				if (alias != null) {
+					Settings.addAlias(alias, scriptOrFile);
+				}
 			}
 		}
 		return 0;

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -907,7 +907,7 @@ public class Main implements Callable<Integer> {
 		if (scriptFile == null) {
 			// Not found as such, so let's check the aliases
 			if (Settings.getAliases().containsKey(scriptResource)) {
-				scriptFile = getScriptFile(Settings.getAliases().getProperty(scriptResource));
+				scriptFile = getScriptFile(Settings.getAliases().get(scriptResource).resource);
 			}
 		}
 

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -163,6 +163,9 @@ public class Main implements Callable<Integer> {
 			"--alias" }, description = "Stores the current script URL/path as an alias with the given name.")
 	String alias;
 
+	@Option(names = { "--remove-alias" }, description = "Removes the alias with the given name.")
+	boolean removeAlias;
+
 	public int completion() throws IOException {
 		String script = AutoComplete.bash(
 				spec.name(),
@@ -224,6 +227,8 @@ public class Main implements Callable<Integer> {
 			return 0; // quit(0);
 		} else if (completionRequested) {
 			return completion();
+		} else if (removeAlias) {
+			Settings.removeAlias(scriptOrFile);
 		}
 
 		if (insecure) {

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -907,7 +907,7 @@ public class Main implements Callable<Integer> {
 		if (scriptFile == null) {
 			// Not found as such, so let's check the aliases
 			if (Settings.getAliases().containsKey(scriptResource)) {
-				scriptFile = getScriptFile(Settings.getAliases().get(scriptResource).resource);
+				scriptFile = getScriptFile(Settings.getAliases().get(scriptResource).scriptRef);
 			}
 		}
 

--- a/src/main/java/dk/xam/jbang/Settings.java
+++ b/src/main/java/dk/xam/jbang/Settings.java
@@ -2,11 +2,12 @@ package dk.xam.jbang;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
-import java.io.Reader;
 import java.nio.file.Paths;
+import java.util.Comparator;
 import java.util.Properties;
 
 import io.quarkus.qute.Template;
@@ -24,7 +25,8 @@ public class Settings {
 	private static TrustedSources trustedSources;
 
 	final private static Properties aliases = new Properties();
-
+	final private static String ALIASES_FILE_HEADER = "Aliases file, created by JBang";
+	
 	static {
 		String v = System.getenv("JBANG_CACHE_DIR");
 
@@ -116,7 +118,7 @@ public class Settings {
 
 	public static void clearCache() {
 		try {
-			Files.walk(Settings.getCacheDir().toPath())
+			Files	.walk(Settings.getCacheDir().toPath())
 					.sorted(Comparator.reverseOrder())
 					.map(Path::toFile)
 					.forEach(File::delete);
@@ -143,5 +145,15 @@ public class Settings {
 			}
 		}
 		return aliases;
+	}
+
+	public static void addAlias(String name, String resource) {
+		Properties as = getAliases();
+		try (Writer out = Files.newBufferedWriter(JBANG_ALIASES_FILE)) {
+			as.setProperty(name, resource);
+			as.store(out, ALIASES_FILE_HEADER);
+		} catch (IOException ex) {
+			Util.warnMsg("Unable to add alias: " + ex.getMessage());
+		}
 	}
 }

--- a/src/main/java/dk/xam/jbang/Settings.java
+++ b/src/main/java/dk/xam/jbang/Settings.java
@@ -179,10 +179,14 @@ public class Settings {
 		return getAliasInfo().aliases;
 	}
 
-	public static void addAlias(String name, String resource) {
+	public static void addAlias(String name, String scriptRef) {
+		if (getAliases().containsKey(scriptRef)) {
+			throw new ExitException(1, "Can't create alias to another alias.");
+		}
+		getAliases().put(name, new Alias(scriptRef));
+
 		setupJBangDir();
 		try (Writer out = Files.newBufferedWriter(JBANG_ALIASES_FILE)) {
-			getAliases().put(name, new Alias(resource));
 			Gson parser = new GsonBuilder().setPrettyPrinting().create();
 			parser.toJson(getAliasInfo(), out);
 		} catch (IOException ex) {

--- a/src/main/java/dk/xam/jbang/Settings.java
+++ b/src/main/java/dk/xam/jbang/Settings.java
@@ -47,7 +47,7 @@ public class Settings {
 
 		DEP_LOOKUP_CACHE_FILE = JBANG_CACHE_DIR.resolve("dependency_cache.txt");
 
-		JBANG_TRUSTED_SOURCES_FILE = JBANG_CACHE_DIR.resolve("trusted-sources.json");
+		JBANG_TRUSTED_SOURCES_FILE = JBANG_DIR.resolve("trusted-sources.json");
 
 		setupCache();
 
@@ -148,10 +148,10 @@ public class Settings {
 	}
 
 	static class Alias {
-		final String resource;
+		final String scriptRef;
 
-		Alias(String resource) {
-			this.resource = resource;
+		Alias(String scriptRef) {
+			this.scriptRef = scriptRef;
 		}
 	}
 
@@ -159,7 +159,7 @@ public class Settings {
 		Map<String, Alias> aliases = new HashMap<>();
 	}
 
-	public static Map<String, Alias> getAliases() {
+	private static AliasInfo getAliasInfo() {
 		if (aliasInfo == null) {
 			if (Files.isRegularFile(JBANG_ALIASES_FILE)) {
 				try (Reader in = Files.newBufferedReader(JBANG_ALIASES_FILE)) {
@@ -172,7 +172,11 @@ public class Settings {
 				aliasInfo = new AliasInfo();
 			}
 		}
-		return aliasInfo.aliases;
+		return aliasInfo;
+	}
+
+	public static Map<String, Alias> getAliases() {
+		return getAliasInfo().aliases;
 	}
 
 	public static void addAlias(String name, String resource) {
@@ -180,19 +184,19 @@ public class Settings {
 		try (Writer out = Files.newBufferedWriter(JBANG_ALIASES_FILE)) {
 			getAliases().put(name, new Alias(resource));
 			Gson parser = new GsonBuilder().setPrettyPrinting().create();
-			parser.toJson(aliasInfo, out);
+			parser.toJson(getAliasInfo(), out);
 		} catch (IOException ex) {
 			Util.warnMsg("Unable to add alias: " + ex.getMessage());
 		}
 	}
 
 	public static void removeAlias(String name) {
-		if (aliasInfo.aliases.containsKey(name)) {
+		if (getAliasInfo().aliases.containsKey(name)) {
 			setupJBangDir();
 			try (Writer out = Files.newBufferedWriter(JBANG_ALIASES_FILE)) {
 				getAliases().remove(name);
 				Gson parser = new GsonBuilder().setPrettyPrinting().create();
-				parser.toJson(aliasInfo, out);
+				parser.toJson(getAliasInfo(), out);
 			} catch (IOException ex) {
 				Util.warnMsg("Unable to remove alias: " + ex.getMessage());
 			}

--- a/src/main/java/dk/xam/jbang/Settings.java
+++ b/src/main/java/dk/xam/jbang/Settings.java
@@ -26,7 +26,7 @@ public class Settings {
 
 	final private static Properties aliases = new Properties();
 	final private static String ALIASES_FILE_HEADER = "Aliases file, created by JBang";
-	
+
 	static {
 		String v = System.getenv("JBANG_CACHE_DIR");
 
@@ -154,6 +154,18 @@ public class Settings {
 			as.store(out, ALIASES_FILE_HEADER);
 		} catch (IOException ex) {
 			Util.warnMsg("Unable to add alias: " + ex.getMessage());
+		}
+	}
+
+	public static void removeAlias(String name) {
+		Properties as = getAliases();
+		if (as.containsKey(name)) {
+			try (Writer out = Files.newBufferedWriter(JBANG_ALIASES_FILE)) {
+				as.remove(name);
+				as.store(out, ALIASES_FILE_HEADER);
+			} catch (IOException ex) {
+				Util.warnMsg("Unable to remove alias: " + ex.getMessage());
+			}
 		}
 	}
 }


### PR DESCRIPTION
With this PR you can do something like:

 - `jbang --alias=printprops https://github.com/quintesse/jbang-scripts/blob/master/system_properties.java`

Script is compiled and executed and prints output.

 - `jbang printprops`

Script prints output

If it some point you want to get rid of the alias you can do:

 - `jbang --remove-alias printprops`

Let me know what you think @maxandersen ! :-)
