### PR TITLE
First stab at allowing Vendor selection.

### DIFF
--- a/src/main/java/dev/jbang/JdkManager.java
+++ b/src/main/java/dev/jbang/JdkManager.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import picocli.CommandLine;
 
 public class JdkManager {
-	private static final String JDK_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/adoptopenjdk";
+	private static final String JDK_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/%s";
 
 	public static Path getCurrentJdk(String requestedVersion) {
 		int currentVersion = JavaUtil.determineJavaVersion();
@@ -41,7 +41,8 @@ public class JdkManager {
 
 	public static Path downloadAndInstallJdk(int version, boolean updateCache) {
 		Util.infoMsg("Downloading JDK " + version + ". Be patient, this can take several minutes...");
-		String url = String.format(JDK_DOWNLOAD_URL, version, Util.getOS().name(), Util.getArch().name());
+		String url = String.format(JDK_DOWNLOAD_URL, version, Util.getOS().name(), Util.getArch().name(),
+				Util.getVendor().name());
 		Util.debugMsg("Downloading " + url);
 		Path jdkDir = getJdkPath(version);
 		Path jdkTmpDir = jdkDir.getParent().resolve(jdkDir.getFileName().toString() + ".tmp");

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -27,6 +27,8 @@ import picocli.CommandLine;
 
 public class Util {
 
+	public static final String JBANG_JDK_VENDOR = "JBANG_JDK_VENDOR";
+
 	static boolean verbose;
 
 	public static void setVerbose(boolean verbose) {
@@ -43,6 +45,10 @@ public class Util {
 
 	public enum Arch {
 		x32, x64
+	}
+
+	public enum Vendor {
+		adoptopenjdk, openjdk
 	}
 
 	static public void debugMsg(String msg) {
@@ -127,6 +133,18 @@ public class Util {
 
 	public static boolean isMac() {
 		return getOS() == OS.mac;
+	}
+
+	public static Vendor getVendor() {
+		String vendorName = System.getenv(JBANG_JDK_VENDOR);
+		if (vendorName != null) {
+			try {
+				return Vendor.valueOf(vendorName);
+			} catch (IllegalArgumentException ex) {
+				warnMsg("JDK vendor '" + vendorName + "' does not exist, should be one of: " + Vendor.values());
+			}
+		}
+		return Vendor.adoptopenjdk;
 	}
 
 	/**


### PR DESCRIPTION
This is a very simplistic implementation that allows the user to select
the vendor at install time by defining a `JBANG_JDK_VENDOR` env var.

For now it at least makes it possible for those people that really want this.
We should see if this , somewhat hidden, option warrants to be turned into a full-fledged feature.
But that will be a lot more work.

See #203