### PR TITLE
Now quoting all arguments generated by Jbang before passing on to bash/cmd

### DIFF
--- a/itests/quoting-win.feature
+++ b/itests/quoting-win.feature
@@ -3,14 +3,10 @@ Feature: jshell
 
 Background:
 * if (javaversion == 8) karate.abort()
-* if (windows) karate.abort()
-
-Scenario: piping code via stdin
-When command('echo \'System.out.println(\"Hello World\")\' | jbang -')
-Then match out == "Hello World\n"
+* if (!windows) karate.abort()
 
 Scenario: check quotes are kept when wrapped with quotes
-When command('jbang echo.java \'foo *\'')
+When command('jbang echo.java "foo *"')
 Then match out == "0:foo *\n"
 
 Scenario: check expansion does happen
@@ -18,9 +14,9 @@ When command('jbang echo.java foo *')
 Then match out contains "0:foo\n1:"
 
 Scenario: check special characters on command line work
-When command('jbang echo.java \' ~!@#$%^&*()-+\\:;\'\\\'\'`<>?/,.{}[]"\'')
+When command('jbang echo.java " ~!@#$%^&*()-+\\:;\'`<>?/,.{}[]""')
 Then match out == "0: ~!@#$%^&*()-+\\:;'`<>?/,.{}[]\"\n"
 
 Scenario: check spaces in JBANG_DIR path work (Issue #171)
-When command('jbang echo.java \'foo *\'', { JBANG_DIR: scratch + '/jbang dir test' })
+When command('jbang echo.java "foo *"', { JBANG_DIR: scratch + '\\jbang dir test' })
 Then match out == "0:foo *\n"

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -25,7 +25,11 @@ public abstract class BaseCommand implements Callable<Integer> {
 	static boolean verbose = false;
 
 	void info(String msg) {
-		spec.commandLine().getErr().println("[jbang] " + msg);
+		if (spec != null) {
+			spec.commandLine().getErr().println("[jbang] " + msg);
+		} else {
+			System.err.println("[jbang] " + msg);
+		}
 	}
 
 	void warn(String msg) {

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -26,17 +26,18 @@ IF NOT EXIST "%TDIR%" ( mkdir "%TDIR%")
 
 set tmpfile=%TDIR%\%RANDOM%.tmp
 rem execute jbang and pipe to temporary random file
-%JAVA_EXEC% %JBANG_JAVA_OPTIONS% -classpath %jarPath% dev.jbang.Main %* > %tmpfile%
+%JAVA_EXEC% > "%tmpfile%" %JBANG_JAVA_OPTIONS% -classpath "%jarPath%" dev.jbang.Main %*
 set ERROR=%ERRORLEVEL%
 rem catch errorlevel straight after; rem or FOR /F swallow would have swallowed the errorlevel
 
 IF %ERROR% NEQ 0 (
+
     del ""%tmpfile%""
     exit /b %ERROR%
 )
 
 rem read generated java command by jang, delete temporary file and execute.
-for %%A in (%tmpfile%) do for /f "usebackq delims=" %%B in ("%%A") do (
+for %%A in ("%tmpfile%") do for /f "usebackq delims=" %%B in (%%A) do (
   set "OUTPUT=%%B"
   goto :break
 )

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -84,7 +84,8 @@ public class TestRun {
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("helloworld.jsh"));
 		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT --startup="));
+		assertThat(result, containsString("--startup=DEFAULT"));
+		assertThat(result, matchesPattern(".*--startup=[^ ]*helloworld.jsh.*"));
 		assertThat(result, not(containsString("blah")));
 		assertThat(result, containsString("jbang_exit_"));
 	}
@@ -104,7 +105,8 @@ public class TestRun {
 
 		String result = run.generateCommandLine(s);
 		assertThat(result, matchesPattern("^.*java(.exe)?.*"));
-		assertThat(result, matchesPattern("^.*java -jar .*helloworld.jar"));
+		assertThat(result, containsString("-jar"));
+		assertThat(result, containsString("helloworld.jar"));
 
 		assertThat(s.getBackingFile().toString(), equalTo(jar));
 		assertThat(s.forJar(), equalTo(true));
@@ -129,7 +131,7 @@ public class TestRun {
 
 		String cmd = run.generateCommandLine(result);
 
-		assertThat(cmd, containsString(" -jar "));
+		assertThat(cmd, containsString(Run.escapeArgument("-jar")));
 
 	}
 
@@ -174,7 +176,8 @@ public class TestRun {
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("helloworld.jsh"));
 		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT --startup="));
+		assertThat(result, containsString("--startup=DEFAULT"));
+		assertThat(result, matchesPattern(".*--startup=[^ ]*helloworld.jsh.*"));
 		assertThat(result, not(containsString("blah")));
 		assertThat(result, not(containsString("jbang_exit_")));
 	}
@@ -240,7 +243,7 @@ public class TestRun {
 		if (Util.isWindows()) {
 			assertThat(result, containsString("^\"-Dquoted=see this^\""));
 		} else {
-			assertThat(result, containsString("\"-Dquoted=see this\""));
+			assertThat(result, containsString("'-Dquoted=see this'"));
 		}
 		String[] split = result.split("example.java");
 		assertEquals(split.length, 2);
@@ -281,7 +284,7 @@ public class TestRun {
 		if (Util.isWindows()) {
 			assertThat(s, containsString("^\" ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
 		} else {
-			assertThat(s, containsString(" ~\\!@#\\$%^&*()-+\\\\:;'\\`<>?/,.{}[]\\\""));
+			assertThat(s, containsString("' ~!@#$%^&*()-+\\:;'\\''`<>?/,.{}[]\"'"));
 		}
 	}
 


### PR DESCRIPTION
Fixes #171. Quoting is now also a bit smarter, only quoting when necessary.

@maxandersen I tested this with the following command:

```
$ JBANG_CACHE_DIR=/tmp/jbang\ cache\ test ./build/install/jbang/bin/jbang echo.java test
```

But I'm not sure how to add that to Karate, so we're still missing a test for this.