### PR TITLE
The `alias.json` file now uses kebab naming

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -11,6 +11,7 @@ import java.util.*;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.SerializedName;
 
 import io.quarkus.qute.Template;
 
@@ -146,6 +147,7 @@ public class Settings {
 	}
 
 	public static class Alias {
+		@SerializedName(value = "script-ref", alternate = { "scriptRef" })
 		public final String scriptRef;
 		public final String description;
 		public final List<String> arguments;


### PR DESCRIPTION
Older files will still be read and be automatically updated next time
a change has been made