### PR TITLE
feat: Initial support for multiple sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ jbang-action
 out
 node_modules
 package-lock.json
+*.jfr

--- a/examples/NanoClock.java
+++ b/examples/NanoClock.java
@@ -1,0 +1,52 @@
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+public class NanoClock extends Clock
+{
+    private final Clock clock;
+
+    private final long initialNanos;
+
+    private final Instant initialInstant;
+
+    public NanoClock()
+    {
+        this(Clock.systemUTC());
+    }
+
+    public NanoClock(final Clock clock)
+    {
+        this.clock = clock;
+        initialInstant = clock.instant();
+        initialNanos = getSystemNanos();
+    }
+
+    @Override
+    public ZoneId getZone()
+    {
+        return clock.getZone();
+    }
+
+    @Override
+    public Instant instant()
+    {
+        return initialInstant.plusNanos(getSystemNanos() - initialNanos);
+    }
+
+    @Override
+    public Clock withZone(final ZoneId zone)
+    {
+        return new NanoClock(clock.withZone(zone));
+    }
+
+    private long getSystemNanos()
+    {
+        return System.nanoTime();
+    }
+}

--- a/examples/inetTest.java
+++ b/examples/inetTest.java
@@ -1,10 +1,10 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
+//SOURCES NanoClock.java
 
 // This example tests the time taken in ms to resolve localhostname.
 // Original idea: https://github.com/thoeni/inetTester
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -22,48 +22,5 @@ public class inetTest {
         System.out.printf("hostname %s, elapsed time: %d (ms)%n", hostName, TimeUnit.NANOSECONDS.toMillis(Duration.between(startTime, endTime).toNanos()));
     }
 
-    static class NanoClock extends Clock
-    {
-        private final Clock clock;
-
-        private final long initialNanos;
-
-        private final Instant initialInstant;
-
-        public NanoClock()
-        {
-            this(Clock.systemUTC());
-        }
-
-        public NanoClock(final Clock clock)
-        {
-            this.clock = clock;
-            initialInstant = clock.instant();
-            initialNanos = getSystemNanos();
-        }
-
-        @Override
-        public ZoneId getZone()
-        {
-            return clock.getZone();
-        }
-
-        @Override
-        public Instant instant()
-        {
-            return initialInstant.plusNanos(getSystemNanos() - initialNanos);
-        }
-
-        @Override
-        public Clock withZone(final ZoneId zone)
-        {
-            return new NanoClock(clock.withZone(zone));
-        }
-
-        private long getSystemNanos()
-        {
-            return System.nanoTime();
-        }
-    }
 
 }

--- a/itests/Two.java
+++ b/itests/Two.java
@@ -1,0 +1,11 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+// //DEPS <dependency1> <dependency2>
+
+import static java.lang.System.*;
+
+public class Two {
+
+    public static void main(String... args) {
+        out.println("Hello World");
+    }
+}

--- a/itests/one.java
+++ b/itests/one.java
@@ -1,0 +1,12 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+// //DEPS <dependency1> <dependency2>
+//SOURCES Two.java
+
+import static java.lang.System.*;
+
+public class one {
+
+    public static void main(String... args) {
+        out.println(Two.class.getName());
+    }
+}

--- a/itests/run.feature
+++ b/itests/run.feature
@@ -15,3 +15,7 @@ Scenario: java launch helloworld with jfr
   Then match out contains "Started recording 1. No limit specified, using maxsize=250MB as default."
 
 
+Scenario: java run multiple sources
+  When command('jbang --verbose one.java')
+  Then match out contains "Two"
+

--- a/readme.adoc
+++ b/readme.adoc
@@ -646,6 +646,14 @@ it will if you `java` command supports Java modules automatically set the necess
 
 See `link:examples/jfx.java[]` and `link:examples/jfxtiles.java[]` for examples of this.
 
