### PR TITLE
Quote JAVA_HOME for non english Windows.

### DIFF
--- a/src/main/scripts/jbang.bat
+++ b/src/main/scripts/jbang.bat
@@ -1,14 +1,14 @@
 @echo off
 
 rem resolve application jar path from script location and convert to windows path when using cygwin
-set jarPath=%~dp0\jbang.jar
+set jarPath=%~dp0jbang.jar
 
 rem prefer JAVA instead of PATH to resolve `java` location
 rem if [[ -z "$JAVA_HOME" ]]; then JAVA_EXEC="java"; else JAVA_EXEC="$JAVA_HOME/bin/java"; fi
 if "%JAVA_HOME%"=="" (
-  set JAVA_EXEC=java
+  set JAVA_EXEC=java.exe
 ) else (
-  set JAVA_EXEC=%JAVA_HOME%\bin\java
+  set JAVA_EXEC="%JAVA_HOME%\bin\java.exe"
 )
 
 rem expose the name of the script being run to the script itself
@@ -18,4 +18,3 @@ rem run it using command substitution to have just the user process once jbang i
 rem eval "exec $(${JAVA_EXEC} -classpath ${jarPath} dk.xam.jbang.Main "$@")"
 FOR /F "tokens=*" %%a in ('%JAVA_EXEC% %JBANG_JAVA_OPTIONS% -classpath %jarPath% dk.xam.jbang.Main %*') do SET OUTPUT=%%a
 %OUTPUT%
-


### PR DESCRIPTION
JAVA_HOME on non english Windows System is usually on Path with Spaces inside like "C:\Program Files\OpenJDK\", so we need to quote them.