### PR TITLE
Remove rogue backtick preventing link from working

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -791,7 +791,7 @@ The aliases managed locally are stored in `~/.jbang/jbang-catalog.json`, but jba
 
 Examples:
 
-`jbang hello@jbangdev` will run the alias `hello` as defined in `jbang-catalog.json` found in https://github.com/jbangdev/jbang-catalog`.
+`jbang hello@jbangdev` will run the alias `hello` as defined in `jbang-catalog.json` found in https://github.com/jbangdev/jbang-catalog.
 
 This allows anyone to provde a set of jbang scripts defined out of their github, gitlab or bitbucket repository.
 


### PR DESCRIPTION
This is good as a link, since it links to example source. However there's a
rogue backtick preventing it from linking to the right place (it appends a
"%60" to the URL). Removing it makes the link work properly.