### PR TITLE
Alias fix and refactor

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -24,7 +24,6 @@ public class Settings {
 	public static final String JBANG_DIR = "JBANG_DIR";
 	public static final String JBANG_CACHE_DIR = "JBANG_CACHE_DIR";
 
-	public static final String ALIASES_JSON = "aliases.json";
 	public static final String CATALOGS_JSON = "catalogs.json";
 	public static final String TRUSTED_SOURCES_JSON = "trusted-sources.json";
 	public static final String DEPENDENCY_CACHE_TXT = "dependency_cache.txt";
@@ -165,7 +164,7 @@ public class Settings {
 	}
 
 	public static Path getAliasesFile() {
-		return getConfigDir().resolve(ALIASES_JSON);
+		return getConfigDir().resolve(AliasUtil.JBANG_CATALOG_JSON);
 	}
 
 	public static Aliases getAliasesFromCatalog(Path catalogPath, boolean updateCache) {

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -36,18 +36,18 @@ public class Alias {
 	public Integer list(
 			@CommandLine.Parameters(paramLabel = "catalogName", index = "0", description = "The name of a catalog", arity = "0..1") String catalogName) {
 		PrintWriter out = spec.commandLine().getOut();
-		Settings.Aliases aliases = AliasUtil.getCatalogAliasesByName(catalogName, false);
+		AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(catalogName, false);
 		printAliases(out, catalogName, aliases);
 		return CommandLine.ExitCode.SOFTWARE;
 	}
 
-	static void printAliases(PrintWriter out, String catalogName, Settings.Aliases aliases) {
+	static void printAliases(PrintWriter out, String catalogName, AliasUtil.Aliases aliases) {
 		aliases.aliases
 						.keySet()
 						.stream()
 						.sorted()
 						.forEach(name -> {
-							Settings.Alias ai = AliasUtil.getCatalogAlias(aliases, name);
+							AliasUtil.Alias ai = AliasUtil.getCatalogAlias(aliases, name);
 							String fullName = catalogName != null ? name + "@" + catalogName : name;
 							if (ai.description != null) {
 								out.println(fullName + " = " + ai.description);

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -94,7 +94,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		File scriptFile = getScriptFile(scriptResource);
 		if (scriptFile == null) {
 			// Not found as such, so let's check the aliases
-			Settings.Alias alias = AliasUtil.getAlias(scriptResource, arguments, properties);
+			AliasUtil.Alias alias = AliasUtil.getAlias(scriptResource, arguments, properties);
 			if (alias != null) {
 				scriptFile = getScriptFile(alias.scriptRef);
 				arguments = alias.arguments;

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -28,7 +28,7 @@ public class Catalog {
 			throw new IllegalArgumentException("A catalog with that name already exists");
 		}
 		PrintWriter err = spec.commandLine().getErr();
-		Settings.Aliases aliases = AliasUtil.getCatalogAliasesByRef(urlOrFile, true);
+		AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByRef(urlOrFile, true);
 		if (description == null) {
 			description = aliases.description;
 		}
@@ -60,7 +60,7 @@ public class Catalog {
 					.stream()
 					.sorted()
 					.forEach(nm -> {
-						Settings.Catalog cat = Settings.getCatalogs().get(nm);
+						AliasUtil.Catalog cat = Settings.getCatalogs().get(nm);
 						if (cat.description != null) {
 							out.println(nm + " = " + cat.description);
 							out.println(Util.repeat(" ", nm.length()) + "   (" + cat.catalogRef + ")");
@@ -69,7 +69,7 @@ public class Catalog {
 						}
 					});
 		} else {
-			Settings.Aliases aliases = AliasUtil.getCatalogAliasesByName(name, false);
+			AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(name, false);
 			Alias.printAliases(out, name, aliases);
 		}
 		return CommandLine.ExitCode.SOFTWARE;

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -61,7 +61,7 @@ public class TestAlias {
 	void init() throws IOException {
 		jbangTempDir.create();
 		environmentVariables.set("JBANG_DIR", jbangTempDir.getRoot().getPath());
-		Files.write(jbangTempDir.getRoot().toPath().resolve("aliases.json"), aliases.getBytes());
+		Files.write(jbangTempDir.getRoot().toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), aliases.getBytes());
 	}
 
 	@Rule

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -97,13 +97,13 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasNone() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("dummy-alias!", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("dummy-alias!", null, null);
 		assertThat(alias, nullValue());
 	}
 
 	@Test
 	void testGetAliasOne() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("one", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("one", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, nullValue());
@@ -112,7 +112,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasOneWithArgs() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("one", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias("one", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -124,7 +124,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasTwo() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("two", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("two", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -135,7 +135,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasTwoWithArgs() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("two", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias("two", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -147,7 +147,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFour() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("four", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("four", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -158,7 +158,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFourWithArgs() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("four", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias("four", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -170,7 +170,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFive() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("five", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("five", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -181,7 +181,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFiveWithArgs() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("five", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias("five", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -194,7 +194,7 @@ public class TestAlias {
 	@Test
 	void testGetAliasLoop() throws IOException {
 		try {
-			Settings.Alias alias = AliasUtil.getAlias("eight", null, null);
+			AliasUtil.Alias alias = AliasUtil.getAlias("eight", null, null);
 			Assert.fail();
 		} catch (RuntimeException ex) {
 			assertThat(ex.getMessage(), containsString("seven"));

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -85,7 +85,7 @@ public class TestCatalog {
 
 	@Test
 	void testGetAlias() throws IOException {
-		Settings.Alias alias = AliasUtil.getAlias("one@test", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias("one@test", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 	}


### PR DESCRIPTION
Local aliases are now stored in `~/.jbang/jbang-catalog.json` as stated by the docs.

And moved a bunch of alias/catalog related classes and utility methods from Settings to AliasUtil. (Settings was holding a lot of things not directly related to settings)