### PR TITLE
Move common code from `build` and `run` to common base class

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -1,0 +1,255 @@
+package dev.jbang.cli;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import dev.jbang.*;
+
+import io.quarkus.qute.Template;
+import picocli.CommandLine;
+
+public abstract class BaseBuildCommand extends BaseScriptCommand {
+	protected String javaVersion;
+
+	@CommandLine.Option(names = { "-m",
+			"--main" }, description = "Main class to use when running. Used primarily for running jar's.")
+	String main;
+
+	@CommandLine.Option(names = { "-j",
+			"--java" }, description = "JDK version to use for running the script.")
+	void setJavaVersion(String javaVersion) {
+		if (!javaVersion.matches("\\d+[+]?")) {
+			throw new IllegalArgumentException(
+					"Invalid version, should be a number optionally followed by a plus sign");
+		}
+		this.javaVersion = javaVersion;
+	}
+
+	@CommandLine.Option(names = {
+			"--cds" }, description = "If specified Class Data Sharing (CDS) will be used for building and running (requires Java 13+)", negatable = true)
+	Boolean cds;
+
+	Optional<Boolean> cds() {
+		return Optional.ofNullable(cds);
+	}
+
+	@CommandLine.Option(names = { "-D" }, description = "set a system property")
+	Map<String, String> properties = new HashMap<>();
+
+	@CommandLine.Option(names = {
+			"-n", "--native" }, description = "Build using native-image", defaultValue = "false")
+	boolean nativeImage;
+
+	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	List<String> dependencies;
+
+	@CommandLine.Option(names = { "--cp", "--class-path" }, description = "Add class path entries.")
+	List<String> classpaths;
+
+	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
+
+	// build with javac and then jar... todo: split up in more testable chunks
+	void build(Script script) throws IOException {
+		File baseDir = Settings.getCacheDir(Settings.CacheClass.jars).toFile();
+		File tmpJarDir = new File(baseDir, script.getBackingFile().getName() +
+				"." + Util.getStableID(script.getBackingFile()));
+		tmpJarDir.mkdirs();
+
+		File outjar = new File(tmpJarDir.getParentFile(), tmpJarDir.getName() + ".jar");
+
+		if (outjar.exists()) {
+			try (JarFile jf = new JarFile(outjar)) {
+				script.setMainClass(
+						jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS));
+				script.setBuildJdk(
+						JavaUtil.parseJavaVersion(jf.getManifest().getMainAttributes().getValue("Build-Jdk")));
+			}
+		}
+
+		boolean nativeBuildRequired = nativeImage && !getImageName(outjar).exists();
+		Path externalNativeImage = null;
+		String requestedJavaVersion = javaVersion != null ? javaVersion : script.javaVersion();
+		// always build the jar for native mode
+		// it allows integrations the options to produce the native image
+		if (!outjar.exists() || JavaUtil.javaVersion(requestedJavaVersion) < script.getBuildJdk()
+				|| nativeBuildRequired) {
+			List<String> optionList = new ArrayList<String>();
+			optionList.add(resolveInJavaHome("javac", requestedJavaVersion));
+			optionList.addAll(script.collectCompileOptions());
+			String path = script.resolveClassPath(offline);
+			if (!path.trim().isEmpty()) {
+				optionList.addAll(Arrays.asList("-classpath", path));
+			}
+			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
+			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
+
+			// add additional files
+			List<FileRef> files = script.collectFiles();
+			for (FileRef file : files) {
+				file.copy(tmpJarDir.toPath(), Files.createTempDirectory(String.valueOf(System.currentTimeMillis())));
+			}
+
+			Template pomTemplate = Settings.getTemplateEngine().getTemplate("pom.qute.xml");
+
+			Path pomPath = null;
+			if (pomTemplate == null) {
+				// ignore
+				Util.warnMsg("Could not locate pom.xml template");
+			} else {
+				String pomfile = pomTemplate
+											.data("baseName", Util.getBaseName(script.getBackingFile().getName()))
+											.data("dependencies", script.getClassPath().getArtifacts())
+											.render();
+				pomPath = new File(tmpJarDir, "META-INF/maven/g/a/v/pom.xml").toPath();
+				Files.createDirectories(pomPath.getParent());
+				Util.writeString(pomPath, pomfile);
+			}
+
+			info("Building jar...");
+			debug("compile: " + String.join(" ", optionList));
+
+			Process process = new ProcessBuilder(optionList).inheritIO().start();
+			try {
+				process.waitFor();
+			} catch (InterruptedException e) {
+				throw new ExitException(1, e);
+			}
+
+			if (process.exitValue() != 0) {
+				throw new ExitException(1, "Error during compile");
+			}
+
+			try {
+				// using Files.walk method with try-with-resources
+				try (Stream<Path> paths = Files.walk(tmpJarDir.toPath())) {
+					List<Path> items = paths.filter(Files::isRegularFile)
+											.filter(f -> !f.toFile().getName().contains("$"))
+											.filter(f -> f.toFile().getName().endsWith(".class"))
+											.collect(Collectors.toList());
+
+					if (items.size() > 1) { // todo: this feels like a very sketchy way to find the proper class name
+						// but it works.
+						String mainname = script.getBackingFile().getName().replace(".java", ".class");
+						items = items	.stream()
+										.filter(f -> f.toFile().getName().equalsIgnoreCase(mainname))
+										.collect(Collectors.toList());
+					}
+
+					if (items.size() != 1) {
+						throw new ExitException(1,
+								"Could not locate unique class. Found " + items.size() + " candidates.");
+					} else {
+						Path classfile = items.get(0);
+						String mainClass = findMainClass(tmpJarDir.toPath(), classfile);
+						script.setMainClass(mainClass);
+					}
+				}
+			} catch (IOException e) {
+				throw new ExitException(1, e);
+			}
+			script.setBuildJdk(JavaUtil.javaVersion(requestedJavaVersion));
+			externalNativeImage = IntegrationManager.runIntegration(script.getRepositories(),
+					script.getClassPath().getArtifacts(),
+					tmpJarDir.toPath(), pomPath,
+					script, nativeImage);
+			script.createJarFile(tmpJarDir, outjar);
+		}
+
+		if (nativeBuildRequired) {
+			if (externalNativeImage != null) {
+				Files.move(externalNativeImage, getImageName(outjar).toPath());
+			} else {
+				List<String> optionList = new ArrayList<String>();
+				optionList.add(resolveInGraalVMHome("native-image", requestedJavaVersion));
+
+				optionList.add("-H:+ReportExceptionStackTraces");
+
+				optionList.add("--enable-https");
+
+				String classpath = script.resolveClassPath(offline);
+				if (!classpath.trim().isEmpty()) {
+					optionList.add("--class-path=" + classpath);
+				}
+
+				optionList.add("-jar");
+				optionList.add(outjar.toString());
+
+				optionList.add(getImageName(outjar).toString());
+
+				File nilog = File.createTempFile("jbang", "native-image");
+				debug("native-image: " + String.join(" ", optionList));
+				info("log: " + nilog.toString());
+
+				Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog).start();
+				try {
+					process.waitFor();
+				} catch (InterruptedException e) {
+					throw new ExitException(1, e);
+				}
+
+				if (process.exitValue() != 0) {
+					throw new ExitException(1, "Error during native-image");
+				}
+			}
+		}
+		script.setJar(outjar);
+	}
+
+	/** based on jar what will the binary image name be. **/
+	protected File getImageName(File outjar) {
+		if (Util.isWindows()) {
+			return new File(outjar.toString() + ".exe");
+		} else {
+			return new File(outjar.toString() + ".bin");
+		}
+	}
+
+	static public String findMainClass(Path base, Path classfile) {
+		StringBuilder mainClass = new StringBuilder(classfile.getFileName().toString().replace(".class", ""));
+		while (!classfile.getParent().equals(base)) {
+			classfile = classfile.getParent();
+			mainClass.insert(0, classfile.getFileName().toString() + ".");
+		}
+		return mainClass.toString();
+	}
+
+	String resolveInJavaHome(String cmd, String requestedVersion) {
+		Path jdkHome = JdkManager.getCurrentJdk(requestedVersion);
+		if (jdkHome != null) {
+			if (Util.isWindows()) {
+				cmd = cmd + ".exe";
+			}
+			return jdkHome.resolve("bin").resolve(cmd).toAbsolutePath().toString();
+		}
+		return cmd;
+	}
+
+	String resolveInGraalVMHome(String cmd, String requestedVersion) {
+		String newcmd = resolveInEnv("GRAALVM_HOME", cmd);
+
+		if (newcmd.equals(cmd) &&
+				!new File(newcmd).exists()) {
+			return resolveInJavaHome(cmd, requestedVersion);
+		} else {
+			return newcmd;
+		}
+	}
+
+	private static String resolveInEnv(String env, String cmd) {
+		if (System.getenv(env) != null) {
+			if (Util.isWindows()) {
+				cmd = cmd + ".exe";
+			}
+			return new File(System.getenv(env)).toPath().resolve("bin").resolve(cmd).toAbsolutePath().toString();
+		} else {
+			return cmd;
+		}
+	}
+
+}

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import picocli.CommandLine.Command;
 
 @Command(name = "build", description = "Compiles and stores script in the cache.")
