### PR TITLE
Add initial //FILES support for adding resuorces to app

### DIFF
--- a/examples/resource.java
+++ b/examples/resource.java
@@ -1,0 +1,17 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+//FILES resource.properties resource.properties=renamed.properties
+//FILES resource.properties=META-INF/application.properties
+
+import java.io.InputStream;
+import java.util.Properties;
+
+class resource {
+
+    public static void main(String[] args) throws Exception {
+        Properties prop = new Properties();
+        try(InputStream is = resource.class.getClassLoader().getResourceAsStream("resource.properties")) {
+            prop.load(is);
+        }
+        System.out.println("hello " + prop.getProperty("message"));
+    }
+}

--- a/examples/resource.properties
+++ b/examples/resource.properties
@@ -1,0 +1,1 @@
+message=properties

--- a/src/main/java/dev/jbang/FileRef.java
+++ b/src/main/java/dev/jbang/FileRef.java
@@ -1,0 +1,38 @@
+package dev.jbang;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class FileRef {
+
+	private final Script source;
+	String ref;
+
+	String destination;
+
+	public FileRef(Script source, String ref, String destination) {
+		this.source = source;
+		this.ref = ref;
+		this.destination = destination;
+	}
+
+	/**
+	 *
+	 */
+	public Path from() {
+		if (Paths.get(ref).isAbsolute()) {
+			throw new IllegalStateException("Only relative paths allowed in //FILES. Found absolute path: " + ref);
+		}
+
+		return Paths.get(source.getOriginalFile()).resolveSibling(ref);
+	}
+
+	public Path to(Path parent) {
+		String p = destination != null ? destination : ref;
+		if (Paths.get(p).isAbsolute()) {
+			throw new IllegalStateException("Only relative paths allowed in //FILES. Found absolute path: " + p);
+		}
+
+		return destination != null ? parent.resolve(destination) : parent.resolve(ref);
+	}
+}

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -25,7 +25,7 @@ public class Init extends BaseScriptCommand {
 		if (f.exists()) {
 			warn("File " + f + " already exists. Will not initialize.");
 		} else {
-			if (!f.getParentFile().exists()) {
+			if (f.getParentFile() != null && !f.getParentFile().exists()) {
 				f.getParentFile().mkdirs();
 			}
 			// Use try-with-resource to get auto-closeable writer instance

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -133,6 +134,21 @@ public class Run extends BaseScriptCommand {
 			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
 
 			// add additional files
+			List<FileRef> files = script.collectFiles();
+			for (FileRef file : files) {
+				Path from = file.from();
+				Path to = file.to(tmpJarDir.toPath());
+				Util.verboseMsg("Copying " + from + " to " + to);
+				try {
+					if (!to.toFile().getParentFile().exists()) {
+						to.toFile().getParentFile().mkdirs();
+					}
+					Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
+				} catch (IOException ioe) {
+					throw new ExitException(CommandLine.ExitCode.USAGE, "Could not copy " + from + " to " + to, ioe);
+				}
+			}
+
 			Template pomTemplate = Settings.getTemplateEngine().getTemplate("pom.qute.xml");
 
 			Path pomPath = null;


### PR DESCRIPTION
Supports `//FILES <relative path>[=<relative path>]`

meaning:

`//FILES resource.txt`
adds a file named `resource.txt`

`//FILES resource.txt=META-INF/application.properties`

This does not yet support:
- edit (files not handled thus just broken)
- files fetched from http(s) (no HttpFileSystemProvider)
- jsh (ignored)

Relates to #39