### PR TITLE
feat: Implemented local catalogs

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -29,4 +29,7 @@ Scenario: add catalog twice with different name
   And  match exit == 0
   Then command('jbang echo@ct tako')
   And match exit == 0
- 
+
+Scenario: access remote catalog
+  When command('jbang build hello@jbangdev')
+  Then  match exit == 0

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -12,14 +12,14 @@
     "vertx": {
       "script-ref": "vertx.java"
     },
-    "classpath_example": {
+    "classpath_example_java": {
+      "script-ref": "classpath_example.java"
+    },
+    "classpath_example_jsh": {
       "script-ref": "classpath_example.jsh"
     },
     "hibernate": {
       "script-ref": "hibernate.java"
-    },
-    "example": {
-      "script-ref": "example"
     },
     "docker": {
       "script-ref": "docker.java"
@@ -45,12 +45,6 @@
     "webdriver": {
       "script-ref": "webdriver.java"
     },
-    "jetty": {
-      "script-ref": "jetty.jsh"
-    },
-    "scripts": {
-      "script-ref": "scripts"
-    },
     "lang": {
       "script-ref": "lang.java"
     },
@@ -64,10 +58,13 @@
       "script-ref": "asciidoc.java"
     },
     "helloworld": {
-      "script-ref": "helloworld.jsh"
+      "script-ref": "helloworld.java"
     },
     "urldep": {
       "script-ref": "urldep.java"
+    },
+    "ilc": {
+      "script-ref": "ilc.java"
     },
     "imap": {
       "script-ref": "imap.java"
@@ -77,6 +74,9 @@
     },
     "asciidoctor": {
       "script-ref": "asciidoctor.java"
+    },
+    "resource": {
+      "script-ref": "resource.java"
     },
     "plantuml": {
       "script-ref": "plantuml.java"
@@ -116,8 +116,11 @@
     },
     "junit-run": {
       "script-ref": "junit-run.java"
+    },
+    "jetty": {
+      "script-ref": "jetty.jsh"
     }
   },
   "base-ref": "examples",
