### PR TITLE
fix: `jdk uninstall` now firsts checks if JDK exists

### DIFF
--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -39,7 +39,11 @@ public class Jdk {
 	public Integer remove(
 			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version to install", arity = "1") int version)
 			throws IOException {
-		JdkManager.uninstallJdk(version);
+		if (JdkManager.isInstalledJdk(version)) {
+			JdkManager.uninstallJdk(version);
+		} else {
+			Util.infoMsg("JDK " + version + " is not installed");
+		}
 		return CommandLine.ExitCode.SOFTWARE;
 	}
 }


### PR DESCRIPTION
Before, if the JDK didn't exist, it would first nicely download the JDK
before deling it ;-)