### PR TITLE
Added options `--cp` and `--deps`

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -85,7 +85,16 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		}
 	}
 
-	public static Script prepareScript(String scriptResource, List<String> arguments, Map<String, String> properties)
+	public static Script prepareScript(String scriptResource) throws IOException {
+		return prepareScript(scriptResource, null, null, null, null);
+	}
+
+	public static Script prepareScript(String scriptResource, List<String> arguments) throws IOException {
+		return prepareScript(scriptResource, arguments, null, null, null);
+	}
+
+	public static Script prepareScript(String scriptResource, List<String> arguments, Map<String, String> properties,
+			List<String> dependencies, List<String> classpaths)
 			throws IOException {
 		File scriptFile = getScriptFile(scriptResource);
 		if (scriptFile == null) {
@@ -125,6 +134,8 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		try {
 			s = new Script(scriptFile, arguments, properties);
 			s.setOriginal(scriptResource);
+			s.setAdditionalDependencies(dependencies);
+			s.setAdditionalClasspaths(classpaths);
 		} catch (FileNotFoundException e) {
 			throw new ExitException(1, e);
 		}

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -13,7 +13,7 @@ public class Build extends Run {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams, properties);
+		script = prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths);
 
 		if (script.needsJar()) {
 			build(script);

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -31,7 +31,7 @@ public class Edit extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams, null);
+		script = prepareScript(scriptOrFile, userParams);
 		File project = createProjectForEdit(script, false);
 		// err.println(project.getAbsolutePath());
 		if (liveeditor == null) {
@@ -74,7 +74,7 @@ public class Edit extends BaseScriptCommand {
 							try {
 								// TODO only regenerate when dependencies changes.
 								info("Regenerating project.");
-								script = prepareScript(scriptOrFile, userParams, null);
+								script = prepareScript(scriptOrFile, userParams);
 								createProjectForEdit(script, true);
 							} catch (RuntimeException ee) {
 								warn("Error when re-generating project. Ignoring it, but state might be undefined: "

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -76,6 +76,12 @@ public class Run extends BaseScriptCommand {
 			"-n", "--native" }, description = "Build via native-image and run", defaultValue = "false")
 	boolean nativeImage;
 
+	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	List<String> dependencies;
+
+	@CommandLine.Option(names = { "--cp" }, description = "Add class path entries.")
+	List<String> classpaths;
+
 	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 
 	@Override
@@ -84,7 +90,7 @@ public class Run extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams, properties);
+		script = prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths);
 
 		if (script.needsJar()) {
 			build(script);

--- a/src/test/java/dev/jbang/TestScript.java
+++ b/src/test/java/dev/jbang/TestScript.java
@@ -135,7 +135,7 @@ class TestScript {
 		Path p = output.resolve("kube-example");
 		writeString(p, example);
 
-		Script s = BaseScriptCommand.prepareScript(p.toAbsolutePath().toString(), null, null);
+		Script s = BaseScriptCommand.prepareScript(p.toAbsolutePath().toString());
 
 	}
 

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -45,7 +45,7 @@ public class TestEdit {
 		Jbang.getCommandLine().execute("init", s);
 		assertThat(new File(s).exists(), is(true));
 
-		Script script = BaseScriptCommand.prepareScript(s, null, null);
+		Script script = BaseScriptCommand.prepareScript(s);
 
 		File project = new Edit().createProjectForEdit(script, false);
 
@@ -83,7 +83,7 @@ public class TestEdit {
 
 		Util.writeString(p, "//DEPS org.openjfx:javafx-graphics:11.0.2${bougus:}\n" + Util.readString(p));
 
-		Script script = BaseScriptCommand.prepareScript(s, null, null);
+		Script script = BaseScriptCommand.prepareScript(s);
 
 		File project = new Edit().createProjectForEdit(script, false);
 
@@ -108,7 +108,7 @@ public class TestEdit {
 		Jbang.getCommandLine().execute("init", s);
 		assertThat(new File(s).exists(), is(true));
 
-		Script script = BaseScriptCommand.prepareScript(s, null, null);
+		Script script = BaseScriptCommand.prepareScript(s);
 
 		File project = new Edit().createProjectForEdit(script, false);
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -108,7 +108,7 @@ public class TestRun {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		Script s = prepareScript(jar, run.userParams, run.properties);
+		Script s = prepareScript(jar, run.userParams, run.properties, run.dependencies, run.classpaths);
 
 		String result = run.generateCommandLine(s);
 		assertThat(result, matchesPattern("^.*java(.exe)?.*"));
@@ -132,7 +132,7 @@ public class TestRun {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		Script result = prepareScript(jar, run.userParams, run.properties);
+		Script result = prepareScript(jar, run.userParams, run.properties, run.dependencies, run.classpaths);
 
 		assertThat(result.getBackingFile().toString(), matchesPattern(".*\\.m2.*codegen-4.5.0.jar"));
 
@@ -154,7 +154,7 @@ public class TestRun {
 				"picocli.codegen.aot.graalvm.ReflectionConfigGenerator", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		Script result = prepareScript(jar, run.userParams, run.properties);
+		Script result = prepareScript(jar, run.userParams, run.properties, run.dependencies, run.classpaths);
 
 		String cmd = run.generateCommandLine(result);
 
@@ -264,7 +264,7 @@ public class TestRun {
 
 		String url = new File(examplesTestFolder, "classpath_example.java").toURI().toString();
 
-		Script result = prepareScript(url, null, null);
+		Script result = prepareScript(url);
 
 		assertThat(result.toString(), not(containsString(url)));
 
@@ -275,7 +275,8 @@ public class TestRun {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		String s = run.generateCommandLine(prepareScript(url, run.userParams, run.properties));
+		String s = run.generateCommandLine(
+				prepareScript(url, run.userParams, run.properties, run.dependencies, run.classpaths));
 
 		assertThat(s, not(containsString("file:")));
 	}
@@ -287,7 +288,8 @@ public class TestRun {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url, " ~!@#$%^&*()-+\\:;'`<>?/,.{}[]\"");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		String s = run.generateCommandLine(prepareScript(url, run.userParams, run.properties));
+		String s = run.generateCommandLine(
+				prepareScript(url, run.userParams, run.properties, run.dependencies, run.classpaths));
 		if (Util.isWindows()) {
 			assertThat(s, containsString("^\"^ ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
 		} else {
@@ -300,7 +302,7 @@ public class TestRun {
 
 		String url = new File(examplesTestFolder, "classpath_example.java.dontexist").toURI().toString();
 
-		assertThrows(ExitException.class, () -> prepareScript(url, null, null));
+		assertThrows(ExitException.class, () -> prepareScript(url));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #169 

This allows for adding additional classpath entries. Either by referring
to directories with classes or JAR files (`--cp`) or by referring to
Maven GAVs or remote JAR files (`--deps`)