### PR TITLE
Fix for quoting, including spaces, on Windows

### DIFF
--- a/itests/quoting-win.feature
+++ b/itests/quoting-win.feature
@@ -1,8 +1,6 @@
-@java9orhigher
-Feature: jshell
+Feature: quoting for windows
 
 Background:
-* if (javaversion == 8) karate.abort()
 * if (!windows) karate.abort()
 
 Scenario: check quotes are kept when wrapped with quotes

--- a/itests/quoting.feature
+++ b/itests/quoting.feature
@@ -1,8 +1,6 @@
-@java9orhigher
-Feature: jshell
+Feature: quoting
 
 Background:
-* if (javaversion == 8) karate.abort()
 * if (windows) karate.abort()
 
 Scenario: piping code via stdin

--- a/itests/quoting.feature
+++ b/itests/quoting.feature
@@ -4,6 +4,7 @@ Background:
 * if (windows) karate.abort()
 
 Scenario: piping code via stdin
+* if (javaversion == 8) karate.abort()
 When command('echo \'System.out.println(\"Hello World\")\' | jbang -')
 Then match out == "Hello World\n"
 

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -359,7 +359,7 @@ public class Run extends BaseScriptCommand {
 		if (Util.isWindows()) {
 			if (!cmdSafeChars.matcher(arg).matches()) {
 				// Windows quoting is just weird
-				arg = arg.replaceAll("([()!^<>&|%])", "^$1");
+				arg = arg.replaceAll("([()!^<>&|% ])", "^$1");
 				arg = arg.replaceAll("([\"])", "\\\\^$1");
 				return "^\"" + arg + "^\"";
 			}

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -68,7 +68,9 @@ if "!JAVA_EXEC!"=="" (
 
 set tmpfile=%TDIR%\%RANDOM%.tmp
 rem execute jbang and pipe to temporary random file
-!JAVA_EXEC! > "%tmpfile%" %JBANG_JAVA_OPTIONS% -classpath "%jarPath%" dev.jbang.Main %*
+set "CMD=!JAVA_EXEC!"
+SETLOCAL DISABLEDELAYEDEXPANSION
+%CMD% > "%tmpfile%" %JBANG_JAVA_OPTIONS% -classpath "%jarPath%" dev.jbang.Main %*
 set ERROR=%ERRORLEVEL%
 rem catch errorlevel straight after; rem or FOR /F swallow would have swallowed the errorlevel
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -241,7 +241,7 @@ public class TestRun {
 		assertThat(result, startsWith("java "));
 		assertThat(result, containsString("-Dwonka=panda"));
 		if (Util.isWindows()) {
-			assertThat(result, containsString("^\"-Dquoted=see this^\""));
+			assertThat(result, containsString("^\"-Dquoted=see^ this^\""));
 		} else {
 			assertThat(result, containsString("'-Dquoted=see this'"));
 		}
@@ -282,7 +282,7 @@ public class TestRun {
 
 		String s = run.generateCommandLine(prepareScript(url, run.userParams, run.properties));
 		if (Util.isWindows()) {
-			assertThat(s, containsString("^\" ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
+			assertThat(s, containsString("^\"^ ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
 		} else {
 			assertThat(s, containsString("' ~!@#$%^&*()-+\\:;'\\''`<>?/,.{}[]\"'"));
 		}


### PR DESCRIPTION
Fixes #245 

So the fix for the spaces was simply the fact that spaces were not being escaped.

But the fact that the IT tests didn't work (anymore) was because we had turned on delayed expansion in the batch file. Turns out that having `!` in your command line on WIndows gives all kinds of trouble when you also have delayed expansion turned on. The `!` is basically unescapable so you need to turn delayed expansion off again just before running the jbang java command.