### PR TITLE
grouping of commands in help

### DIFF
--- a/src/main/java/dev/jbang/DeprecatedMessageHandler.java
+++ b/src/main/java/dev/jbang/DeprecatedMessageHandler.java
@@ -1,4 +1,4 @@
-package dev.jbang.cli;
+package dev.jbang;
 
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -10,7 +10,7 @@ import dev.jbang.Util;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "alias", description = "Manage aliases.")
+@CommandLine.Command(name = "alias", description = "Manage aliases for scripts.")
 public class Alias {
 
 	@CommandLine.Spec

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 
 import picocli.CommandLine.Command;
 
-@Command(name = "build", description = "Build .java/.jsh script without running. Use for caching dependencies.")
+@Command(name = "build", description = "Compiles and stores script in the cache.")
 public class Build extends Run {
 
 	@Override

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -8,7 +8,7 @@ import dev.jbang.Settings;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "cache", description = "Cache management.")
+@CommandLine.Command(name = "cache", description = "Manage compiled scripts in the local cache.")
 public class Cache {
 	@CommandLine.Command(name = "clear", description = "Clear cache of dependency list and temporary projects. By default this will clear the JAR, script, stdin and URL caches")
 	public Integer clear(

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -8,7 +8,7 @@ import dev.jbang.Util;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "catalog", description = "Manage catalogs.")
+@CommandLine.Command(name = "catalog", description = "Manage Catalogs of aliases.")
 public class Catalog {
 
 	@CommandLine.Spec

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -18,7 +18,7 @@ import dev.jbang.*;
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "edit", description = "Edit a .java/.jsh script.")
+@CommandLine.Command(name = "edit", description = "Setup a temporary project to edit script in an IDE.")
 public class Edit extends BaseScriptCommand {
 
 	@CommandLine.Option(names = {

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -12,7 +12,7 @@ import dev.jbang.Util;
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "init", description = "Initialize a .java/.jsh script.")
+@CommandLine.Command(name = "init", description = "Initialize a script.")
 public class Init extends BaseScriptCommand {
 
 	@CommandLine.Option(names = { "--template",

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -8,7 +8,7 @@ import dev.jbang.Util;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "jdk", description = "Manage JDKs.", hidden = true)
+@CommandLine.Command(name = "jdk", description = "Manage Java Development Kits installed by jbang.")
 public class Jdk {
 
 	@CommandLine.Spec

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -25,7 +25,7 @@ import dev.jbang.*;
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "run", description = "Compile and run provided .java/.jsh script.")
+@CommandLine.Command(name = "run", description = "Builds and runs provided script.")
 public class Run extends BaseScriptCommand {
 	private String javaVersion;
 

--- a/src/main/java/dev/jbang/cli/Trust.java
+++ b/src/main/java/dev/jbang/cli/Trust.java
@@ -7,7 +7,7 @@ import dev.jbang.Settings;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "trust", description = "Manage trust domains.")
+@CommandLine.Command(name = "trust", description = "Manage which domains you trust to run scripts from.")
 public class Trust {
 
 	@CommandLine.Spec

--- a/src/test/java/dev/jbang/cli/TestArguments.java
+++ b/src/test/java/dev/jbang/cli/TestArguments.java
@@ -37,6 +37,11 @@ class TestArguments {
 	public final TemporaryFolder jbangTempDir = new TemporaryFolder();
 
 	@Test
+	public void testHelpSections() {
+		Jbang.getCommandRenderer().validate(Jbang.getCommandLine().getHelp());
+	}
+
+	@Test
 	public void testBasicArguments() {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "-h", "--debug", "myfile.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();


### PR DESCRIPTION
Implemented the grouping but not all sure about the grouping - feedback welcome:

```
Usage: jbang [-h] [--verbose] [COMMAND]
Compiles and runs .java/.jsh scripts.
  -h, --help      Display help/info
      --verbose   jbang will be verbose on what it does.

Basic Commands:
  run         Compile and run provided .java/.jsh script.
  edit        Edit a .java/.jsh script.
  init        Initialize a .java/.jsh script.

Advanced Commands:
  build       Build .java/.jsh script without running. Use for caching
                dependencies.
  trust       Manage trust domains.
  cache       Cache management.

Catalog:
  alias       Manage aliases.
  catalog     Manage catalogs.

Other:
  version     Display version info.
  completion  Output auto-completion script for bash/zsh.
              Usage: source <(jbang completion)

Copyright: 2020 Max Rydahl Andersen, License: MIT
Website: https://github.com/jbangdev/jbang
```