### PR TITLE
refactor: Now using special exit code to allow printing to stdout

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -3,7 +3,7 @@ Feature: catalog testing
 Scenario: java catalog list
   When command('jbang catalog add tc jbang-catalog.json')
   And command('jbang catalog list')
-  Then match err contains "tc = JBang test scripts"
+  Then match out contains "tc = JBang test scripts"
 
 Scenario: add catalog and run catalog named reference
   When command('jbang catalog add tc jbang-catalog.json')

--- a/itests/version.feature
+++ b/itests/version.feature
@@ -2,13 +2,13 @@ Feature: version command
 
 Scenario: version
 * command('jbang version')
-* match out == ''
-* match err == '#regex (?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?.*'
+* match out == '#regex (?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?.*'
+* match err == ''
 * match exit == 0
 
 Scenario: verbose version
 * command('jbang --verbose version')
-* match out == ''
+* match out == '#regex (?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?.*'
 * match err contains 'Repository'
 * match exit == 0
 

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -1,5 +1,8 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -14,8 +17,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-
-import picocli.CommandLine;
 
 public class AliasUtil {
 	public static final String JBANG_CATALOG_JSON = "jbang-catalog.json";
@@ -217,7 +218,7 @@ public class AliasUtil {
 		Aliases aliases = getCatalogAliasesByName(catalogName, false);
 		Alias alias = aliases.aliases.get(aliasName);
 		if (alias == null) {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "No alias found with name '" + aliasName + "'");
+			throw new ExitException(EXIT_INVALID_INPUT, "No alias found with name '" + aliasName + "'");
 		}
 		return alias;
 	}
@@ -234,7 +235,7 @@ public class AliasUtil {
 		if (catalog != null) {
 			return getCatalogAliasesByRef(catalog.catalogRef, updateCache);
 		} else {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Unknown catalog '" + catalogName + "'");
+			throw new ExitException(EXIT_INVALID_INPUT, "Unknown catalog '" + catalogName + "'");
 		}
 	}
 
@@ -291,7 +292,7 @@ public class AliasUtil {
 			}
 			String[] names = parts[0].split("/");
 			if (names.length > 3) {
-				throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Invalid catalog name '" + name + "'");
+				throw new ExitException(EXIT_INVALID_INPUT, "Invalid catalog name '" + name + "'");
 			}
 			String org = names[0];
 			String repo;
@@ -464,7 +465,7 @@ public class AliasUtil {
 			}
 			return aliases;
 		} catch (IOException | JsonParseException ex) {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE,
+			throw new ExitException(EXIT_UNEXPECTED_STATE,
 					"Unable to download catalog: " + catalogRef + " via " + catalogPath, ex);
 		}
 	}

--- a/src/main/java/dev/jbang/FileRef.java
+++ b/src/main/java/dev/jbang/FileRef.java
@@ -1,13 +1,13 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-
-import picocli.CommandLine;
 
 public class FileRef {
 
@@ -65,7 +65,7 @@ public class FileRef {
 			}
 			Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
 		} catch (IOException ioe) {
-			throw new ExitException(CommandLine.ExitCode.USAGE, "Could not copy " + from + " to " + to, ioe);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Could not copy " + from + " to " + to, ioe);
 		}
 	}
 