+== Multiple source files (Experimental)
+
+Since version 0.46 there is now initial support for having multiple source files. The main script file defines all the dependencies and you add more source files into the application using `//SOURCES <filename>`.
+
+The listed file name(s) gets added to source list when compiling.
+
+Currently there are not `*.java` style matching or support for these `.java` files to declare `//DEPS` or other jbang configuration. That will currently only be honored by the main script/app. These will be loosen up in future based on feedaback.
+
 == Adding additional resources (Experimental)
 
 If you want to add a `META-INF/application.properties` or `META-INF/resource.index.html` or other files to the generated jar

--- a/src/main/java/dev/jbang/FileRef.java
+++ b/src/main/java/dev/jbang/FileRef.java
@@ -68,4 +68,12 @@ public class FileRef {
 			throw new ExitException(CommandLine.ExitCode.USAGE, "Could not copy " + from + " to " + to, ioe);
 		}
 	}
+
+	public String getRef() {
+		return ref;
+	}
+
+	public String getDestination() {
+		return destination;
+	}
 }

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -28,6 +28,7 @@ public class Script {
 	public static final String JBANG_JAVA_OPTIONS = "JBang-Java-Options";
 	private static final String DEPS_COMMENT_PREFIX = "//DEPS ";
 	private static final String FILES_COMMENT_PREFIX = "//FILES ";
+	private static final String SOURCES_COMMENT_PREFIX = "//SOURCES ";
 
 	private static final String DEPS_ANNOT_PREFIX = "@Grab(";
 	private static final Pattern DEPS_ANNOT_PAIRS = Pattern.compile("(?<key>\\w+)\\s*=\\s*\"(?<value>.*?)\"");
@@ -69,6 +70,8 @@ public class Script {
 	private List<MavenRepo> repositories;
 	private List<FileRef> filerefs;
 	private List<String> persistentJvmArgs;
+	private List<String> jvmArgs;
+	private List<FileRef> sources;
 
 	public Script(File backingFile, String content, List<String> arguments, Map<String, String> properties)
 			throws FileNotFoundException {
@@ -478,6 +481,19 @@ public class Script {
 									.collect(Collectors.toCollection(ArrayList::new));
 		}
 		return filerefs;
+	}
+
+	public List<FileRef> collectSources() {
+
+		if (sources == null) {
+			sources = getLines().stream()
+								.filter(f -> f.startsWith(SOURCES_COMMENT_PREFIX))
+								.flatMap(line -> Arrays.stream(line.split("[ ;,]+")).skip(1).map(String::trim))
+								.map(PropertiesValueResolver::replaceProperties)
+								.map(line -> toFileRef(this, line))
+								.collect(Collectors.toCollection(ArrayList::new));
+		}
+		return sources;
 	}
 
 }

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -95,7 +95,14 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 				optionList.addAll(Arrays.asList("-classpath", path));
 			}
 			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
+
+			// add source files to compile
 			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
+			optionList.addAll(
+					script	.collectSources()
+							.stream()
+							.map(x -> x.getDestination())
+							.collect(Collectors.toList()));
 
 			// add additional files
 			List<FileRef> files = script.collectFiles();

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -132,6 +132,17 @@ public class Edit extends BaseScriptCommand {
 			createHardLink(srcFile.toPath(), originalFile.getAbsoluteFile().toPath());
 		}
 
+		for (FileRef source : script.collectSources()) {
+			File sfile = new File(srcDir, source.getDestination());
+			Path destFile = new File(originalFile.getAbsoluteFile().getParent(),
+					source.getDestination()).getAbsoluteFile()
+											.toPath();
+
+			if (!sfile.exists() && !createSymbolicLink(sfile.toPath(), destFile)) {
+				createHardLink(sfile.toPath(), destFile);
+			}
+		}
+
 		// create build gradle
 		String baseName = Util.getBaseName(name);
 		String templateName = "build.qute.gradle";


### PR DESCRIPTION
Thie lets you use `//SOURCES <path>` with some restrictions:

1) the reference sources are not processed for //DEPS or any other jbang support (will come)
2) jbang edit does not undestand it yet.
3) No **/* matching. Thus each file must be explicit and relative to the file that refer to them.
