### PR TITLE
Add support for twitter and carbon url swizzling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
 	implementation 'com.google.code.gson:gson:2.8.6'
 
+	implementation 'org.jsoup:jsoup:1.13.1'
+
 	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api:3.1.4'
 	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.4'
 	implementation "org.slf4j:slf4j-nop:1.7.25"

--- a/readme.adoc
+++ b/readme.adoc
@@ -293,12 +293,17 @@ chmod +x helloworld.java
 ./helloworld jbang!
 ----
 
-You can use `http(s):/` and `file:/` url's for input and github.com based urls will automatically download the raw version (since v0.15).
+You can use `http(s):/` and `file:/` url's for input:.
 
 [source]
 ----
 jbang https://github.com/jbangdev/jbang/blob/master/examples/helloworld.java
 ----
+
+[TIP]
+====
+Sites such as github, gitlab, bitbucket, gist, twitter and carbon.now.sh jbang will try and extract the proper source rather than the raw html.
+====
 
 [TIP]
 ====

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -1058,7 +1058,7 @@ public class Main implements Callable<Integer> {
 			String urlHash = getStableID(scriptURL);
 			File urlCache = new File(Settings.getCacheDir(), "/url_cache_" + urlHash);
 			urlCache.mkdirs();
-			Path path = Util.downloadFile(scriptURL, urlCache);
+			Path path = Util.downloadFileSwizzled(scriptURL, urlCache);
 
 			return path.toFile();
 		} catch (IOException e) {

--- a/src/main/java/dk/xam/jbang/Main.java
+++ b/src/main/java/dk/xam/jbang/Main.java
@@ -127,9 +127,11 @@ public class Main implements Callable<Integer> {
 			"--init" }, description = "Init script with a java class useful for scripting", parameterConsumer = PlainStringFallbackConsumer.class, arity = "0..1", fallbackValue = "hello")
 	String initTemplate;
 
-	@Option(names = {
-			"--adddeps" }, description = "Add dependencies from the build file specified and inject into the .java files.", arity = "1")
-	String fetchDeps;
+	/**
+	 * @Option(names = { "--adddeps" }, description = "Add dependencies from the
+	 *               build file specified and inject into the .java files.", arity =
+	 *               "1") String fetchDeps;
+	 **/
 
 	@Option(names = "--completion", help = true, description = "Output auto-completion script for bash/zsh.\nUsage: source <(jbang --completion)")
 	boolean completionRequested;

--- a/src/test/java/dk/xam/jbang/TestMain.java
+++ b/src/test/java/dk/xam/jbang/TestMain.java
@@ -294,6 +294,45 @@ public class TestMain {
 	}
 
 	@Test
+	void testFetchFromTwitter(@TempDir Path dir) throws IOException {
+
+		verifyHello("https://twitter.com/maxandersen/status/1266329490927616001", dir);
+	}
+
+	@Test
+	void testFetchFromCarbon(@TempDir Path dir) throws IOException {
+
+		verifyHello("https://carbon.now.sh/ae51bf967c98f31a13cba976903030d5", dir);
+	}
+
+	private void verifyHello(String url, Path dir) throws IOException {
+		String u = Main.swizzleURL(url);
+
+		Path x = Util.downloadFileSwizzled(u,
+				dir.toFile());
+		assertEquals("hello.java", x.getFileName().toString());
+		String java = Util.readString(x);
+		assertThat(java, startsWith("//DEPS"));
+		assertThat(java, not(containsString("&gt;")));
+		assertThat(java, containsString("\n"));
+	}
+
+	@Test
+	void testTwitterjsh(@TempDir Path dir) throws IOException {
+		String u = Main.swizzleURL("https://twitter.com/maxandersen/status/1266904846239752192");
+
+		Path x = Util.downloadFileSwizzled(u,
+				dir.toFile());
+		assertEquals("1266904846239752192.jsh", x.getFileName().toString());
+		String java = Util.readString(x);
+		assertThat(java, startsWith("//DEPS"));
+		assertThat(java, not(containsString("&gt;")));
+		assertThat(java, containsString("\n"));
+		assertThat(java, containsString("/exit"));
+
+	}
+
+	@Test
 	void testSwizzle(@TempDir Path dir) throws IOException {
 
 		assertThat(
@@ -309,4 +348,5 @@ public class TestMain {
 				equalTo("https://bitbucket.org/Shoeboom/test/raw/master/helloworld.java"));
 
 	}
+
 }


### PR DESCRIPTION
This lets you do:

`jbang https://twitter.com/maxandersen/status/1266329490927616001`

and

`jbang https://carbon.now.sh/ae51bf967c98f31a13cba976903030d5`

Why:

 * Because...sorry - no why besides because I can ?

This change addreses the need by:

 * if url is exactly twitter.com or carbon.now.sh uses jsoup to parse
   the downloaded html5 and look for `<meta property|name="og:description">` which luckily has the raw text of the tweet/code
 * ...and then only if can find a `class XYZ ...static.*main` in that text