--- a/src/main/java/dev/jbang/IntegrationManager.java
+++ b/src/main/java/dev/jbang/IntegrationManager.java
@@ -1,5 +1,7 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.*;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -15,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import picocli.CommandLine;
 
 /**
  * JBang uses a 'convention based interface' for build time integration.
@@ -120,14 +120,14 @@ public class IntegrationManager {
 				}
 			}
 		} catch (ClassNotFoundException e) {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Unable to load integration class", e);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Unable to load integration class", e);
 		} catch (NoSuchMethodException e) {
 			throw new ExitException(
-					CommandLine.ExitCode.SOFTWARE,
+					EXIT_UNEXPECTED_STATE,
 					"Integration class missing method with signature public static Map<String, byte[]> postBuild(Path classesDir, Path pomFile, List<Map.Entry<String, Path>> dependencies)",
 					e);
 		} catch (Exception e) {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Issue running postBuild()", e);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Issue running postBuild()", e);
 		} finally {
 			Thread.currentThread().setContextClassLoader(old);
 			System.setOut(oldout);

--- a/src/main/java/dev/jbang/JdkManager.java
+++ b/src/main/java/dev/jbang/JdkManager.java
@@ -1,5 +1,7 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,8 +12,6 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import picocli.CommandLine;
 
 public class JdkManager {
 	private static final String JDK_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/%s";
@@ -76,7 +76,7 @@ public class JdkManager {
 			}
 			Util.errorMsg("Required Java version not possible to download or install. You can run with '--java "
 					+ JavaUtil.determineJavaVersion() + "' to force using the default installed Java.");
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE,
+			throw new ExitException(EXIT_UNEXPECTED_STATE,
 					"Unable to download or install JDK version " + version, e);
 		}
 	}

--- a/src/main/java/dev/jbang/URLRef.java
+++ b/src/main/java/dev/jbang/URLRef.java
@@ -1,5 +1,7 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -7,8 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-
-import picocli.CommandLine;
 
 public class URLRef extends FileRef {
 
@@ -41,7 +41,7 @@ public class URLRef extends FileRef {
 			Path dest = Util.downloadFile(from.toString(), tempDir.toFile());
 			Files.copy(dest, to, StandardCopyOption.REPLACE_EXISTING);
 		} catch (IOException ioe) {
-			throw new ExitException(CommandLine.ExitCode.USAGE, "Could not copy " + from + " to " + to, ioe);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Could not copy " + from + " to " + to, ioe);
 		}
 	}
 }

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -1,5 +1,7 @@
 package dev.jbang;
 
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -35,8 +37,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
 
 import com.google.gson.Gson;
-
-import picocli.CommandLine;
 
 public class Util {
 
@@ -198,7 +198,7 @@ public class Util {
 		} else if (os.startsWith("win")) {
 			return OS.windows;
 		} else {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Unsupported Operating System: " + os);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Unsupported Operating System: " + os);
 		}
 	}
 
@@ -211,7 +211,7 @@ public class Util {
 		} else if (arch.matches("^(aarch64)$")) {
 			return Arch.aarch64;
 		} else {
-			throw new ExitException(CommandLine.ExitCode.SOFTWARE, "Unsupported Architecture: " + arch);
+			throw new ExitException(EXIT_UNEXPECTED_STATE, "Unsupported Architecture: " + arch);
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -1,6 +1,6 @@
 package dev.jbang.cli;
 
-import java.io.PrintWriter;
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -79,7 +79,7 @@ class AliasList extends BaseAliasCommand {
 
 	@Override
 	public Integer doCall() {
-		PrintWriter out = spec.commandLine().getOut();
+		PrintStream out = System.out;
 		AliasUtil.Aliases aliases;
 		if (catalogName != null) {
 			aliases = AliasUtil.getCatalogAliasesByName(catalogName, false);
@@ -93,10 +93,10 @@ class AliasList extends BaseAliasCommand {
 		} else {
 			printAliases(out, catalogName, aliases);
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_PRINT_OUTPUT;
 	}
 
-	static void printAliases(PrintWriter out, String catalogName, AliasUtil.Aliases aliases) {
+	static void printAliases(PrintStream out, String catalogName, AliasUtil.Aliases aliases) {
 		aliases.aliases
 						.keySet()
 						.stream()
@@ -106,7 +106,7 @@ class AliasList extends BaseAliasCommand {
 						});
 	}
 
-	static void printAliasesWithOrigin(PrintWriter out, String catalogName, AliasUtil.Aliases aliases) {
+	static void printAliasesWithOrigin(PrintStream out, String catalogName, AliasUtil.Aliases aliases) {
 		Map<Path, List<Map.Entry<String, AliasUtil.Alias>>> groups = aliases.aliases
 																					.entrySet()
 																					.stream()
@@ -120,7 +120,7 @@ class AliasList extends BaseAliasCommand {
 		});
 	}
 
-	private static void printAlias(PrintWriter out, String catalogName, AliasUtil.Aliases aliases, String name,
+	private static void printAlias(PrintStream out, String catalogName, AliasUtil.Aliases aliases, String name,
 			int indent) {
 		AliasUtil.Alias alias = aliases.aliases.get(name);
 		String fullName = catalogName != null ? name + "@" + catalogName : name;

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -64,7 +64,7 @@ class AliasAdd extends BaseAliasCommand {
 		} else {
 			AliasUtil.addNearestAlias(null, name, scriptOrFile, description, userParams, properties);
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 }
 
@@ -93,7 +93,7 @@ class AliasList extends BaseAliasCommand {
 		} else {
 			printAliases(out, catalogName, aliases);
 		}
-		return EXIT_PRINT_OUTPUT;
+		return EXIT_OK;
 	}
 
 	static void printAliases(PrintStream out, String catalogName, AliasUtil.Aliases aliases) {
@@ -162,6 +162,6 @@ class AliasRemove extends BaseAliasCommand {
 		} else {
 			AliasUtil.removeNearestAlias(null, name);
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -11,6 +11,8 @@ import picocli.CommandLine;
 
 public abstract class BaseCommand implements Callable<Integer> {
 
+	public static int EXIT_PRINT_OUTPUT = 3;
+
 	static {
 		Logger logger = Logger.getLogger("org.jboss.shrinkwrap.resolver");
 		logger.setLevel(Level.SEVERE);

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -11,7 +11,12 @@ import picocli.CommandLine;
 
 public abstract class BaseCommand implements Callable<Integer> {
 
-	public static int EXIT_PRINT_OUTPUT = 3;
+	public static int EXIT_OK = 0;
+	public static int EXIT_GENERIC_ERROR = 1;
+	public static int EXIT_INVALID_INPUT = 2;
+	public static int EXIT_UNEXPECTED_STATE = 3;
+	public static int EXIT_INTERNAL_ERROR = 4;
+	public static int EXIT_EXECUTE = 255;
 
 	static {
 		Logger logger = Logger.getLogger("org.jboss.shrinkwrap.resolver");

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -140,7 +140,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		 */
 		// just proceed if the script file is a regular file at this point
 		if (scriptFile == null || !scriptFile.getFile().canRead()) {
-			throw new IllegalArgumentException("Could not read script argument " + scriptResource);
+			throw new ExitException(EXIT_INVALID_INPUT, "Could not read script argument " + scriptResource);
 		}
 
 		// note script file must be not null at this point

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -18,6 +18,7 @@ public class Build extends BaseBuildCommand {
 		if (script.needsJar()) {
 			build(script);
 		}
-		return 0;
+
+		return EXIT_EXECUTE;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -1,5 +1,7 @@
 package dev.jbang.cli;
 
+import static dev.jbang.cli.BaseCommand.EXIT_OK;
+
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
@@ -53,7 +55,7 @@ public class Cache {
 
 		Settings.CacheClass[] ccs = classes.toArray(new Settings.CacheClass[0]);
 		Settings.clearCache(ccs);
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 
 	private void toggleCache(Boolean b, Settings.CacheClass cache, EnumSet<Settings.CacheClass> classes) {

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -1,5 +1,6 @@
 package dev.jbang.cli;
 
+import java.io.PrintStream;
 import java.io.PrintWriter;
 
 import dev.jbang.AliasUtil;
@@ -52,8 +53,7 @@ public class Catalog {
 	@CommandLine.Command(name = "list", description = "Show currently defined catalogs.")
 	public Integer list(
 			@CommandLine.Parameters(paramLabel = "name", index = "0", description = "The name of a catalog", arity = "0..1") String name) {
-		PrintWriter out = spec.commandLine().getOut();
-		PrintWriter err = spec.commandLine().getErr();
+		PrintStream out = System.out;
 		if (name == null) {
 			Settings.getCatalogs()
 					.keySet()
@@ -72,7 +72,7 @@ public class Catalog {
 			AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(name, false);
 			AliasList.printAliases(out, name, aliases);
 		}
-		return CommandLine.ExitCode.SOFTWARE;
+		return BaseCommand.EXIT_PRINT_OUTPUT;
 	}
 
 	@CommandLine.Command(name = "remove", description = "Remove existing catalog.")

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -1,9 +1,13 @@
 package dev.jbang.cli;
 
+import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
+import static dev.jbang.cli.BaseCommand.EXIT_OK;
+
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
 import dev.jbang.AliasUtil;
+import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.Util;
 
@@ -26,7 +30,7 @@ public class Catalog {
 					"Invalid catalog name, it should start with a letter followed by 0 or more letters, digits, underscores, hyphens or dots");
 		}
 		if (Settings.getCatalogs().containsKey(name)) {
-			throw new IllegalArgumentException("A catalog with that name already exists");
+			throw new ExitException(EXIT_INVALID_INPUT, "A catalog with that name already exists");
 		}
 		PrintWriter err = spec.commandLine().getErr();
 		AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByRef(urlOrFile, true);
@@ -34,7 +38,7 @@ public class Catalog {
 			description = aliases.description;
 		}
 		Settings.addCatalog(name, urlOrFile, description);
-		return CommandLine.ExitCode.SOFTWARE;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "update", description = "Retrieve the latest contents of the catalogs.")
@@ -47,7 +51,7 @@ public class Catalog {
 					err.println("Updating catalog '" + e.getKey() + "' from " + e.getValue().catalogRef + "...");
 					AliasUtil.getCatalogAliasesByRef(e.getValue().catalogRef, true);
 				});
-		return CommandLine.ExitCode.SOFTWARE;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "list", description = "Show currently defined catalogs.")
@@ -72,16 +76,16 @@ public class Catalog {
 			AliasUtil.Aliases aliases = AliasUtil.getCatalogAliasesByName(name, false);
 			AliasList.printAliases(out, name, aliases);
 		}
-		return BaseCommand.EXIT_PRINT_OUTPUT;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "remove", description = "Remove existing catalog.")
 	public Integer remove(
 			@CommandLine.Parameters(paramLabel = "name", index = "0", description = "The name of the catalog", arity = "1") String name) {
 		if (!Settings.getCatalogs().containsKey(name)) {
-			throw new IllegalArgumentException("A catalog with that name does not exist");
+			throw new ExitException(EXIT_INVALID_INPUT, "A catalog with that name does not exist");
 		}
 		Settings.removeCatalog(name);
-		return CommandLine.ExitCode.SOFTWARE;
+		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Completion.java
+++ b/src/main/java/dev/jbang/cli/Completion.java
@@ -2,10 +2,8 @@ package dev.jbang.cli;
 
 import static java.lang.System.out;
 
-import java.io.File;
 import java.io.IOException;
-
-import dev.jbang.Util;
+import java.io.PrintStream;
 
 import picocli.AutoComplete;
 import picocli.CommandLine;
@@ -25,12 +23,10 @@ public class Completion extends BaseCommand {
 		// not PrintWriter.println: scripts with Windows line separators fail in strange
 		// ways!
 
-		File file = File.createTempFile("jbang-completion", "temp");
-		Util.writeString(file.toPath(), script);
-
-		out.print("cat " + file.getAbsolutePath());
+		PrintStream out = System.out;
+		out.print(script);
 		out.print('\n');
 		out.flush();
-		return 0;
+		return EXIT_PRINT_OUTPUT;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Completion.java
+++ b/src/main/java/dev/jbang/cli/Completion.java
@@ -27,6 +27,6 @@ public class Completion extends BaseCommand {
 		out.print(script);
 		out.print('\n');
 		out.flush();
-		return EXIT_PRINT_OUTPUT;
+		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -119,7 +119,7 @@ public class Edit extends BaseScriptCommand {
 				warn("edit-live interrupted");
 			}
 		}
-		return 0;
+		return EXIT_EXECUTE;
 	}
 
 	/** Create Project to use for editing **/

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -41,7 +41,7 @@ public class Init extends BaseScriptCommand {
 			info("File initialized. You can now run it with 'jbang " + scriptOrFile
 					+ "' or edit it using 'code `jbang edit " + scriptOrFile + "`'");
 		}
-		return 0;
+		return EXIT_OK;
 	}
 
 	String renderInitClass(File f, String template) {

--- a/src/main/java/dev/jbang/cli/Jbang.java
+++ b/src/main/java/dev/jbang/cli/Jbang.java
@@ -61,7 +61,7 @@ public class Jbang extends BaseCommand {
 
 	public Integer doCall() {
 		spec.commandLine().usage(err);
-		return 0;
+		return EXIT_OK;
 	}
 
 	public static CommandLine getCommandLine() {
@@ -83,7 +83,7 @@ public class Jbang extends BaseCommand {
 			if (ex instanceof ExitException) {
 				return ((ExitException) ex).getStatus();
 			} else {
-				return CommandLine.ExitCode.USAGE;
+				return EXIT_INTERNAL_ERROR;
 			}
 		}
 	};
@@ -94,9 +94,9 @@ public class Jbang extends BaseCommand {
 			if (t instanceof ExitException) {
 				return ((ExitException) t).getStatus();
 			} else if (t instanceof CommandLine.ParameterException) {
-				return CommandLine.ExitCode.USAGE;
+				return EXIT_INVALID_INPUT;
 			}
-			return CommandLine.ExitCode.SOFTWARE;
+			return EXIT_GENERIC_ERROR;
 		}
 	};
 

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -1,5 +1,7 @@
 package dev.jbang.cli;
 
+import static dev.jbang.cli.BaseCommand.EXIT_OK;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -28,7 +30,7 @@ public class Jdk {
 		} else {
 			Util.infoMsg("JDK " + version + " is already installed");
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "list", description = "Lists installed JDKs.")
@@ -42,7 +44,7 @@ public class Jdk {
 			}
 			err.println();
 		});
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "uninstall", description = "Uninstalls an existing JDK.")
@@ -54,7 +56,7 @@ public class Jdk {
 		} else {
 			Util.infoMsg("JDK " + version + " is not installed");
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "home", description = "Returns the folder where the given JDK is installed.")
@@ -62,7 +64,7 @@ public class Jdk {
 			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version) {
 		Path home = getJdkPath(version);
 		System.out.println("echo " + home);
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "java-env", description = "Returns the folder where the given JDK is installed.")
@@ -70,7 +72,7 @@ public class Jdk {
 			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version) {
 		Path home = getJdkPath(version);
 		if (home != null) {
-			PrintStream out = System.err; // TODO set this to System.out when #336 gets merged
+			PrintStream out = System.out;
 			if (Util.isWindows()) {
 				out.println("set PATH=" + home + "\\bin;%PATH%");
 				out.println("set JAVA_HOME=" + home);
@@ -87,7 +89,7 @@ public class Jdk {
 				out.println(")");
 			}
 		}
-		return CommandLine.ExitCode.OK; // TODO set this to EXIT_PRINT when #336 gets merged
+		return EXIT_OK;
 	}
 
 	private Path getJdkPath(Integer version) {
@@ -123,6 +125,6 @@ public class Jdk {
 				Util.infoMsg("Default JDK is currently set to " + v);
 			}
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -51,7 +51,7 @@ public class Run extends BaseBuildCommand {
 		debug("run: " + cmdline);
 		out.println(cmdline);
 
-		return 0;
+		return EXIT_EXECUTE;
 	}
 
 	String generateCommandLine(Script script) throws IOException {

--- a/src/main/java/dev/jbang/cli/Trust.java
+++ b/src/main/java/dev/jbang/cli/Trust.java
@@ -1,5 +1,6 @@
 package dev.jbang.cli;
 
+import java.io.PrintStream;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,10 +24,11 @@ public class Trust {
 	@CommandLine.Command(name = "list", description = "Show defined trust domains.")
 	public Integer list() {
 		int idx = 0;
+		PrintStream out = System.out;
 		for (String src : Settings.getTrustedSources().trustedSources) {
-			spec.commandLine().getOut().println(++idx + " = " + src);
+			out.println(++idx + " = " + src);
 		}
-		return CommandLine.ExitCode.SOFTWARE;
+		return BaseCommand.EXIT_PRINT_OUTPUT;
 	}
 
 	@CommandLine.Command(name = "remove", description = "Remove trust domains.")

--- a/src/main/java/dev/jbang/cli/Trust.java
+++ b/src/main/java/dev/jbang/cli/Trust.java
@@ -1,5 +1,7 @@
 package dev.jbang.cli;
 
+import static dev.jbang.cli.BaseCommand.EXIT_OK;
+
 import java.io.PrintStream;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -18,7 +20,7 @@ public class Trust {
 	public Integer add(
 			@CommandLine.Parameters(index = "0", description = "Rules for trusted sources", arity = "1..*") List<String> rules) {
 		Settings.getTrustedSources().add(rules, Settings.getTrustedSourcesFile().toFile());
-		return CommandLine.ExitCode.SOFTWARE;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "list", description = "Show defined trust domains.")
@@ -28,7 +30,7 @@ public class Trust {
 		for (String src : Settings.getTrustedSources().trustedSources) {
 			out.println(++idx + " = " + src);
 		}
-		return BaseCommand.EXIT_PRINT_OUTPUT;
+		return EXIT_OK;
 	}
 
 	@CommandLine.Command(name = "remove", description = "Remove trust domains.")
@@ -38,7 +40,7 @@ public class Trust {
 										.map(src -> toDomain(src))
 										.collect(Collectors.toList());
 		Settings.getTrustedSources().remove(newrules, Settings.getTrustedSourcesFile().toFile());
-		return CommandLine.ExitCode.SOFTWARE;
+		return EXIT_OK;
 	}
 
 	private String toDomain(String src) {

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -11,15 +11,14 @@ public class Version extends BaseCommand {
 
 	@Override
 	public Integer doCall() {
-		PrintWriter out = spec.commandLine().getOut();
-
-		out.println(dev.jbang.BuildConfig.VERSION);
+		System.out.println(dev.jbang.BuildConfig.VERSION);
 
 		if (isVerbose()) {
+			PrintWriter out = spec.commandLine().getOut();
 			out.println("Cache: " + Settings.getCacheDir());
 			out.println("Config: " + Settings.getConfigDir());
 			out.println("Repository:" + Settings.getLocalMavenRepo());
 		}
-		return CommandLine.ExitCode.OK;
+		return EXIT_PRINT_OUTPUT;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -19,6 +19,6 @@ public class Version extends BaseCommand {
 			out.println("Config: " + Settings.getConfigDir());
 			out.println("Repository:" + Settings.getLocalMavenRepo());
 		}
-		return EXIT_PRINT_OUTPUT;
+		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -1,5 +1,7 @@
 package dev.jbang.cli;
 
+import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
+import static dev.jbang.cli.BaseCommand.EXIT_OK;
 import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
@@ -29,11 +31,11 @@ public class Wrapper {
 			@CommandLine.Option(names = { "-f",
 					"--force" }, description = "Force installation of wrapper even if files already exist", defaultValue = "false") boolean force) {
 		if (!Files.isDirectory(dest)) {
-			throw new IllegalArgumentException("Destination folder does not exist");
+			throw new ExitException(EXIT_INVALID_INPUT, "Destination folder does not exist");
 		}
 		if ((checkScripts(dest) || checkJar(dest.resolve(DIR_NAME))) && !force) {
 			Util.warnMsg("Wrapper already exists. Use --force to install anyway");
-			return CommandLine.ExitCode.OK;
+			return EXIT_OK;
 		}
 		try {
 			URI uri = Wrapper.class.getProtectionDomain().getCodeSource().getLocation().toURI();
@@ -50,7 +52,7 @@ public class Wrapper {
 			} else {
 				throw new ExitException(1, "Couldn't find Jbang wrapper files");
 			}
-			return CommandLine.ExitCode.OK;
+			return EXIT_OK;
 		} catch (URISyntaxException e) {
 			throw new ExitException(1, "Couldn't find Jbang install location", e);
 		} catch (IOException e) {

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -136,6 +136,8 @@ output=$(CLICOLOR_FORCE=1 ${JAVA_EXEC} ${JBANG_JAVA_OPTIONS} -classpath ${jarPat
 err=$?
 if [ $err -eq 0 ]; then
   eval "exec $output"
+elif [ $err -eq 3 ]; then
+  echo "$output"
 else
   exit $err
 fi

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -134,10 +134,9 @@ export JBANG_FILE="$1"
 ## run it using command substitution to have just the user process once jbang is done
 output=$(CLICOLOR_FORCE=1 ${JAVA_EXEC} ${JBANG_JAVA_OPTIONS} -classpath ${jarPath} dev.jbang.Main "$@")
 err=$?
-if [ $err -eq 0 ]; then
+if [ $err -eq 255 ]; then
   eval "exec $output"
-elif [ $err -eq 3 ]; then
-  echo "$output"
 else
+  echo "$output"
   exit $err
 fi

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -87,18 +87,21 @@ SETLOCAL DISABLEDELAYEDEXPANSION
 set ERROR=%ERRORLEVEL%
 rem catch errorlevel straight after; rem or FOR /F swallow would have swallowed the errorlevel
 
-if %ERROR% NEQ 0 (
-  del ""%tmpfile%""
+if %ERROR% EQU 0 (
+  rem read generated java command by jang, delete temporary file and execute.
+  for %%A in ("%tmpfile%") do for /f "usebackq delims=" %%B in (%%A) do (
+    set "OUTPUT=%%B"
+    goto :break
+  )
+:break
+  del "%tmpfile%"
+  %OUTPUT%
+  exit /b %ERRORLEVEL%
+) else if %ERROR% EQU 3 (
+  type "%tmpfile%"
+  del "%tmpfile%"
+  exit /b 0
+) else (
+  del "%tmpfile%"
   exit /b %ERROR%
 )
-
-rem read generated java command by jang, delete temporary file and execute.
-for %%A in ("%tmpfile%") do for /f "usebackq delims=" %%B in (%%A) do (
-  set "OUTPUT=%%B"
-  goto :break
-)
-
-:break
-del "%tmpfile%"
-%OUTPUT%
-exit /b %ERRORLEVEL%

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -87,7 +87,7 @@ SETLOCAL DISABLEDELAYEDEXPANSION
 set ERROR=%ERRORLEVEL%
 rem catch errorlevel straight after; rem or FOR /F swallow would have swallowed the errorlevel
 
-if %ERROR% EQU 0 (
+if %ERROR% EQU 255 (
   rem read generated java command by jang, delete temporary file and execute.
   for %%A in ("%tmpfile%") do for /f "usebackq delims=" %%B in (%%A) do (
     set "OUTPUT=%%B"
@@ -97,11 +97,8 @@ if %ERROR% EQU 0 (
   del "%tmpfile%"
   %OUTPUT%
   exit /b %ERRORLEVEL%
-) else if %ERROR% EQU 3 (
-  type "%tmpfile%"
-  del "%tmpfile%"
-  exit /b 0
 ) else (
+  type "%tmpfile%"
   del "%tmpfile%"
   exit /b %ERROR%
 )


### PR DESCRIPTION
Before we would either print as much output to stderr, which is not
in line with the Rule of Least Surprise, or we had to print the output
as part of a shell command like `echo` or `cat`. Now we have a special
exit code that will tell the startup scripts to either execute Jbang's
output or to simply display it.