### PR TITLE
On untrusted runs ask user action (run once + various trust)

### DIFF
--- a/src/main/java/dev/jbang/ConsoleInput.java
+++ b/src/main/java/dev/jbang/ConsoleInput.java
@@ -1,0 +1,43 @@
+package dev.jbang;
+
+import java.util.concurrent.*;
+
+public class ConsoleInput {
+	private final int tries;
+	private final int timeout;
+	private final TimeUnit unit;
+
+	public ConsoleInput(int tries, int timeout, TimeUnit unit) {
+		this.tries = tries;
+		this.timeout = timeout;
+		this.unit = unit;
+	}
+
+	public String readLine() {
+		ExecutorService ex = Executors.newSingleThreadExecutor();
+		String input = null;
+		try {
+			// start working
+			for (int i = 0; i < tries; i++) {
+				// Util.infoMsg(String.valueOf(i + 1) + ". loop");
+				Future<String> result = ex.submit(
+						new ConsoleInputReadTask());
+				try {
+					input = result.get(timeout, unit);
+					break;
+				} catch (ExecutionException e) {
+					e.getCause().printStackTrace();
+				} catch (TimeoutException e) {
+					// Util.infoMsg("Cancelling reading task");
+					result.cancel(true);
+					// Util.infoMsg("\nThread cancelled. input is null");
+				} catch (InterruptedException ie) {
+					throw new RuntimeException(ie);
+				}
+			}
+		} finally {
+			ex.shutdownNow();
+		}
+		return input;
+	}
+}

--- a/src/main/java/dev/jbang/ConsoleInputReadTask.java
+++ b/src/main/java/dev/jbang/ConsoleInputReadTask.java
@@ -1,0 +1,28 @@
+package dev.jbang;
+
+import java.io.*;
+import java.util.concurrent.Callable;
+
+public class ConsoleInputReadTask implements Callable<String> {
+	public String call() throws IOException {
+		BufferedReader br = new BufferedReader(
+				new InputStreamReader(System.in));
+		// System.out.println("ConsoleInputReadTask run() called.");
+		String input;
+		do {
+			// System.out.println("Please type something: ");
+			try {
+				// wait until we have data to complete a readLine()
+				while (!br.ready()) {
+					Thread.sleep(200);
+				}
+				input = br.readLine();
+			} catch (InterruptedException e) {
+				// System.out.println("ConsoleInputReadTask() cancelled");
+				return null;
+			}
+		} while ("".equals(input));
+		// System.out.println("Thank You for providing input!");
+		return input;
+	}
+}

--- a/src/main/java/dev/jbang/TrustedSources.java
+++ b/src/main/java/dev/jbang/TrustedSources.java
@@ -183,6 +183,10 @@ public class TrustedSources {
 		return trustedsources;
 	}
 
+	public void add(String trust, File storage) {
+		add(Arrays.asList(trust), storage);
+	}
+
 	public void add(List<String> trust, File storage) {
 
 		Util.infoMsg("Adding " + trust + " to " + storage);

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -244,19 +244,17 @@ public abstract class BaseScriptCommand extends BaseCommand {
 						"\nFor more control edit ~/.jbang/trusted-sources.json" + "\n";
 
 				String question = scriptURL + " is not from a trusted source thus not running it automatically.\n\n" +
-						"If you trust the url to be safe to run you can add one of the following:\n" +
+						"If you trust the url to be safe to run you can do one of the following:\n" +
 						"0) Trust once: Add no trust, just run this time\n" +
-						"1) Limited trust:\n    jbang trust add " + options[1] + "\n" +
-						"2) Trust all subdomains:\n    jbang trust add " + options[2] + "\n" +
-						"3) Trust all sources (WARNING! disables url protection):\n    jbang trust add " + options[3]
-						+ "\n\nAny other response will result in exit.\n";
+						"1) Trust this url in future:\n    jbang trust add " + options[1] + "\n" +
+						"\n\nAny other response will result in exit.\n";
 
 				ConsoleInput con = new ConsoleInput(
 						1,
 						10,
 						TimeUnit.SECONDS);
 				Util.infoMsg(question);
-				Util.infoMsg("Type in your choice (0,1,2 or 3) and hit enter. Times out after 10 seconds.");
+				Util.infoMsg("Type in your choice (0 or 1) and hit enter. Times out after 10 seconds.");
 				String input = con.readLine();
 
 				boolean abort = true;
@@ -265,7 +263,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 					TrustedSources ts = Settings.getTrustedSources();
 					if (result == 0) {
 						abort = false;
-					} else if (result >= 1 && result <= 3) {
+					} else if (result == 1) {
 						ts.add(options[result], Settings.getTrustedSourcesFile().toFile());
 						abort = false;
 					}


### PR DESCRIPTION
Until now we've aborted on untrusted runs. That is safe, but it is not great a user experience.

Main reason it was not added is that since jbang are run with console() returning null
as we are in a nested batch script we couldn't reliably ask for input. Plus it is not
great blocking on such question forever.

This commit fixes it by
   - asking user wether he wants to run once or add one of three level of thrust
   - not relying on console but read directly System.in
   - add timeout for the reading (currently 10 seconds)