### PR TITLE
docs: update github specific icons for asciidoctor syntax

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -2,7 +2,14 @@
 = j'bang - Having fun with Java scripting
 :toc:
 :toc-placement!:
-:icons: font
+ifndef::env-github[:icons: font]
+ifdef::env-github[]
+:caution-caption: :fire:
+:important-caption: :exclamation:
+:note-caption: :paperclip:
+:tip-caption: :bulb:
+:warning-caption: :warning:
+endif::[]
 	
 image:https://img.shields.io/github/release/maxandersen/jbang.svg[Release,link=https://github.com/maxandersen/jbang/releases]
 image:https://github.com/maxandersen/jbang/workflows/ci-build/badge.svg[Build Status,link=https://github.com/maxandersen/jbang/actions]


### PR DESCRIPTION
A minor update to readme for showing icons when rendering on github. 

**Original:**
<img width="274" alt="image" src="https://user-images.githubusercontent.com/877286/83318465-1807fe00-a203-11ea-87cb-cd8e67c9e757.png">

**With this change:**
<img width="231" alt="image" src="https://user-images.githubusercontent.com/877286/83318451-f9096c00-a202-11ea-89fa-3152442989ad.png">


