### PR TITLE
SPI for 3rd party integration into build - enabling Quarkus native apps and use of Quarkus programming model

### DIFF
--- a/src/main/java/dev/jbang/ArtifactInfo.java
+++ b/src/main/java/dev/jbang/ArtifactInfo.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.util.Objects;
 
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
-import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
 
 /**
  * class describing artifact coordinates and its resolved physical location.
@@ -30,15 +29,6 @@ public class ArtifactInfo {
 	public String toString() {
 		String path = asFile().getAbsolutePath();
 		return getCoordinate().toCanonicalForm() + "=" + path;
-	}
-
-	static public ArtifactInfo fromExternalString(String externalString) {
-
-		MavenCoordinate coordinate = MavenCoordinates.createCoordinate(
-				externalString.substring(0, externalString.indexOf("=")));
-		File file = new File(externalString.substring(externalString.indexOf("=") + 1, externalString.length()));
-
-		return new ArtifactInfo(coordinate, file);
 	}
 
 	@Override

--- a/src/test/java/dev/jbang/TestArtifactInfo.java
+++ b/src/test/java/dev/jbang/TestArtifactInfo.java
@@ -13,18 +13,6 @@ import org.junit.jupiter.api.Test;
 public class TestArtifactInfo {
 
 	@Test
-	public void testArtifactFromExternalString() {
-
-		ArtifactInfo info = ArtifactInfo.fromExternalString("g:a:23.4=/here/is/a/path");
-
-		assertThat(info.asFile().getPath(), equalTo("/here/is/a/path"));
-		assertThat(info.getCoordinate().getGroupId(), equalTo("g"));
-		assertThat(info.getCoordinate().getArtifactId(), equalTo("a"));
-		assertThat(info.getCoordinate().getVersion(), equalTo("23.4"));
-
-	}
-
-	@Test
 	public void testDependencyCache() {
 
 		Settings.clearDependencyCache();


### PR DESCRIPTION
Bubble up artifact dependency info to build for better integration.

This introduce ArtifactInfo interface to use for capturing GAV + resolved
location for use during build.

Lets us generated pom.xml metadata and also explore adding SPI to let
dependencies process the jar before its built. Potential usefull for Quarkus integration :)