### PR TITLE
Fixed aliases not picking up pre-defined arguments

### DIFF
--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -98,8 +98,9 @@ public class AliasUtil {
 		if (a2 != null) {
 			names.add(name);
 			a2 = mergeAliases(a2, a2.scriptRef, names);
-			List<String> args = a1.arguments != null ? a1.arguments : a2.arguments;
-			Map<String, String> props = a1.properties != null ? a1.properties : a2.properties;
+			List<String> args = a1.arguments != null && !a1.arguments.isEmpty() ? a1.arguments : a2.arguments;
+			Map<String, String> props = a1.properties != null && !a1.properties.isEmpty() ? a1.properties
+					: a2.properties;
 			return new Alias(a2.scriptRef, null, args, props);
 		} else {
 			return a1;

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -134,6 +134,17 @@ public class TestAlias {
 	}
 
 	@Test
+	void testGetAliasTwoAlt() throws IOException {
+		AliasUtil.Alias alias = AliasUtil.getAlias("two", Collections.emptyList(), Collections.emptyMap());
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		assertThat(alias.arguments, iterableWithSize(1));
+		assertThat(alias.arguments, contains("2"));
+		assertThat(alias.properties, aMapWithSize(1));
+		assertThat(alias.properties, hasEntry("two", "2"));
+	}
+
+	@Test
 	void testGetAliasTwoWithArgs() throws IOException {
 		AliasUtil.Alias alias = AliasUtil.getAlias("two", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));


### PR DESCRIPTION
Very small fix that prevented pre-defined arguments (and properties) from working