-public class Build extends Run {
+public class Build extends BaseBuildCommand {
 
 	@Override
 	public Integer doCall() throws IOException {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -1,46 +1,20 @@
 package dev.jbang.cli;
 
 import java.io.File;
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.jar.Attributes;
-import java.util.jar.JarFile;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.net.ssl.*;
 
 import org.apache.commons.text.StringEscapeUtils;
 
 import dev.jbang.*;
 
-import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "run", description = "Builds and runs provided script.")
-public class Run extends BaseScriptCommand {
-	private String javaVersion;
-
-	@CommandLine.Option(names = { "-m",
-			"--main" }, description = "Main class to use when running. Used primarily for running jar's.")
-	String main;
-
-	@CommandLine.Option(names = { "-j",
-			"--java" }, description = "JDK version to use for running the script.")
-	void setJavaVersion(String javaVersion) {
-		if (!javaVersion.matches("\\d+[+]?")) {
-			throw new IllegalArgumentException(
-					"Invalid version, should be a number optionally followed by a plus sign");
-		}
-		this.javaVersion = javaVersion;
-	}
+public class Run extends BaseBuildCommand {
 
 	@CommandLine.Option(names = { "-r",
 			"--jfr" }, fallbackValue = "filename={baseName}.jfr", parameterConsumer = KeyValueFallbackConsumer.class, arity = "0..1", description = "Launch with Java Flight Recorder enabled.")
@@ -54,35 +28,12 @@ public class Run extends BaseScriptCommand {
 			"--debug" }, fallbackValue = "4004", parameterConsumer = DebugFallbackConsumer.class, description = "Launch with java debug enabled on specified port (default: ${FALLBACK-VALUE}) ")
 	String debugString;
 
-	@CommandLine.Option(names = {
-			"--cds" }, description = "If specified Class Data Sharing (CDS) will be used for building and running (requires Java 13+)", negatable = true)
-	Boolean cds;
-
-	Optional<Boolean> cds() {
-		return Optional.ofNullable(cds);
-	}
-
 	boolean debug() {
 		return debugString != null;
 	}
 
-	@CommandLine.Option(names = { "-D" }, description = "set a system property")
-	Map<String, String> properties = new HashMap<>();
-
 	@CommandLine.Option(names = { "--interactive" }, description = "activate interactive mode")
 	boolean interactive;
-
-	@CommandLine.Option(names = {
-			"-n", "--native" }, description = "Build via native-image and run", defaultValue = "false")
-	boolean nativeImage;
-
-	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
-	List<String> dependencies;
-
-	@CommandLine.Option(names = { "--cp", "--class-path" }, description = "Add class path entries.")
-	List<String> classpaths;
-
-	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 
 	@Override
 	public Integer doCall() throws IOException {
@@ -101,153 +52,6 @@ public class Run extends BaseScriptCommand {
 		out.println(cmdline);
 
 		return 0;
-	}
-
-	// build with javac and then jar... todo: split up in more testable chunks
-	void build(Script script) throws IOException {
-		File baseDir = Settings.getCacheDir(Settings.CacheClass.jars).toFile();
-		File tmpJarDir = new File(baseDir, script.getBackingFile().getName() +
-				"." + Util.getStableID(script.getBackingFile()));
-		tmpJarDir.mkdirs();
-
-		File outjar = new File(tmpJarDir.getParentFile(), tmpJarDir.getName() + ".jar");
-
-		if (outjar.exists()) {
-			try (JarFile jf = new JarFile(outjar)) {
-				script.setMainClass(
-						jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS));
-				script.setBuildJdk(
-						JavaUtil.parseJavaVersion(jf.getManifest().getMainAttributes().getValue("Build-Jdk")));
-			}
-		}
-
-		boolean nativeBuildRequired = nativeImage && !getImageName(outjar).exists();
-		Path externalNativeImage = null;
-		String requestedJavaVersion = javaVersion != null ? javaVersion : script.javaVersion();
-		// always build the jar for native mode
-		// it allows integrations the options to produce the native image
-		if (!outjar.exists() || JavaUtil.javaVersion(requestedJavaVersion) < script.getBuildJdk()
-				|| nativeBuildRequired) {
-			List<String> optionList = new ArrayList<String>();
-			optionList.add(resolveInJavaHome("javac", requestedJavaVersion));
-			optionList.addAll(script.collectCompileOptions());
-			String path = script.resolveClassPath(offline);
-			if (!path.trim().isEmpty()) {
-				optionList.addAll(Arrays.asList("-classpath", path));
-			}
-			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
-			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
-
-			// add additional files
-			List<FileRef> files = script.collectFiles();
-			for (FileRef file : files) {
-				file.copy(tmpJarDir.toPath(), Files.createTempDirectory(String.valueOf(System.currentTimeMillis())));
-			}
-
-			Template pomTemplate = Settings.getTemplateEngine().getTemplate("pom.qute.xml");
-
-			Path pomPath = null;
-			if (pomTemplate == null) {
-				// ignore
-				Util.warnMsg("Could not locate pom.xml template");
-			} else {
-				String pomfile = pomTemplate
-											.data("baseName", Util.getBaseName(script.getBackingFile().getName()))
-											.data("dependencies", script.getClassPath().getArtifacts())
-											.render();
-				pomPath = new File(tmpJarDir, "META-INF/maven/g/a/v/pom.xml").toPath();
-				Files.createDirectories(pomPath.getParent());
-				Util.writeString(pomPath, pomfile);
-			}
-
-			info("Building jar...");
-			debug("compile: " + String.join(" ", optionList));
-
-			Process process = new ProcessBuilder(optionList).inheritIO().start();
-			try {
-				process.waitFor();
-			} catch (InterruptedException e) {
-				throw new ExitException(1, e);
-			}
-
-			if (process.exitValue() != 0) {
-				throw new ExitException(1, "Error during compile");
-			}
-
-			try {
-				// using Files.walk method with try-with-resources
-				try (Stream<Path> paths = Files.walk(tmpJarDir.toPath())) {
-					List<Path> items = paths.filter(Files::isRegularFile)
-											.filter(f -> !f.toFile().getName().contains("$"))
-											.filter(f -> f.toFile().getName().endsWith(".class"))
-											.collect(Collectors.toList());
-
-					if (items.size() > 1) { // todo: this feels like a very sketchy way to find the proper class name
-						// but it works.
-						String mainname = script.getBackingFile().getName().replace(".java", ".class");
-						items = items	.stream()
-										.filter(f -> f.toFile().getName().equalsIgnoreCase(mainname))
-										.collect(Collectors.toList());
-					}
-
-					if (items.size() != 1) {
-						throw new ExitException(1,
-								"Could not locate unique class. Found " + items.size() + " candidates.");
-					} else {
-						Path classfile = items.get(0);
-						String mainClass = findMainClass(tmpJarDir.toPath(), classfile);
-						script.setMainClass(mainClass);
-					}
-				}
-			} catch (IOException e) {
-				throw new ExitException(1, e);
-			}
-			script.setBuildJdk(JavaUtil.javaVersion(requestedJavaVersion));
-			externalNativeImage = IntegrationManager.runIntegration(script.getRepositories(),
-					script.getClassPath().getArtifacts(),
-					tmpJarDir.toPath(), pomPath,
-					script, nativeImage);
-			script.createJarFile(tmpJarDir, outjar);
-		}
-
-		if (nativeBuildRequired) {
-			if (externalNativeImage != null) {
-				Files.move(externalNativeImage, getImageName(outjar).toPath());
-			} else {
-				List<String> optionList = new ArrayList<String>();
-				optionList.add(resolveInGraalVMHome("native-image", requestedJavaVersion));
-
-				optionList.add("-H:+ReportExceptionStackTraces");
-
-				optionList.add("--enable-https");
-
-				String classpath = script.resolveClassPath(offline);
-				if (!classpath.trim().isEmpty()) {
-					optionList.add("--class-path=" + classpath);
-				}
-
-				optionList.add("-jar");
-				optionList.add(outjar.toString());
-
-				optionList.add(getImageName(outjar).toString());
-
-				File nilog = File.createTempFile("jbang", "native-image");
-				debug("native-image: " + String.join(" ", optionList));
-				info("log: " + nilog.toString());
-
-				Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog).start();
-				try {
-					process.waitFor();
-				} catch (InterruptedException e) {
-					throw new ExitException(1, e);
-				}
-
-				if (process.exitValue() != 0) {
-					throw new ExitException(1, "Error during native-image");
-				}
-			}
-		}
-		script.setJar(outjar);
 	}
 
 	String generateCommandLine(Script script) throws IOException {
@@ -360,24 +164,6 @@ public class Run extends BaseScriptCommand {
 		return master.map(Boolean::booleanValue).orElse(local);
 	}
 
-	/** based on jar what will the binary image name be. **/
-	private File getImageName(File outjar) {
-		if (Util.isWindows()) {
-			return new File(outjar.toString() + ".exe");
-		} else {
-			return new File(outjar.toString() + ".bin");
-		}
-	}
-
-	static public String findMainClass(Path base, Path classfile) {
-		StringBuilder mainClass = new StringBuilder(classfile.getFileName().toString().replace(".class", ""));
-		while (!classfile.getParent().equals(base)) {
-			classfile = classfile.getParent();
-			mainClass.insert(0, classfile.getFileName().toString() + ".");
-		}
-		return mainClass.toString();
-	}
-
 	private void addPropertyFlags(Map<String, String> properties, String def, List<String> result) {
 		properties.forEach((k, e) -> {
 			result.add(def + k + "=" + e);
@@ -394,8 +180,7 @@ public class Run extends BaseScriptCommand {
 		return args.stream().map(Run::escapeArgument).collect(Collectors.toList());
 	}
 
-	// There are probably more safe characters, but I couldn't find a definitive
-	// list
+	// NB: This might not be a definitive list of safe characters
 	static Pattern cmdSafeChars = Pattern.compile("[a-zA-Z0-9.,_+=:;@()-]*");
 
 	static Pattern shellSafeChars = Pattern.compile("[a-zA-Z0-9._+=:@%/-]*");
@@ -417,7 +202,7 @@ public class Run extends BaseScriptCommand {
 		return arg;
 	}
 
-	String generateArgs(List<String> args, Map<String, String> properties) {
+	static String generateArgs(List<String> args, Map<String, String> properties) {
 
 		String buf = "String[] args = { " +
 				args.stream()
@@ -431,39 +216,6 @@ public class Run extends BaseScriptCommand {
 							.map(x -> "System.setProperty(\"" + x.getKey() + "\",\"" + x.getValue() + "\");")
 							.collect(Collectors.joining("\n"));
 		return buf;
-	}
-
-	String resolveInJavaHome(String cmd, String requestedVersion) {
-		Path jdkHome = JdkManager.getCurrentJdk(requestedVersion);
-		if (jdkHome != null) {
-			if (Util.isWindows()) {
-				cmd = cmd + ".exe";
-			}
-			return jdkHome.resolve("bin").resolve(cmd).toAbsolutePath().toString();
-		}
-		return cmd;
-	}
-
-	String resolveInGraalVMHome(String cmd, String requestedVersion) {
-		String newcmd = resolveInEnv("GRAALVM_HOME", cmd);
-
-		if (newcmd.equals(cmd) &&
-				!new File(newcmd).exists()) {
-			return resolveInJavaHome(cmd, requestedVersion);
-		} else {
-			return newcmd;
-		}
-	}
-
-	private static String resolveInEnv(String env, String cmd) {
-		if (System.getenv(env) != null) {
-			if (Util.isWindows()) {
-				cmd = cmd + ".exe";
-			}
-			return new File(System.getenv(env)).toPath().resolve("bin").resolve(cmd).toAbsolutePath().toString();
-		} else {
-			return cmd;
-		}
 	}
 
 	/**

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -355,19 +355,19 @@ public class TestRun {
 
 		Map<String, String> properties = new HashMap<>();
 
-		assertThat(new Run().generateArgs(Collections.emptyList(), properties), equalTo("String[] args = {  }"));
+		assertThat(Run.generateArgs(Collections.emptyList(), properties), equalTo("String[] args = {  }"));
 
-		assertThat(new Run().generateArgs(Arrays.asList("one"), properties),
+		assertThat(Run.generateArgs(Arrays.asList("one"), properties),
 				equalTo("String[] args = { \"one\" }"));
 
-		assertThat(new Run().generateArgs(Arrays.asList("one", "two"), properties),
+		assertThat(Run.generateArgs(Arrays.asList("one", "two"), properties),
 				equalTo("String[] args = { \"one\", \"two\" }"));
 
-		assertThat(new Run().generateArgs(Arrays.asList("one", "two", "three \"quotes\""), properties),
+		assertThat(Run.generateArgs(Arrays.asList("one", "two", "three \"quotes\""), properties),
 				equalTo("String[] args = { \"one\", \"two\", \"three \\\"quotes\\\"\" }"));
 
 		properties.put("value", "this value");
-		assertThat(new Run().generateArgs(Collections.emptyList(), properties),
+		assertThat(Run.generateArgs(Collections.emptyList(), properties),
 				equalTo("String[] args = {  }\nSystem.setProperty(\"value\",\"this value\");"));
 
 	}


### PR DESCRIPTION
Didn't really like `Build` inheriting from `Run` because it seemed the wrong way around. So I created a common base class for them containing all the code necessary for `Build` and all of the build-related code for `Run`.