### PR TITLE
Use Docker ADD to avoid public key errors

### DIFF
--- a/src/main/scripts/container/Dockerfile
+++ b/src/main/scripts/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM adoptopenjdk:11-jdk-hotspot
 
-RUN curl -Ls "https://github.com/jbangdev/jbang/releases/download/v@projectVersion@/jbang-@projectVersion@.zip" --output jbang.zip \
-              && jar xf jbang.zip && rm jbang.zip && mv jbang-* jbang && chmod +x jbang/bin/jbang
+ADD https://github.com/jbangdev/jbang/releases/download/v@projectVersion@/jbang-@projectVersion@.zip jbang.zip
+RUN jar xf jbang.zip && rm jbang.zip && mv jbang-* jbang && chmod +x jbang/bin/jbang
 
 ADD ./entrypoint /bin/entrypoint
 


### PR DESCRIPTION
`curl: (6) Could not resolve host: github.com`