### PR TITLE
fix: made downloading more robust

### DIFF
--- a/src/main/java/dev/jbang/JdkManager.java
+++ b/src/main/java/dev/jbang/JdkManager.java
@@ -63,6 +63,13 @@ public class JdkManager {
 			return jdkDir;
 		} catch (Exception e) {
 			Util.deleteFolder(jdkTmpDir, true);
+			if (!Files.isDirectory(jdkDir) && Files.isDirectory(jdkOldDir)) {
+				try {
+					Files.move(jdkOldDir, jdkDir);
+				} catch (IOException ex) {
+					// Ignore
+				}
+			}
 			Util.errorMsg("Required Java version not possible to download or install. You can run with '--java "
 					+ JavaUtil.determineJavaVersion() + "' to force using the default installed Java.");
 			throw new ExitException(CommandLine.ExitCode.SOFTWARE,

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -284,7 +284,6 @@ public abstract class BaseScriptCommand extends BaseCommand {
 
 			String urlHash = Util.getStableID(scriptURL);
 			File urlCache = Settings.getCacheDir(Settings.CacheClass.urls).resolve(urlHash).toFile();
-			urlCache.mkdirs();
 			Path path = Util.downloadFileSwizzled(scriptURL, urlCache);
 
 			return path.toFile();


### PR DESCRIPTION
`JdkManager.downloadAndInstall()` now restores better after an error.
`Util.downloadFile()` is now equally robust as the JDK downloader.

I noticed that interrupting a download could leave the cache in an unusable state unless first cleaned.
The JDK downloader was already very careful about first downloading to a temp location and only committing when the download finished correctly, but now the file downloader does this as well.