### PR TITLE
Extend aliases to store arguments and properties

### DIFF
--- a/src/main/java/dk/xam/jbang/Script.java
+++ b/src/main/java/dk/xam/jbang/Script.java
@@ -52,22 +52,34 @@ public class Script {
 	// true if in this run a jar was build/created
 	private boolean createdJar;
 
-	public Script(File backingFile, String content) throws FileNotFoundException {
+	private List<String> arguments;
+
+	private Map<String, String> properties;
+
+	public Script(File backingFile, String content, List<String> arguments, Map<String, String> properties)
+			throws FileNotFoundException {
 		this.backingFile = backingFile;
 		this.script = content;
+		this.arguments = arguments;
+		this.properties = properties;
 	}
 
-	public Script(File backingFile) throws FileNotFoundException {
+	public Script(File backingFile, List<String> arguments, Map<String, String> properties)
+			throws FileNotFoundException {
 		this.backingFile = backingFile;
+		this.arguments = arguments;
+		this.properties = properties;
 		try (Scanner sc = new Scanner(this.backingFile)) {
 			sc.useDelimiter("\\Z");
 			this.script = sc.next();
 		}
 	}
 
-	public Script(String script) {
+	public Script(String script, List<String> arguments, Map<String, String> properties) {
 		this.backingFile = null;
 		this.script = script;
+		this.arguments = arguments;
+		this.properties = properties;
 	}
 
 	private List<String> getLines() {
@@ -305,5 +317,13 @@ public class Script {
 
 	public boolean wasJarCreated() {
 		return createdJar;
+	}
+
+	public List<String> getArguments() {
+		return (arguments != null) ? arguments : Collections.emptyList();
+	}
+
+	public Map<String, String> getProperties() {
+		return (properties != null) ? properties : Collections.emptyMap();
 	}
 }

--- a/src/main/java/dk/xam/jbang/Settings.java
+++ b/src/main/java/dk/xam/jbang/Settings.java
@@ -151,9 +151,11 @@ public class Settings {
 
 	public static class Alias {
 		public final String scriptRef;
+		public final String description;
 
-		Alias(String scriptRef) {
+		Alias(String scriptRef, String description) {
 			this.scriptRef = scriptRef;
+			this.description = description;
 		}
 	}
 
@@ -186,11 +188,11 @@ public class Settings {
 		return getAliasInfo().aliases;
 	}
 
-	public static void addAlias(String name, String scriptRef) {
+	public static void addAlias(String name, String scriptRef, String description) {
 		if (getAliases().containsKey(scriptRef)) {
 			throw new ExitException(1, "Can't create alias to another alias.");
 		}
-		getAliases().put(name, new Alias(scriptRef));
+		getAliases().put(name, new Alias(scriptRef, description));
 
 		try (Writer out = Files.newBufferedWriter(getAliasesFile())) {
 			Gson parser = new GsonBuilder().setPrettyPrinting().create();

--- a/src/main/java/dk/xam/jbang/Util.java
+++ b/src/main/java/dk/xam/jbang/Util.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
@@ -301,6 +302,11 @@ public class Util {
 			scanner.useDelimiter("\\A");
 			return scanner.hasNext() ? scanner.next() : "";
 		}
+	}
+
+	public static String repeat(String s, int times) {
+		// If Java 11 becomes the default we can change this to String::repeat
+		return String.join("", Collections.nCopies(times, s));
 	}
 
 	static class Gist {

--- a/src/main/java/dk/xam/jbang/cli/Alias.java
+++ b/src/main/java/dk/xam/jbang/cli/Alias.java
@@ -1,6 +1,9 @@
 package dk.xam.jbang.cli;
 
+import java.io.PrintWriter;
+
 import dk.xam.jbang.Settings;
+import dk.xam.jbang.Util;
 
 import picocli.CommandLine;
 
@@ -12,9 +15,11 @@ public class Alias {
 
 	@CommandLine.Command(name = "add", description = "Add alias for script reference.")
 	public Integer add(
+			@CommandLine.Option(names = { "--description",
+					"-d" }, description = "A description for the alias") String description,
 			@CommandLine.Parameters(index = "0", description = "A name for the alias", arity = "1") String name,
 			@CommandLine.Parameters(index = "1", description = "A file or URL to a Java code file", arity = "1") String scriptOrFile) {
-		Settings.addAlias(name, scriptOrFile);
+		Settings.addAlias(name, scriptOrFile, description);
 		return CommandLine.ExitCode.SOFTWARE;
 	}
 
@@ -24,7 +29,16 @@ public class Alias {
 				.keySet()
 				.stream()
 				.sorted()
-				.forEach(a -> spec.commandLine().getOut().println(a + " = " + Settings.getAliases().get(a).scriptRef));
+				.forEach(a -> {
+					PrintWriter out = spec.commandLine().getOut();
+					Settings.Alias ai = Settings.getAliases().get(a);
+					if (ai.description != null) {
+						out.println(a + " = " + ai.description);
+						out.println(Util.repeat(" ", a.length()) + "   (" + ai.scriptRef + ")");
+					} else {
+						out.println(a + " = " + ai.scriptRef);
+					}
+				});
 		return CommandLine.ExitCode.SOFTWARE;
 	}
 

--- a/src/main/java/dk/xam/jbang/cli/Alias.java
+++ b/src/main/java/dk/xam/jbang/cli/Alias.java
@@ -1,6 +1,8 @@
 package dk.xam.jbang.cli;
 
 import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
 
 import dk.xam.jbang.Settings;
 import dk.xam.jbang.Util;
@@ -17,9 +19,12 @@ public class Alias {
 	public Integer add(
 			@CommandLine.Option(names = { "--description",
 					"-d" }, description = "A description for the alias") String description,
+			@CommandLine.Option(names = { "-D" }, description = "set a system property") Map<String, String> properties,
 			@CommandLine.Parameters(index = "0", description = "A name for the alias", arity = "1") String name,
-			@CommandLine.Parameters(index = "1", description = "A file or URL to a Java code file", arity = "1") String scriptOrFile) {
-		Settings.addAlias(name, scriptOrFile, description);
+			@CommandLine.Parameters(index = "1", description = "A file or URL to a Java code file", arity = "1") String scriptOrFile,
+			@CommandLine.Parameters(index = "2..*", arity = "0..*", description = "Parameters to pass on to the script") List<String> userParams) {
+
+		Settings.addAlias(name, scriptOrFile, description, userParams, properties);
 		return CommandLine.ExitCode.SOFTWARE;
 	}
 
@@ -37,6 +42,12 @@ public class Alias {
 						out.println(Util.repeat(" ", a.length()) + "   (" + ai.scriptRef + ")");
 					} else {
 						out.println(a + " = " + ai.scriptRef);
+					}
+					if (ai.arguments != null) {
+						out.println(Util.repeat(" ", a.length()) + "   Arguments: " + String.join(" ", ai.arguments));
+					}
+					if (ai.properties != null) {
+						out.println(Util.repeat(" ", a.length()) + "   Properties: " + ai.properties);
 					}
 				});
 		return CommandLine.ExitCode.SOFTWARE;

--- a/src/main/java/dk/xam/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dk/xam/jbang/cli/BaseScriptCommand.java
@@ -11,6 +11,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import dk.xam.jbang.ExitException;
@@ -34,12 +35,16 @@ public abstract class BaseScriptCommand extends BaseCommand {
 
 	protected Script script;
 
-	public static Script prepareScript(String scriptResource) throws IOException {
+	public static Script prepareScript(String scriptResource, List<String> arguments, Map<String, String> properties)
+			throws IOException {
 		File scriptFile = getScriptFile(scriptResource);
 		if (scriptFile == null) {
 			// Not found as such, so let's check the aliases
-			if (Settings.getAliases().containsKey(scriptResource)) {
-				scriptFile = getScriptFile(Settings.getAliases().get(scriptResource).scriptRef);
+			Settings.Alias alias = Settings.getAlias(scriptResource, arguments, properties);
+			if (alias != null) {
+				scriptFile = getScriptFile(alias.scriptRef);
+				arguments = alias.arguments;
+				properties = alias.properties;
 			}
 		}
 
@@ -68,7 +73,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 
 		Script s = null;
 		try {
-			s = new Script(scriptFile);
+			s = new Script(scriptFile, arguments, properties);
 			s.setOriginal(new File(scriptResource));
 		} catch (FileNotFoundException e) {
 			throw new ExitException(1, e);

--- a/src/main/java/dk/xam/jbang/cli/Edit.java
+++ b/src/main/java/dk/xam/jbang/cli/Edit.java
@@ -27,8 +27,8 @@ public class Edit extends BaseScriptCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
-		script = prepareScript(scriptOrFile);
-		File project = createProjectForEdit(script, userParams, false);
+		script = prepareScript(scriptOrFile, userParams, null);
+		File project = createProjectForEdit(script, false);
 		// err.println(project.getAbsolutePath());
 		if (liveeditor == null) {
 			out.println("echo " + project.getAbsolutePath()); // quit(project.getAbsolutePath());
@@ -66,8 +66,8 @@ public class Edit extends BaseScriptCommand {
 							try {
 								// TODO only regenerate when dependencies changes.
 								info("Regenerating project.");
-								script = prepareScript(scriptOrFile);
-								createProjectForEdit(script, userParams, true);
+								script = prepareScript(scriptOrFile, userParams, null);
+								createProjectForEdit(script, true);
 							} catch (RuntimeException ee) {
 								warn("Error when re-generating project. Ignoring it, but state might be undefined: "
 										+ ee.getMessage());
@@ -88,7 +88,7 @@ public class Edit extends BaseScriptCommand {
 	}
 
 	/** Create Project to use for editing **/
-	File createProjectForEdit(Script script, List<String> userParams, boolean reload) throws IOException {
+	File createProjectForEdit(Script script, boolean reload) throws IOException {
 
 		List<String> collectDependencies = script.collectDependencies();
 		String cp = script.resolveClassPath(offline);
@@ -120,29 +120,29 @@ public class Edit extends BaseScriptCommand {
 		Path destination = new File(tmpProjectDir, "build.gradle").toPath();
 		TemplateEngine engine = Settings.getTemplateEngine();
 
-		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, script.getArguments(),
 				destination);
 
 		// setup eclipse
 		templateName = ".qute.classpath";
 		destination = new File(tmpProjectDir, ".classpath").toPath();
-		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, script.getArguments(),
 				destination);
 
 		templateName = ".qute.project";
 		destination = new File(tmpProjectDir, ".project").toPath();
-		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, script.getArguments(),
 				destination);
 
 		templateName = "main.qute.launch";
 		destination = new File(tmpProjectDir, ".eclipse/" + baseName + ".launch").toPath();
 		destination.toFile().getParentFile().mkdirs();
-		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, script.getArguments(),
 				destination);
 
 		templateName = "main-port-4004.qute.launch";
 		destination = new File(tmpProjectDir, ".eclipse/" + baseName + "-port-4004.launch").toPath();
-		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+		renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, script.getArguments(),
 				destination);
 
 		// setup vscode
@@ -150,7 +150,8 @@ public class Edit extends BaseScriptCommand {
 		destination = new File(tmpProjectDir, ".vscode/launch.json").toPath();
 		if (isNeeded(reload, destination)) {
 			destination.toFile().getParentFile().mkdirs();
-			renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+			renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName,
+					script.getArguments(),
 					destination);
 		}
 
@@ -158,7 +159,8 @@ public class Edit extends BaseScriptCommand {
 		destination = new File(tmpProjectDir, ".vscode/settings.json").toPath();
 		if (isNeeded(reload, destination)) {
 			destination.toFile().getParentFile().mkdirs();
-			renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName, userParams,
+			renderTemplate(engine, collectDependencies, baseName, resolvedDependencies, templateName,
+					script.getArguments(),
 					destination);
 		}
 
@@ -168,13 +170,13 @@ public class Edit extends BaseScriptCommand {
 		 * File(tmpProjectDir, ".idea/runConfigurations/" + baseName +
 		 * "-port-4004.xml").toPath(); destination.toFile().getParentFile().mkdirs();
 		 * renderTemplate(engine, collectDependencies, baseName, resolvedDependencies,
-		 * templateName, userParams, destination);
+		 * templateName, script.getArguments(), destination);
 		 *
 		 * templateName = "idea.qute.xml"; destination = new File(tmpProjectDir,
 		 * ".idea/runConfigurations/" + baseName + ".xml").toPath();
 		 * destination.toFile().getParentFile().mkdirs(); renderTemplate(engine,
 		 * collectDependencies, baseName, resolvedDependencies, templateName,
-		 * userParams, destination);
+		 * script.getArguments(), destination);
 		 */
 
 		return tmpProjectDir;

--- a/src/main/java/dk/xam/jbang/cli/Run.java
+++ b/src/main/java/dk/xam/jbang/cli/Run.java
@@ -65,7 +65,7 @@ public class Run extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile);
+		script = prepareScript(scriptOrFile, userParams, properties);
 
 		if (script.needsJar()) {
 			build(script);
@@ -250,7 +250,7 @@ public class Run extends BaseScriptCommand {
 				optionalArgs.add("--startup=DEFAULT");
 
 				File tempFile = File.createTempFile("jbang_arguments_", script.backingFile.getName());
-				Util.writeString(tempFile.toPath(), generateArgs(userParams, properties));
+				Util.writeString(tempFile.toPath(), generateArgs(script.getArguments(), script.getProperties()));
 
 				optionalArgs.add("--startup=" + tempFile.getAbsolutePath());
 
@@ -301,7 +301,7 @@ public class Run extends BaseScriptCommand {
 		}
 
 		if (!script.forJShell()) {
-			fullArgs.addAll(userParams);
+			fullArgs.addAll(script.getArguments());
 		} else if (!interactive) {
 			File tempFile = File.createTempFile("jbang_exit_", script.backingFile.getName());
 			Util.writeString(tempFile.toPath(), "/exit");

--- a/src/test/java/dk/xam/jbang/TestGrape.java
+++ b/src/test/java/dk/xam/jbang/TestGrape.java
@@ -36,7 +36,7 @@ public class TestGrape {
 				+
 				"})\n";
 
-		Script s = new Script(grabBlock);
+		Script s = new Script(grabBlock, null, null);
 
 		List<String> deps = s.collectDependencies();
 

--- a/src/test/java/dk/xam/jbang/TestScript.java
+++ b/src/test/java/dk/xam/jbang/TestScript.java
@@ -47,7 +47,7 @@ class TestScript {
 
 	@Test
 	void testFindDependencies() {
-		Script script = new Script(example);
+		Script script = new Script(example, null, null);
 
 		List<String> dependencies = script.collectDependencies();
 		assertEquals(2, dependencies.size());
@@ -58,8 +58,8 @@ class TestScript {
 
 	@Test
 	void testCDS() {
-		Script script = new Script("//CDS\nclass m { }");
-		Script script2 = new Script("class m { }");
+		Script script = new Script("//CDS\nclass m { }", null, null);
+		Script script2 = new Script("class m { }", null, null);
 
 		assertTrue(script.enableCDS());
 		assertFalse(script2.enableCDS());
@@ -105,7 +105,7 @@ class TestScript {
 
 	@Test
 	void testExtractOptions() {
-		Script s = new Script(example);
+		Script s = new Script(example, null, null);
 
 		assertEquals(s.collectCompileOptions(), Arrays.asList("--enable-preview", "--verbose"));
 
@@ -118,7 +118,7 @@ class TestScript {
 		Path p = output.resolve("kube-example");
 		writeString(p, example);
 
-		Script s = BaseScriptCommand.prepareScript(p.toAbsolutePath().toString());
+		Script s = BaseScriptCommand.prepareScript(p.toAbsolutePath().toString(), null, null);
 
 	}
 

--- a/src/test/java/dk/xam/jbang/cli/TestAlias.java
+++ b/src/test/java/dk/xam/jbang/cli/TestAlias.java
@@ -8,8 +8,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Comparator;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.AfterAll;
@@ -28,7 +30,31 @@ public class TestAlias {
 			"      \"scriptRef\": \"http://dummy\"\n" +
 			"    },\n" +
 			"    \"two\": {\n" +
-			"      \"scriptRef\": \"http://dummy\"\n" +
+			"      \"scriptRef\": \"one\",\n" +
+			"      \"arguments\": [\"2\"],\n" +
+			"      \"properties\": {\"two\":\"2\"}\n" +
+			"    },\n" +
+			"    \"three\": {\n" +
+			"      \"scriptRef\": \"http://dummy\",\n" +
+			"      \"arguments\": [\"3\"],\n" +
+			"      \"properties\": {\"three\":\"3\"}\n" +
+			"    },\n" +
+			"    \"four\": {\n" +
+			"      \"scriptRef\": \"three\",\n" +
+			"      \"arguments\": [\"4\"],\n" +
+			"      \"properties\": {\"four\":\"4\"}\n" +
+			"    },\n" +
+			"    \"five\": {\n" +
+			"      \"scriptRef\": \"three\"\n" +
+			"    },\n" +
+			"    \"six\": {\n" +
+			"      \"scriptRef\": \"seven\"\n" +
+			"    },\n" +
+			"    \"seven\": {\n" +
+			"      \"scriptRef\": \"six\"\n" +
+			"    },\n" +
+			"    \"eight\": {\n" +
+			"      \"scriptRef\": \"seven\"\n" +
 			"    }\n" +
 			"  }\n" +
 			"}";
@@ -78,6 +104,107 @@ public class TestAlias {
 		new CommandLine(jbang).execute("alias", "remove", "two");
 		clearSettingsAliasInfo();
 		assertThat(Settings.getAliases().get("two"), nullValue());
+	}
+
+	@Test
+	void testGetAliasOne() throws IOException {
+		Settings.Alias alias = Settings.getAlias("one", null, null);
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, nullValue());
+		assertThat(alias.properties, nullValue());
+	}
+
+	@Test
+	void testGetAliasOneWithArgs() throws IOException {
+		Settings.Alias alias = Settings.getAlias("one", Collections.singletonList("X"),
+				Collections.singletonMap("foo", "bar"));
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("X"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("foo", "bar"));
+	}
+
+	@Test
+	void testGetAliasTwo() throws IOException {
+		Settings.Alias alias = Settings.getAlias("two", null, null);
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("2"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("two", "2"));
+	}
+
+	@Test
+	void testGetAliasTwoWithArgs() throws IOException {
+		Settings.Alias alias = Settings.getAlias("two", Collections.singletonList("X"),
+				Collections.singletonMap("foo", "bar"));
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("X"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("foo", "bar"));
+	}
+
+	@Test
+	void testGetAliasFour() throws IOException {
+		Settings.Alias alias = Settings.getAlias("four", null, null);
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("4"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("four", "4"));
+	}
+
+	@Test
+	void testGetAliasFourWithArgs() throws IOException {
+		Settings.Alias alias = Settings.getAlias("four", Collections.singletonList("X"),
+				Collections.singletonMap("foo", "bar"));
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("X"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("foo", "bar"));
+	}
+
+	@Test
+	void testGetAliasFive() throws IOException {
+		Settings.Alias alias = Settings.getAlias("five", null, null);
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("3"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("three", "3"));
+	}
+
+	@Test
+	void testGetAliasFiveWithArgs() throws IOException {
+		Settings.Alias alias = Settings.getAlias("five", Collections.singletonList("X"),
+				Collections.singletonMap("foo", "bar"));
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("X"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("foo", "bar"));
+	}
+
+	@Test
+	void testGetAliasLoop() throws IOException {
+		try {
+			Settings.Alias alias = Settings.getAlias("eight", null, null);
+			Assert.fail();
+		} catch (RuntimeException ex) {
+			assertThat(ex.getMessage(), containsString("seven"));
+		}
+
 	}
 
 }

--- a/src/test/java/dk/xam/jbang/cli/TestEdit.java
+++ b/src/test/java/dk/xam/jbang/cli/TestEdit.java
@@ -14,7 +14,6 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.stream.Collectors;
 
 import org.hamcrest.MatcherAssert;
@@ -46,9 +45,9 @@ public class TestEdit {
 		Jbang.getCommandLine().execute("init", s);
 		assertThat(new File(s).exists(), is(true));
 
-		Script script = BaseScriptCommand.prepareScript(s);
+		Script script = BaseScriptCommand.prepareScript(s, null, null);
 
-		File project = new Edit().createProjectForEdit(script, Collections.emptyList(), false);
+		File project = new Edit().createProjectForEdit(script, false);
 
 		assertThat(new File(project, "src"), FileMatchers.anExistingDirectory());
 		File build = new File(project, "build.gradle");
@@ -84,9 +83,9 @@ public class TestEdit {
 
 		Util.writeString(p, "//DEPS org.openjfx:javafx-graphics:11.0.2${bougus:}\n" + Util.readString(p));
 
-		Script script = BaseScriptCommand.prepareScript(s);
+		Script script = BaseScriptCommand.prepareScript(s, null, null);
 
-		File project = new Edit().createProjectForEdit(script, Collections.emptyList(), false);
+		File project = new Edit().createProjectForEdit(script, false);
 
 		File gradle = new File(project, "build.gradle");
 		assert (gradle.exists());
@@ -109,9 +108,9 @@ public class TestEdit {
 		Jbang.getCommandLine().execute("init", s);
 		assertThat(new File(s).exists(), is(true));
 
-		Script script = BaseScriptCommand.prepareScript(s);
+		Script script = BaseScriptCommand.prepareScript(s, null, null);
 
-		File project = new Edit().createProjectForEdit(script, Collections.emptyList(), false);
+		File project = new Edit().createProjectForEdit(script, false);
 
 		File java = new File(project, "src/KubeExample.java");
 


### PR DESCRIPTION
You can now specify arguments and properties with aliases, just like with the `run` command. If you run an alias that has arguments and/or properties without specifying arguments and/or properties yourself then those arguments/properties will be used.

(depends on #144)