### PR TITLE
Fixes #154 Incorrect handling of arguments with space/metachars

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -25,7 +25,7 @@ public class Settings {
 	public static final String TRUSTED_SOURCES_JSON = "trusted-sources.json";
 	public static final String DEPENDENCY_CACHE_TXT = "dependency_cache.txt";
 
-	final public static String CP_SEPARATOR = Util.isWindows() ? ";" : ":";
+	final public static String CP_SEPARATOR = File.pathSeparator;
 
 	private static TrustedSources trustedSources;
 

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -25,9 +25,7 @@ public class Settings {
 	public static final String TRUSTED_SOURCES_JSON = "trusted-sources.json";
 	public static final String DEPENDENCY_CACHE_TXT = "dependency_cache.txt";
 
-	final public static String CP_SEPARATOR = System.getProperty("os.name").toLowerCase().contains("windows")
-			? ";"
-			: ":";
+	final public static String CP_SEPARATOR = Util.isWindows() ? ";" : ":";
 
 	private static TrustedSources trustedSources;
 

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -71,6 +71,10 @@ public class Util {
 	private static final Pattern mainClassPattern = Pattern.compile(
 			"(?sm)class *(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*) .*static void main");
 
+	public static boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase().contains("windows");
+	}
+
 	/**
 	 * Download file from url but will swizzle output for sites that are known to
 	 * possibly embed code (i.e. twitter and carbon)


### PR DESCRIPTION
This seems to work. Not sure if there are any other special chars I might have missed, but I've Googled the special chars for each environment (shell vs CMD) and added all other chars on my keyboard just to be sure.

On Linux even multi-line arguments work correctly. (On Windows that's not really possible)

We might need to add an integration test for this though.