### PR TITLE
Make sure we really delete JDK folder if download or install fails

### DIFF
--- a/src/main/java/dev/jbang/JdkManager.java
+++ b/src/main/java/dev/jbang/JdkManager.java
@@ -39,10 +39,14 @@ public class JdkManager {
 			Util.infoMsg("Installing JDK " + version + "...");
 			UnpackUtil.unpack(jdkPkg, jdkDir);
 			return jdkDir;
-		} catch (Exception e) {
+		} catch (IOException e) {
 			Util.deleteFolder(jdkDir, true);
 			Util.errorMsg("Unable to download or install JDK", e);
 			return null;
+		} catch (Throwable e) {
+			Util.deleteFolder(jdkDir, true);
+			Util.errorMsg("Unable to download or install JDK", e);
+			throw e;
 		}
 	}
 


### PR DESCRIPTION
Doing this because I think it's important to at least try to clean up, even in case of a low memory error or something like that.