-  "description": "\u0027JBang example scripts\u0027"
+  "description": "Jbang example scripts"
 }

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -512,7 +512,7 @@ public class AliasUtil {
 				if (as != null) {
 					aliases = as;
 					// Validate the result (Gson can't do this)
-					check(aliases.aliases != null, "Missing required attribute 'aliases'");
+					check(aliases.aliases != null, "Missing required attribute 'aliases' in " + catalogPath);
 					for (String aliasName : aliases.aliases.keySet()) {
 						Alias alias = aliases.aliases.get(aliasName);
 						alias.aliases = aliases;

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -5,6 +5,7 @@ import java.io.Reader;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -18,6 +19,7 @@ import picocli.CommandLine;
 
 public class AliasUtil {
 	public static final String JBANG_CATALOG_JSON = "jbang-catalog.json";
+	public static final String JBANG_DOT_DIR = ".jbang";
 
 	private static final String GITHUB_URL = "https://github.com/";
 	private static final String GITLAB_URL = "https://gitlab.com/";
@@ -25,26 +27,77 @@ public class AliasUtil {
 
 	private static final String JBANG_CATALOG_REPO = "jbang-catalog";
 
+	static Map<Path, Aliases> catalogCache = new HashMap<>();
+
 	public static class Alias {
 		@SerializedName(value = "script-ref", alternate = { "scriptRef" })
 		public final String scriptRef;
 		public final String description;
 		public final List<String> arguments;
 		public final Map<String, String> properties;
+		public transient Aliases aliases;
 
-		public Alias(String scriptRef, String description, List<String> arguments, Map<String, String> properties) {
+		public Alias(String scriptRef, String description, List<String> arguments, Map<String, String> properties,
+				Aliases aliases) {
 			this.scriptRef = scriptRef;
 			this.description = description;
 			this.arguments = arguments;
 			this.properties = properties;
+			this.aliases = aliases;
+		}
+
+		/**
+		 * This method returns the scriptRef of the Alias with all contextual modifiers
+		 * like baseRefs and current working directories applied.
+		 */
+		public String resolve(Path cwd) {
+			if (cwd == null) {
+				cwd = getCwd();
+			}
+			String baseRef = aliases.baseRef;
+			String ref = scriptRef;
+			if (baseRef != null && !isAbsoluteRef(ref)) {
+				if (!baseRef.endsWith("/")) {
+					baseRef += "/";
+				}
+				if (ref.startsWith("./")) {
+					baseRef += ref.substring(2);
+				} else {
+					baseRef += ref;
+				}
+				ref = baseRef;
+			}
+			if (!isAbsoluteRef(ref)) {
+				Path script = scriptParent(aliases.catalogFile).resolve(ref);
+				if (script.startsWith(cwd) || cwd.startsWith(script)
+						|| !cwd.relativize(script).startsWith("../../..")) {
+					script = cwd.relativize(script);
+				}
+				ref = script.toString();
+			}
+			return ref;
 		}
 	}
 
 	public static class Aliases {
-		public Map<String, Alias> aliases = new HashMap<>();
+		public final Map<String, Alias> aliases = new HashMap<>();
 		@SerializedName(value = "base-ref", alternate = { "baseRef" })
-		public String baseRef;
-		public String description;
+		public final String baseRef;
+		public final String description;
+		public transient Path catalogFile;
+
+		public Aliases(String baseRef, String description, Path catalogFile) {
+			this.baseRef = baseRef;
+			this.description = description;
+			this.catalogFile = catalogFile;
+		}
+
+		public Aliases(String baseRef, String description, Path catalogFile, Map<String, Alias> aliases) {
+			this.baseRef = baseRef;
+			this.description = description;
+			this.catalogFile = catalogFile;
+			this.aliases.putAll(aliases);
+		}
 	}
 
 	public static class Catalog {
@@ -63,22 +116,33 @@ public class AliasUtil {
 	}
 
 	/**
+	 * Returns an Alias object for the given name
+	 *
+	 * @param cwd       The current working directory (leave null to auto detect)
+	 * @param aliasName The name of an Alias
+	 * @return An Alias object or null if no alias was found
+	 */
+	public static Alias getAlias(Path cwd, String aliasName) {
+		return getAlias(cwd, aliasName, null, null);
+	}
+
+	/**
 	 * Returns an Alias object for the given name with the given arguments and
 	 * properties applied to it. Or null if no alias with that name could be found.
-	 * 
+	 *
 	 * @param aliasName  The name of an Alias
 	 * @param arguments  Optional arguments to apply to the Alias
 	 * @param properties Optional properties to apply to the Alias
 	 * @return An Alias object or null if no alias was found
 	 */
-	public static Alias getAlias(String aliasName, List<String> arguments, Map<String, String> properties) {
+	public static Alias getAlias(Path cwd, String aliasName, List<String> arguments, Map<String, String> properties) {
 		HashSet<String> names = new HashSet<>();
-		Alias alias = new Alias(null, null, arguments, properties);
-		Alias result = mergeAliases(alias, aliasName, names);
+		Alias alias = new Alias(null, null, arguments, properties, null);
+		Alias result = mergeAliases(cwd, alias, aliasName, names);
 		return result.scriptRef != null ? result : null;
 	}
 
-	private static Alias mergeAliases(Alias a1, String name, HashSet<String> names) {
+	private static Alias mergeAliases(Path cwd, Alias a1, String name, HashSet<String> names) {
 		if (names.contains(name)) {
 			throw new RuntimeException("Encountered alias loop on '" + name + "'");
 		}
@@ -88,7 +152,7 @@ public class AliasUtil {
 		}
 		Alias a2;
 		if (parts.length == 1) {
-			a2 = Settings.getAliases().get(name);
+			a2 = getLocalAlias(cwd, name);
 		} else {
 			if (parts[1].isEmpty()) {
 				throw new RuntimeException("Invalid alias name '" + name + "'");
@@ -97,14 +161,27 @@ public class AliasUtil {
 		}
 		if (a2 != null) {
 			names.add(name);
-			a2 = mergeAliases(a2, a2.scriptRef, names);
+			a2 = mergeAliases(cwd, a2, a2.scriptRef, names);
 			List<String> args = a1.arguments != null && !a1.arguments.isEmpty() ? a1.arguments : a2.arguments;
 			Map<String, String> props = a1.properties != null && !a1.properties.isEmpty() ? a1.properties
 					: a2.properties;
-			return new Alias(a2.scriptRef, null, args, props);
+			Aliases aliases = a2.aliases != null ? a2.aliases : a1.aliases;
+			return new Alias(a2.scriptRef, null, args, props, aliases);
 		} else {
 			return a1;
 		}
+	}
+
+	/**
+	 * Returns the given Alias from the local file system
+	 *
+	 * @param cwd       The current working directory (leave null to auto detect)
+	 * @param aliasName The name of an Alias
+	 * @return An Alias object
+	 */
+	private static Alias getLocalAlias(Path cwd, String aliasName) {
+		Aliases aliases = getAllAliasesFromLocalCatalogs(cwd);
+		return aliases.aliases.getOrDefault(aliasName, null);
 	}
 
 	/**
@@ -114,23 +191,23 @@ public class AliasUtil {
 	 * @param aliasName   The name of an Alias
 	 * @return An Alias object
 	 */
-	public static Alias getCatalogAlias(String catalogName, String aliasName) {
+	private static Alias getCatalogAlias(String catalogName, String aliasName) {
 		Aliases aliases = getCatalogAliasesByName(catalogName, false);
-		return getCatalogAlias(aliases, aliasName);
+		Alias alias = aliases.aliases.get(aliasName);
+		if (alias == null) {
+			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "No alias found with name '" + aliasName + "'");
+		}
+		return alias;
 	}
 
 	/**
 	 * Load a Catalog's aliases given the name of a previously registered Catalog
 	 * 
-	 * @param catalogName The name of a registered Catalog. Set to null to retrieve
-	 *                    the Alias from the local aliases
+	 * @param catalogName The name of a registered
 	 * @param updateCache Set to true to ignore cached values
 	 * @return An Aliases object
 	 */
 	public static Aliases getCatalogAliasesByName(String catalogName, boolean updateCache) {
-		if (catalogName == null) {
-			return Settings.getAliasesFromLocalCatalog();
-		}
 		Catalog catalog = getCatalog(catalogName);
 		if (catalog != null) {
 			return getCatalogAliasesByRef(catalog.catalogRef, updateCache);
@@ -223,6 +300,90 @@ public class AliasUtil {
 	}
 
 	/**
+	 * Will either return the given catalog or search for the nearest catalog
+	 * starting from cwd.
+	 * 
+	 * @param cwd     The folder to use as a starting point for getting the nearest
+	 *                catalog
+	 * @param catalog The catalog to return or null to return the nearest catalog
+	 * @return Path to a catalog
+	 */
+	public static Path getCatalog(Path cwd, Path catalog) {
+		if (catalog == null) {
+			catalog = findNearestLocalCatalog(cwd);
+			if (catalog == null) {
+				catalog = Settings.getAliasesFile();
+			}
+		}
+		return catalog;
+	}
+
+	/**
+	 * Adds a new alias to the nearest catalog
+	 * 
+	 * @param cwd  The folder to use as a starting point for getting the nearest
+	 *             catalog
+	 * @param name The name of the new alias
+	 */
+	public static void addNearestAlias(Path cwd, String name, String scriptRef, String description,
+			List<String> arguments,
+			Map<String, String> properties) {
+		Path catalog = getCatalog(cwd, null);
+		addAlias(catalog, name, scriptRef, description, arguments, properties);
+	}
+
+	/**
+	 * Adds a new alias to the given catalog
+	 * 
+	 * @param catalog Path to catalog file
+	 * @param name    The name of the new alias
+	 */
+	public static void addAlias(Path catalog, String name, String scriptRef, String description, List<String> arguments,
+			Map<String, String> properties) {
+		Aliases aliases = getAliasesFromCatalogFile(catalog, true);
+		aliases.aliases.put(name, new Alias(scriptRef, description, arguments, properties, aliases));
+		try {
+			writeAliasesToCatalogFile(catalog, aliases);
+		} catch (IOException ex) {
+			Util.warnMsg("Unable to add alias: " + ex.getMessage());
+		}
+	}
+
+	/**
+	 * Finds the nearest catalog file that contains an alias with the given name and
+	 * removes it
+	 * 
+	 * @param cwd  The folder to use as a starting point for getting the nearest
+	 *             catalog
+	 * @param name Name of alias to remove
+	 */
+	public static void removeNearestAlias(Path cwd, String name) {
+		Path catalog = findNearestLocalCatalogWithAlias(cwd, name);
+		if (catalog == null) {
+			catalog = Settings.getAliasesFile();
+		}
+		removeAlias(catalog, name);
+	}
+
+	/**
+	 * Remove alias from specified catalog file
+	 * 
+	 * @param catalog Path to catalog file
+	 * @param name    Name of alias to remove
+	 */
+	public static void removeAlias(Path catalog, String name) {
+		Aliases aliases = getAliasesFromCatalogFile(catalog, true);
+		if (aliases.aliases.containsKey(name)) {
+			aliases.aliases.remove(name);
+			try {
+				writeAliasesToCatalogFile(catalog, aliases);
+			} catch (IOException ex) {
+				Util.warnMsg("Unable to remove alias: " + ex.getMessage());
+			}
+		}
+	}
+
+	/**
 	 * Load a Catalog's aliases given a file path or URL
 	 * 
 	 * @param catalogRef  File path or URL to a Catalog JSON file. If this does not
@@ -241,17 +402,19 @@ public class AliasUtil {
 		Path catalogPath = null;
 		try {
 			catalogPath = Util.obtainFile(catalogRef, updateCache);
-			Aliases aliases = Settings.getAliasesFromCatalog(catalogPath, updateCache);
+			Aliases aliases = getAliasesFromCatalogFile(catalogPath, updateCache);
 			int p = catalogRef.lastIndexOf('/');
 			if (p > 0) {
+				String baseRef = aliases.baseRef;
 				String catalogBaseRef = catalogRef.substring(0, p);
-				if (aliases.baseRef != null) {
-					if (!aliases.baseRef.startsWith("/") && !aliases.baseRef.contains(":")) {
-						aliases.baseRef = catalogBaseRef + "/" + aliases.baseRef;
+				if (baseRef != null) {
+					if (!baseRef.startsWith("/") && !baseRef.contains(":")) {
+						baseRef = catalogBaseRef + "/" + baseRef;
 					}
 				} else {
-					aliases.baseRef = catalogBaseRef;
+					baseRef = catalogBaseRef;
 				}
+				aliases = new Aliases(baseRef, aliases.description, aliases.catalogFile, aliases.aliases);
 			}
 			return aliases;
 		} catch (IOException | JsonParseException ex) {
@@ -260,49 +423,107 @@ public class AliasUtil {
 		}
 	}
 
-	/**
-	 * Returns the given Alias from the given Aliases object. The Alias returned
-	 * from this function is not simply the Alias stored in the Aliases object but
-	 * one that has the Aliases' baseRef (if defined) applied to it.
-	 * 
-	 * @param aliases   An Aliases object
-	 * @param aliasName The name of an Alias
-	 * @return An Alias object
-	 */
-	public static Alias getCatalogAlias(Aliases aliases, String aliasName) {
-		Alias alias = aliases.aliases.get(aliasName);
-		if (alias == null) {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "No alias found with name '" + aliasName + "'");
+	public static Aliases getAllAliasesFromLocalCatalogs(Path cwd) {
+		if (cwd == null) {
+			cwd = getCwd();
 		}
-		if (aliases.baseRef != null && !isAbsoluteRef(alias.scriptRef)) {
-			String ref = aliases.baseRef;
-			if (!ref.endsWith("/")) {
-				ref += "/";
-			}
-			if (alias.scriptRef.startsWith("./")) {
-				ref += alias.scriptRef.substring(2);
-			} else {
-				ref += alias.scriptRef;
-			}
-			alias = new Alias(ref, alias.description, alias.arguments, alias.properties);
-		}
-		// TODO if we have to combine the baseUrl with the scriptRef
-		// we need to make a copy of the Alias with the full URL
-		return alias;
+		Aliases result = new Aliases(null, null, null);
+		result.aliases.putAll(getAliasesFromCatalogFile(Settings.getAliasesFile(), false).aliases);
+		allAliasesFromLocalCatalogs(cwd, result);
+		return result;
 	}
 
-	static Aliases readAliasesFromCatalog(Path catalogPath) {
+	private static void allAliasesFromLocalCatalogs(Path dir, Aliases result) {
+		if (dir.getParent() != null) {
+			allAliasesFromLocalCatalogs(dir.getParent(), result);
+		}
+		Path catalog = dir.resolve(JBANG_DOT_DIR).resolve(JBANG_CATALOG_JSON);
+		if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+			result.aliases.putAll(getAliasesFromCatalogFile(catalog, false).aliases);
+		}
+		catalog = dir.resolve(JBANG_CATALOG_JSON);
+		if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+			result.aliases.putAll(getAliasesFromCatalogFile(catalog, false).aliases);
+		}
+	}
+
+	private static Path findNearestLocalCatalog(Path dir) {
+		if (dir == null) {
+			dir = getCwd();
+		}
+		while (dir != null) {
+			Path catalog = dir.resolve(JBANG_CATALOG_JSON);
+			if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+				return catalog;
+			}
+			catalog = dir.resolve(JBANG_DOT_DIR).resolve(JBANG_CATALOG_JSON);
+			if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+				return catalog;
+			}
+			dir = dir.getParent();
+		}
+		return null;
+	}
+
+	public static Path findNearestLocalCatalogWithAlias(Path dir, String aliasName) {
+		if (dir == null) {
+			dir = getCwd();
+		}
+		while (dir != null) {
+			Path catalog = dir.resolve(JBANG_CATALOG_JSON);
+			if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+				Aliases aliases = getAliasesFromCatalogFile(catalog, false);
+				if (aliases.aliases.containsKey(aliasName)) {
+					return catalog;
+				}
+			}
+			catalog = dir.resolve(JBANG_DOT_DIR).resolve(JBANG_CATALOG_JSON);
+			if (Files.isRegularFile(catalog) && Files.isReadable(catalog)) {
+				Aliases aliases = getAliasesFromCatalogFile(catalog, false);
+				if (aliases.aliases.containsKey(aliasName)) {
+					return catalog;
+				}
+			}
+			dir = dir.getParent();
+		}
+		return null;
+	}
+
+	public static Aliases getAliasesFromCatalogFile(Path catalogPath, boolean updateCache) {
 		Aliases aliases;
-		aliases = new Aliases();
+		if (updateCache || !catalogCache.containsKey(catalogPath)) {
+			aliases = readAliasesFromCatalogFile(catalogPath);
+			aliases.catalogFile = catalogPath;
+			catalogCache.put(catalogPath, aliases);
+		} else {
+			aliases = catalogCache.get(catalogPath);
+		}
+		return aliases;
+	}
+
+	static private Path scriptParent(Path script) {
+		Path parent = script.getParent();
+		if (parent.getFileName().toString().equals(JBANG_DOT_DIR)) {
+			parent = parent.getParent();
+		}
+		return parent;
+	}
+
+	static Aliases readAliasesFromCatalogFile(Path catalogPath) {
+		Aliases aliases = new Aliases(null, null, null);
 		if (Files.isRegularFile(catalogPath)) {
 			try (Reader in = Files.newBufferedReader(catalogPath)) {
 				Gson parser = new Gson();
-				aliases = parser.fromJson(in, Aliases.class);
-				// Validate the result (Gson can't do this)
-				check(aliases.aliases != null, "Missing required attribute 'aliases'");
-				for (String aliasName : aliases.aliases.keySet()) {
-					Alias alias = aliases.aliases.get(aliasName);
-					check(alias.scriptRef != null, "Missing required attribute 'aliases.script-ref'");
+				Aliases as = parser.fromJson(in, Aliases.class);
+				if (as != null) {
+					aliases = as;
+					// Validate the result (Gson can't do this)
+					check(aliases.aliases != null, "Missing required attribute 'aliases'");
+					for (String aliasName : aliases.aliases.keySet()) {
+						Alias alias = aliases.aliases.get(aliasName);
+						alias.aliases = aliases;
+						check(alias.scriptRef != null, "Missing required attribute 'aliases.script-ref'");
+					}
 				}
 			} catch (IOException e) {
 				// Ignore errors
@@ -311,10 +532,10 @@ public class AliasUtil {
 		return aliases;
 	}
 
-	static void writeAliasesToCatalog(Path catalogPath) throws IOException {
+	static void writeAliasesToCatalogFile(Path catalogPath, Aliases aliases) throws IOException {
 		try (Writer out = Files.newBufferedWriter(catalogPath)) {
 			Gson parser = new GsonBuilder().setPrettyPrinting().create();
-			parser.toJson(Settings.getAliasesFromLocalCatalog(), out);
+			parser.toJson(aliases, out);
 		}
 	}
 
@@ -330,11 +551,15 @@ public class AliasUtil {
 			try (Reader in = Files.newBufferedReader(catalogsPath)) {
 				Gson parser = new Gson();
 				info = parser.fromJson(in, CatalogInfo.class);
-				// Validate the result (Gson can't do this)
-				check(info.catalogs != null, "Missing required attribute 'catalogs'");
-				for (String catName : info.catalogs.keySet()) {
-					Catalog cat = info.catalogs.get(catName);
-					check(cat.catalogRef != null, "Missing required attribute 'catalogs.catalogRef'");
+				if (info != null) {
+					// Validate the result (Gson can't do this)
+					check(info.catalogs != null, "Missing required attribute 'catalogs'");
+					for (String catName : info.catalogs.keySet()) {
+						Catalog cat = info.catalogs.get(catName);
+						check(cat.catalogRef != null, "Missing required attribute 'catalogs.catalogRef'");
+					}
+				} else {
+					info = new CatalogInfo();
 				}
 			} catch (IOException e) {
 				info = new CatalogInfo();
@@ -358,9 +583,12 @@ public class AliasUtil {
 
 	@SafeVarargs
 	public static <T> Stream<T> chain(Supplier<Optional<T>>... suppliers) {
-		return Arrays	.asList(suppliers)
-						.stream()
+		return Arrays	.stream(suppliers)
 						.map(Supplier::get)
 						.flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty));
+	}
+
+	private static Path getCwd() {
+		return Paths.get("").toAbsolutePath();
 	}
 }

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -571,6 +571,18 @@ public class AliasUtil {
 		}
 	}
 
+	public static boolean isValidName(String name) {
+		return name.matches("^[a-zA-Z][-\\w]*$");
+	}
+
+	public static boolean isValidCatalogReference(String name) {
+		String[] parts = name.split("@");
+		if (parts.length != 2 || parts[0].isEmpty() || parts[1].isEmpty()) {
+			return false;
+		}
+		return isValidName(parts[0]);
+	}
+
 	private static boolean isAbsoluteRef(String ref) {
 		return ref.startsWith("/") || ref.contains(":");
 	}

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -402,6 +402,7 @@ public class AliasUtil {
 		Path catalogPath = null;
 		try {
 			catalogPath = Util.obtainFile(catalogRef, updateCache);
+			Util.verboseMsg(String.format("Downloaded catalog from %s", catalogRef));
 			Aliases aliases = getAliasesFromCatalogFile(catalogPath, updateCache);
 			int p = catalogRef.lastIndexOf('/');
 			if (p > 0) {
@@ -501,15 +502,8 @@ public class AliasUtil {
 		return aliases;
 	}
 
-	static private Path scriptParent(Path script) {
-		Path parent = script.getParent();
-		if (parent.getFileName().toString().equals(JBANG_DOT_DIR)) {
-			parent = parent.getParent();
-		}
-		return parent;
-	}
-
 	static Aliases readAliasesFromCatalogFile(Path catalogPath) {
+		Util.verboseMsg(String.format("Reading aliases from %s", catalogPath));
 		Aliases aliases = new Aliases(null, null, null);
 		if (Files.isRegularFile(catalogPath)) {
 			try (Reader in = Files.newBufferedReader(catalogPath)) {

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -68,7 +68,7 @@ public class AliasUtil {
 				ref = baseRef;
 			}
 			if (!isAbsoluteRef(ref)) {
-				Path script = scriptParent(aliases.catalogFile).resolve(ref);
+				Path script = aliases.catalogFile.getParent().resolve(ref);
 				if (script.startsWith(cwd) || cwd.startsWith(script)
 						|| !cwd.relativize(script).startsWith("../../..")) {
 					script = cwd.relativize(script);

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -5,6 +5,7 @@ import static dev.jbang.Util.warnMsg;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -187,6 +188,14 @@ public class Settings {
 	}
 
 	public static AliasUtil.Catalog addCatalog(String name, String catalogRef, String description) {
+		try {
+			Path cat = Paths.get(catalogRef);
+			if (!cat.isAbsolute() && Files.isRegularFile(cat)) {
+				catalogRef = cat.toAbsolutePath().toString();
+			}
+		} catch (InvalidPathException ex) {
+			// Ignore
+		}
 		AliasUtil.Catalog catalog = new AliasUtil.Catalog(catalogRef, description);
 		getCatalogs().put(name, catalog);
 		try {

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -17,7 +17,6 @@ import com.google.gson.reflect.TypeToken;
 import io.quarkus.qute.Template;
 
 public class Settings {
-	static Map<Path, AliasUtil.Aliases> catalogCache = new HashMap<>();
 	static AliasUtil.CatalogInfo catalogInfo = null;
 
 	public static final String JBANG_REPO = "JBANG_REPO";
@@ -170,46 +169,6 @@ public class Settings {
 
 	public static Path getAliasesFile() {
 		return getConfigDir().resolve(AliasUtil.JBANG_CATALOG_JSON);
-	}
-
-	public static AliasUtil.Aliases getAliasesFromCatalog(Path catalogPath, boolean updateCache) {
-		AliasUtil.Aliases aliases;
-		if (updateCache || !catalogCache.containsKey(catalogPath)) {
-			aliases = AliasUtil.readAliasesFromCatalog(catalogPath);
-			catalogCache.put(catalogPath, aliases);
-		} else {
-			aliases = catalogCache.get(catalogPath);
-		}
-		return aliases;
-	}
-
-	public static AliasUtil.Aliases getAliasesFromLocalCatalog() {
-		return getAliasesFromCatalog(getAliasesFile(), false);
-	}
-
-	public static Map<String, AliasUtil.Alias> getAliases() {
-		return getAliasesFromLocalCatalog().aliases;
-	}
-
-	public static void addAlias(String name, String scriptRef, String description, List<String> arguments,
-			Map<String, String> properties) {
-		getAliases().put(name, new AliasUtil.Alias(scriptRef, description, arguments, properties));
-		try {
-			AliasUtil.writeAliasesToCatalog(getAliasesFile());
-		} catch (IOException ex) {
-			Util.warnMsg("Unable to add alias: " + ex.getMessage());
-		}
-	}
-
-	public static void removeAlias(String name) {
-		if (getAliases().containsKey(name)) {
-			getAliases().remove(name);
-			try {
-				AliasUtil.writeAliasesToCatalog(getAliasesFile());
-			} catch (IOException ex) {
-				Util.warnMsg("Unable to remove alias: " + ex.getMessage());
-			}
-		}
 	}
 
 	public static Path getCatalogsFile() {

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -60,7 +60,7 @@ class AliasAdd extends BaseAliasCommand {
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 		}
 		if (getCatalog() != null) {
-			AliasUtil.addAlias(getCatalog(), name, scriptOrFile, description, userParams, properties);
+			AliasUtil.addAlias(null, getCatalog(), name, scriptOrFile, description, userParams, properties);
 		} else {
 			AliasUtil.addNearestAlias(null, name, scriptOrFile, description, userParams, properties);
 		}

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -54,7 +54,7 @@ class AliasAdd extends BaseAliasCommand {
 
 	@Override
 	public Integer doCall() {
-		if (!name.matches("^[a-zA-Z][-\\w]*$")) {
+		if (!AliasUtil.isValidName(name)) {
 			throw new IllegalArgumentException(
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 		}
@@ -97,13 +97,9 @@ class AliasList extends BaseAliasCommand {
 							AliasUtil.Alias alias = aliases.aliases.get(name);
 							String fullName = catalogName != null ? name + "@" + catalogName : name;
 							String scriptRef = alias.scriptRef;
-							try {
-								AliasUtil.Alias merged = AliasUtil.getAlias(null, name);
-								if (alias.scriptRef.equals(merged.scriptRef)) {
-									scriptRef = alias.resolve(null);
-								}
-							} catch (Exception ex) {
-								// Ignore
+							if (!aliases.aliases.containsKey(scriptRef)
+									&& !AliasUtil.isValidCatalogReference(scriptRef)) {
+								scriptRef = alias.resolve(null);
 							}
 							if (alias.description != null) {
 								out.println(fullName + " = " + alias.description);

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -1,6 +1,7 @@
 package dev.jbang.cli;
 
 import java.io.PrintWriter;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -10,35 +11,81 @@ import dev.jbang.Util;
 
 import picocli.CommandLine;
 
-@CommandLine.Command(name = "alias", description = "Manage aliases for scripts.")
+@CommandLine.Command(name = "alias", description = "Manage aliases for scripts.", subcommands = { AliasAdd.class,
+		AliasList.class, AliasRemove.class })
 public class Alias {
+}
 
-	@CommandLine.Spec
-	CommandLine.Model.CommandSpec spec;
+abstract class BaseAliasCommand extends BaseCommand {
 
-	@CommandLine.Command(name = "add", description = "Add alias for script reference.")
-	public Integer add(
-			@CommandLine.Option(names = { "--description",
-					"-d" }, description = "A description for the alias") String description,
-			@CommandLine.Option(names = { "-D" }, description = "set a system property") Map<String, String> properties,
-			@CommandLine.Parameters(paramLabel = "name", index = "0", description = "A name for the alias", arity = "1") String name,
-			@CommandLine.Parameters(paramLabel = "scriptOrFile", index = "1", description = "A file or URL to a Java code file", arity = "1") String scriptOrFile,
-			@CommandLine.Parameters(paramLabel = "params", index = "2..*", arity = "0..*", description = "Parameters to pass on to the script") List<String> userParams) {
+	@CommandLine.Option(names = { "--global", "-g" }, description = "Use the global (user) catalog file")
+	boolean global;
+
+	@CommandLine.Option(names = { "--file", "-f" }, description = "Path to the catalog file to use")
+	Path catalogFile;
+
+	protected Path getCatalog() {
+		if (global) {
+			return Settings.getAliasesFile();
+		} else {
+			return catalogFile;
+		}
+	}
+}
+
+@CommandLine.Command(name = "add", description = "Add alias for script reference.")
+class AliasAdd extends BaseAliasCommand {
+
+	@CommandLine.Option(names = { "--description",
+			"-d" }, description = "A description for the alias")
+	String description;
+
+	@CommandLine.Option(names = { "-D" }, description = "set a system property")
+	Map<String, String> properties;
+
+	@CommandLine.Parameters(paramLabel = "name", index = "0", description = "A name for the alias", arity = "1")
+	String name;
+
+	@CommandLine.Parameters(paramLabel = "scriptOrFile", index = "1", description = "A file or URL to a Java code file", arity = "1")
+	String scriptOrFile;
+
+	@CommandLine.Parameters(paramLabel = "params", index = "2..*", arity = "0..*", description = "Parameters to pass on to the script")
+	List<String> userParams;
+
+	@Override
+	public Integer doCall() {
 		if (!name.matches("^[a-zA-Z][-\\w]*$")) {
 			throw new IllegalArgumentException(
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 		}
-		Settings.addAlias(name, scriptOrFile, description, userParams, properties);
-		return CommandLine.ExitCode.SOFTWARE;
+		if (getCatalog() != null) {
+			AliasUtil.addAlias(getCatalog(), name, scriptOrFile, description, userParams, properties);
+		} else {
+			AliasUtil.addNearestAlias(null, name, scriptOrFile, description, userParams, properties);
+		}
+		return CommandLine.ExitCode.OK;
 	}
+}
 
-	@CommandLine.Command(name = "list", description = "Lists locally defined aliases or from the given catalog.")
-	public Integer list(
-			@CommandLine.Parameters(paramLabel = "catalogName", index = "0", description = "The name of a catalog", arity = "0..1") String catalogName) {
+@CommandLine.Command(name = "list", description = "Lists locally defined aliases or from the given catalog.")
+class AliasList extends BaseAliasCommand {
+
+	@CommandLine.Parameters(paramLabel = "catalogName", index = "0", description = "The name of a catalog", arity = "0..1")
+	String catalogName;
+
+	@Override
+	public Integer doCall() {
 		PrintWriter out = spec.commandLine().getOut();
-		AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(catalogName, false);
+		AliasUtil.Aliases aliases;
+		if (catalogName != null) {
+			aliases = AliasUtil.getCatalogAliasesByName(catalogName, false);
+		} else if (getCatalog() != null) {
+			aliases = AliasUtil.getAliasesFromCatalogFile(getCatalog(), false);
+		} else {
+			aliases = AliasUtil.getAllAliasesFromLocalCatalogs(null);
+		}
 		printAliases(out, catalogName, aliases);
-		return CommandLine.ExitCode.SOFTWARE;
+		return CommandLine.ExitCode.OK;
 	}
 
 	static void printAliases(PrintWriter out, String catalogName, AliasUtil.Aliases aliases) {
@@ -47,31 +94,50 @@ public class Alias {
 						.stream()
 						.sorted()
 						.forEach(name -> {
-							AliasUtil.Alias ai = AliasUtil.getCatalogAlias(aliases, name);
+							AliasUtil.Alias alias = aliases.aliases.get(name);
 							String fullName = catalogName != null ? name + "@" + catalogName : name;
-							if (ai.description != null) {
-								out.println(fullName + " = " + ai.description);
-								if (Util.isVerbose())
-									out.println(Util.repeat(" ", fullName.length()) + "   (" + ai.scriptRef + ")");
-							} else {
-								out.println(fullName + " = " + ai.scriptRef);
+							String scriptRef = alias.scriptRef;
+							try {
+								AliasUtil.Alias merged = AliasUtil.getAlias(null, name);
+								if (alias.scriptRef.equals(merged.scriptRef)) {
+									scriptRef = alias.resolve(null);
+								}
+							} catch (Exception ex) {
+								// Ignore
 							}
-							if (ai.arguments != null) {
+							if (alias.description != null) {
+								out.println(fullName + " = " + alias.description);
+								if (Util.isVerbose())
+									out.println(Util.repeat(" ", fullName.length()) + "   (" + scriptRef + ")");
+							} else {
+								out.println(fullName + " = " + scriptRef);
+							}
+							if (alias.arguments != null) {
 								out.println(
 										Util.repeat(" ", fullName.length()) + "   Arguments: "
-												+ String.join(" ", ai.arguments));
+												+ String.join(" ", alias.arguments));
 							}
-							if (ai.properties != null) {
+							if (alias.properties != null) {
 								out.println(
-										Util.repeat(" ", fullName.length()) + "   Properties: " + ai.properties);
+										Util.repeat(" ", fullName.length()) + "   Properties: " + alias.properties);
 							}
 						});
 	}
+}
 
-	@CommandLine.Command(name = "remove", description = "Remove existing alias.")
-	public Integer remove(
-			@CommandLine.Parameters(paramLabel = "name", index = "0", description = "The name of the alias", arity = "1") String name) {
-		Settings.removeAlias(name);
-		return CommandLine.ExitCode.SOFTWARE;
+@CommandLine.Command(name = "remove", description = "Remove existing alias.")
+class AliasRemove extends BaseAliasCommand {
+
+	@CommandLine.Parameters(paramLabel = "name", index = "0", description = "The name of the alias", arity = "1")
+	String name;
+
+	@Override
+	public Integer doCall() {
+		if (getCatalog() != null) {
+			AliasUtil.removeAlias(getCatalog(), name);
+		} else {
+			AliasUtil.removeNearestAlias(null, name);
+		}
+		return CommandLine.ExitCode.OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -99,9 +99,9 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		File scriptFile = getScriptFile(scriptResource);
 		if (scriptFile == null) {
 			// Not found as such, so let's check the aliases
-			AliasUtil.Alias alias = AliasUtil.getAlias(scriptResource, arguments, properties);
+			AliasUtil.Alias alias = AliasUtil.getAlias(null, scriptResource, arguments, properties);
 			if (alias != null) {
-				scriptFile = getScriptFile(alias.scriptRef);
+				scriptFile = getScriptFile(alias.resolve(null));
 				arguments = alias.arguments;
 				properties = alias.properties;
 			}

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -104,6 +104,11 @@ public abstract class BaseScriptCommand extends BaseCommand {
 				scriptFile = getScriptFile(alias.resolve(null));
 				arguments = alias.arguments;
 				properties = alias.properties;
+				if (scriptFile == null) {
+					throw new IllegalArgumentException(
+							"Alias " + scriptResource + " from " + alias.aliases.catalogFile + " failed to resolve "
+									+ alias.scriptRef);
+				}
 			}
 		}
 

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -70,7 +70,7 @@ public class Catalog {
 					});
 		} else {
 			AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(name, false);
-			Alias.printAliases(out, name, aliases);
+			AliasList.printAliases(out, name, aliases);
 		}
 		return CommandLine.ExitCode.SOFTWARE;
 	}

--- a/src/test/java/dev/jbang/TestUtil.java
+++ b/src/test/java/dev/jbang/TestUtil.java
@@ -2,7 +2,7 @@ package dev.jbang;
 
 public class TestUtil {
 	public static void clearSettingsCaches() {
-		Settings.catalogCache.clear();
+		AliasUtil.catalogCache.clear();
 		Settings.catalogInfo = null;
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 import org.junit.Assert;
@@ -16,9 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.rules.TemporaryFolder;
 
 import dev.jbang.AliasUtil;
-import dev.jbang.Settings;
-
-import picocli.CommandLine;
 
 public class TestAlias {
 
@@ -60,8 +58,10 @@ public class TestAlias {
 	@BeforeEach
 	void init() throws IOException {
 		jbangTempDir.create();
+		testTempDir.create();
 		environmentVariables.set("JBANG_DIR", jbangTempDir.getRoot().getPath());
 		Files.write(jbangTempDir.getRoot().toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), aliases.getBytes());
+		cwd = testTempDir.newFolder("test").toPath();
 	}
 
 	@Rule
@@ -70,40 +70,26 @@ public class TestAlias {
 	@Rule
 	public final TemporaryFolder jbangTempDir = new TemporaryFolder();
 
+	@Rule
+	public final TemporaryFolder testTempDir = new TemporaryFolder();
+
+	private Path cwd;
+
 	@Test
 	void testReadFromFile() throws IOException {
 		clearSettingsCaches();
-		assertThat(Settings.getAliases().get("one"), notNullValue());
-	}
-
-	@Test
-	void testAdd() throws IOException {
-		Jbang jbang = new Jbang();
-		new CommandLine(jbang).execute("alias", "add", "new", "http://dummy");
-		clearSettingsCaches();
-		assertThat(Settings.getAliases().get("new").scriptRef, equalTo("http://dummy"));
-	}
-
-	@Test
-	void testRemove() throws IOException {
-		clearSettingsCaches();
-		System.err.println(Settings.getAliases().toString());
-		assertThat(Settings.getAliases().get("two"), notNullValue());
-		Jbang jbang = new Jbang();
-		new CommandLine(jbang).execute("alias", "remove", "two");
-		clearSettingsCaches();
-		assertThat(Settings.getAliases().get("two"), nullValue());
+		assertThat(AliasUtil.getAlias(cwd, "one"), notNullValue());
 	}
 
 	@Test
 	void testGetAliasNone() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("dummy-alias!", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "dummy-alias!", null, null);
 		assertThat(alias, nullValue());
 	}
 
 	@Test
 	void testGetAliasOne() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("one", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "one", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, nullValue());
@@ -112,7 +98,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasOneWithArgs() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("one", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "one", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -124,7 +110,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasTwo() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("two", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "two", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -135,7 +121,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasTwoAlt() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("two", Collections.emptyList(), Collections.emptyMap());
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "two", Collections.emptyList(), Collections.emptyMap());
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -146,7 +132,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasTwoWithArgs() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("two", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "two", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -158,7 +144,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFour() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("four", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "four", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -169,7 +155,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFourWithArgs() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("four", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "four", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -181,7 +167,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFive() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("five", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "five", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.arguments, iterableWithSize(1));
@@ -192,7 +178,7 @@ public class TestAlias {
 
 	@Test
 	void testGetAliasFiveWithArgs() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("five", Collections.singletonList("X"),
+		AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "five", Collections.singletonList("X"),
 				Collections.singletonMap("foo", "bar"));
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
@@ -205,7 +191,7 @@ public class TestAlias {
 	@Test
 	void testGetAliasLoop() throws IOException {
 		try {
-			AliasUtil.Alias alias = AliasUtil.getAlias("eight", null, null);
+			AliasUtil.Alias alias = AliasUtil.getAlias(cwd, "eight", null, null);
 			Assert.fail();
 		} catch (RuntimeException ex) {
 			assertThat(ex.getMessage(), containsString("seven"));

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -171,6 +171,16 @@ public class TestAliasNearest {
 	}
 
 	@Test
+	void testAddLocalExplicit() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.addAlias(cwd, Paths.get(AliasUtil.JBANG_CATALOG_JSON), "new", "dummy.java", null, null, null);
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+		assertThat(aliases.aliases.get("new").scriptRef, equalTo("dummy.java"));
+	}
+
+	@Test
 	void testAddDotLocalUrl() throws IOException {
 		testAddDotLocal("http://dummy", "http://dummy");
 	}

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -1,0 +1,241 @@
+package dev.jbang.cli;
+
+import static dev.jbang.TestUtil.clearSettingsCaches;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+
+import dev.jbang.AliasUtil;
+import dev.jbang.Settings;
+
+public class TestAliasNearest {
+
+	static final String global = "{\n" +
+			"  \"aliases\": {\n" +
+			"    \"global1\": {\n" +
+			"      \"script-ref\": \"global1ref\"\n" +
+			"    },\n" +
+			"    \"global2\": {\n" +
+			"      \"script-ref\": \"global2ref\"\n" +
+			"    },\n" +
+			"    \"global3\": {\n" +
+			"      \"script-ref\": \"global3ref\"\n" +
+			"    },\n" +
+			"    \"global4\": {\n" +
+			"      \"script-ref\": \"global4ref\"\n" +
+			"    }\n" +
+			"  }\n" +
+			"}";
+
+	static final String parent = "{\n" +
+			"  \"aliases\": {\n" +
+			"    \"parent1\": {\n" +
+			"      \"script-ref\": \"parent1ref\"\n" +
+			"    },\n" +
+			"    \"parent2\": {\n" +
+			"      \"script-ref\": \"parent2ref\"\n" +
+			"    },\n" +
+			"    \"parent3\": {\n" +
+			"      \"script-ref\": \"parent3ref\"\n" +
+			"    },\n" +
+			"    \"global2\": {\n" +
+			"      \"script-ref\": \"global2inparent\"\n" +
+			"    }\n" +
+			"  }\n" +
+			"}";
+
+	static final String dotlocal = "{\n" +
+			"  \"aliases\": {\n" +
+			"    \"dotlocal1\": {\n" +
+			"      \"script-ref\": \"dotlocal1ref\"\n" +
+			"    },\n" +
+			"    \"dotlocal2\": {\n" +
+			"      \"script-ref\": \"dotlocal2ref\"\n" +
+			"    },\n" +
+			"    \"parent2\": {\n" +
+			"      \"script-ref\": \"parent2indotlocal\"\n" +
+			"    },\n" +
+			"    \"global3\": {\n" +
+			"      \"script-ref\": \"global3indotlocal\"\n" +
+			"    }\n" +
+			"  }\n" +
+			"}";
+
+	static final String local = "{\n" +
+			"  \"aliases\": {\n" +
+			"    \"local1\": {\n" +
+			"      \"script-ref\": \"local1ref\"\n" +
+			"    },\n" +
+			"    \"dotlocal2\": {\n" +
+			"      \"script-ref\": \"dotlocal2inlocal\"\n" +
+			"    },\n" +
+			"    \"parent3\": {\n" +
+			"      \"script-ref\": \"parent3inlocal\"\n" +
+			"    },\n" +
+			"    \"global4\": {\n" +
+			"      \"script-ref\": \"global4inlocal\"\n" +
+			"    }\n" +
+			"  }\n" +
+			"}";
+
+	@BeforeEach
+	void init() throws IOException {
+		jbangTempDir.create();
+		testTempDir.create();
+		environmentVariables.set("JBANG_DIR", jbangTempDir.getRoot().getPath());
+		Files.write(jbangTempDir.getRoot().toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), global.getBytes());
+		File parentDotDir = testTempDir.newFolder(".jbang");
+		Files.write(parentDotDir.toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), parent.getBytes());
+		cwd = testTempDir.newFolder("test").toPath();
+		File testDotDir = testTempDir.newFolder("test", ".jbang");
+		Files.write(testDotDir.toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), dotlocal.getBytes());
+		Files.write(cwd.resolve(AliasUtil.JBANG_CATALOG_JSON), local.getBytes());
+	}
+
+	@Rule
+	public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+	@Rule
+	public final TemporaryFolder jbangTempDir = new TemporaryFolder();
+
+	@Rule
+	public final TemporaryFolder testTempDir = new TemporaryFolder();
+
+	private Path cwd;
+
+	@Test
+	void testList() throws IOException {
+		AliasUtil.Aliases aliases = AliasUtil.getAllAliasesFromLocalCatalogs(cwd);
+		assertThat(aliases, notNullValue());
+
+		HashSet<String> keys = new HashSet<String>(Arrays.asList(
+				"global1",
+				"global2",
+				"global3",
+				"global4",
+				"parent1",
+				"parent2",
+				"parent3",
+				"dotlocal1",
+				"dotlocal2",
+				"local1"));
+		assertThat(aliases.aliases.keySet(), equalTo(keys));
+
+		assertThat(aliases.aliases.get("global1").scriptRef, is("global1ref"));
+		assertThat(aliases.aliases.get("global2").scriptRef, is("global2inparent"));
+		assertThat(aliases.aliases.get("global3").scriptRef, is("global3indotlocal"));
+		assertThat(aliases.aliases.get("global4").scriptRef, is("global4inlocal"));
+
+		assertThat(aliases.aliases.get("parent1").scriptRef, is("parent1ref"));
+		assertThat(aliases.aliases.get("parent2").scriptRef, is("parent2indotlocal"));
+		assertThat(aliases.aliases.get("parent3").scriptRef, is("parent3inlocal"));
+
+		assertThat(aliases.aliases.get("dotlocal1").scriptRef, is("dotlocal1ref"));
+		assertThat(aliases.aliases.get("dotlocal2").scriptRef, is("dotlocal2inlocal"));
+
+		assertThat(aliases.aliases.get("local1").scriptRef, is("local1ref"));
+	}
+
+	@Test
+	void testAddLocal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.addNearestAlias(cwd, "new", "http://dummy", null, null, null);
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+	}
+
+	@Test
+	void testAddDotLocal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "http://dummy", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+	}
+
+	@Test
+	void testAddParent() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		Files.delete(dotLocalCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "http://dummy", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+	}
+
+	@Test
+	void testAddGlobal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		Files.delete(dotLocalCatalog);
+		Files.delete(parentCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "http://dummy", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
+		assertThat(parentCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(Settings.getAliasesFile(), true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+	}
+
+	@Test
+	void testRemoveLocal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.removeNearestAlias(cwd, "local1");
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
+		assertThat(aliases.aliases.keySet(), not(hasItem("local1")));
+	}
+
+	@Test
+	void testRemoveDotLocal() throws IOException {
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.removeNearestAlias(cwd, "dotlocal1");
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
+		assertThat(aliases.aliases.keySet(), not(hasItem("dotlocal1")));
+	}
+
+	@Test
+	void testRemoveParent() throws IOException {
+		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.removeNearestAlias(cwd, "parent1");
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
+		assertThat(aliases.aliases.keySet(), not(hasItem("parent1")));
+	}
+
+	@Test
+	void testRemoveGlobal() throws IOException {
+		Path globalCatalog = Settings.getAliasesFile();
+		AliasUtil.removeNearestAlias(cwd, "global1");
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(globalCatalog, true);
+		assertThat(aliases.aliases.keySet(), not(hasItem("global1")));
+	}
+
+}

--- a/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
@@ -1,0 +1,131 @@
+package dev.jbang.cli;
+
+import static dev.jbang.TestUtil.clearSettingsCaches;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+
+import dev.jbang.AliasUtil;
+
+public class TestAliasNearestWithBaseRef {
+
+	static final String global = "{\n" +
+			"  \"aliases\": {\n" +
+			"  }\n" +
+			"}";
+
+	static final String parent = "{\n" +
+			"  \"base-ref\": \"../scripts\",\n" +
+			"  \"aliases\": {\n" +
+			"  }\n" +
+			"}";
+
+	static final String dotlocal = "{\n" +
+			"  \"base-ref\": \"../scripts\",\n" +
+			"  \"aliases\": {\n" +
+			"  }\n" +
+			"}";
+
+	static final String local = "{\n" +
+			"  \"base-ref\": \"scripts\",\n" +
+			"  \"aliases\": {\n" +
+			"  }\n" +
+			"}";
+
+	@BeforeEach
+	void init() throws IOException {
+		jbangTempDir.create();
+		testTempDir.create();
+		environmentVariables.set("JBANG_DIR", jbangTempDir.getRoot().getPath());
+		Files.write(jbangTempDir.getRoot().toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), global.getBytes());
+		File parentDotDir = testTempDir.newFolder(".jbang");
+		Files.write(parentDotDir.toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), parent.getBytes());
+		File parentScriptsDir = testTempDir.newFolder("scripts");
+		Files.write(parentScriptsDir.toPath().resolve("parent.java"), "// Dummy Java File".getBytes());
+		cwd = testTempDir.newFolder("test").toPath();
+		File testDotDir = testTempDir.newFolder("test", ".jbang");
+		Files.write(testDotDir.toPath().resolve(AliasUtil.JBANG_CATALOG_JSON), dotlocal.getBytes());
+		Files.write(cwd.resolve(AliasUtil.JBANG_CATALOG_JSON), local.getBytes());
+		Files.write(cwd.resolve("dummy.java"), "// Dummy Java File".getBytes());
+		File localScriptsDir = testTempDir.newFolder("test", "scripts");
+		Files.write(localScriptsDir.toPath().resolve("local.java"), "// Dummy Java File".getBytes());
+	}
+
+	@Rule
+	public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+	@Rule
+	public final TemporaryFolder jbangTempDir = new TemporaryFolder();
+
+	@Rule
+	public final TemporaryFolder testTempDir = new TemporaryFolder();
+
+	private Path cwd;
+
+	@Test
+	void testAddLocal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		AliasUtil.addNearestAlias(cwd, "new", "scripts/local.java", null, null, null);
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+		assertThat(aliases.aliases.get("new").scriptRef, equalTo("local.java"));
+	}
+
+	@Test
+	void testAddDotLocal() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "scripts/local.java", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+		assertThat(aliases.aliases.get("new").scriptRef, equalTo("local.java"));
+	}
+
+	@Test
+	void testAddParent1() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		Files.delete(dotLocalCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "scripts/local.java", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+		assertThat(aliases.aliases.get("new").scriptRef.replace('\\', '/'), equalTo("../test/scripts/local.java"));
+	}
+
+	@Test
+	void testAddParent2() throws IOException {
+		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+		Files.delete(localCatalog);
+		Files.delete(dotLocalCatalog);
+		AliasUtil.addNearestAlias(cwd, "new", "../scripts/parent.java", null, null, null);
+		assertThat(localCatalog.toFile(), not(anExistingFile()));
+		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
+		clearSettingsCaches();
+		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
+		assertThat(aliases.aliases.keySet(), hasItem("new"));
+		assertThat(aliases.aliases.get("new").scriptRef, equalTo("parent.java"));
+	}
+
+}

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -85,7 +85,7 @@ public class TestCatalog {
 
 	@Test
 	void testGetAlias() throws IOException {
-		AliasUtil.Alias alias = AliasUtil.getAlias("one@test", null, null);
+		AliasUtil.Alias alias = AliasUtil.getAlias(null, "one@test", null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 	}


### PR DESCRIPTION
See #180

Jbang will now look for unqualified aliases in the following order:

1. `./jbang-catalog.json` (non-hidden file!)
2. `./.jbang/jbang-catalog.json` (hidden folder!)
3. The same for any parent folder, recursively upwards
4. And finally `$HOME/.jbang/jbang-catalog.json`

Any relative paths used in those catalog files will be relative to the "base folder", so for (1) it would be `.`, but for (2) as well! The same for any parent folders. And for (4) it would be `$HOME`.