### PR TITLE
feat: Added `jdk default`, `jdk home` and `jdk java-env` commands 

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -712,8 +712,8 @@ For now this is required for `kubectl` plugin but not `git`. https://github.com/
 
 If your script requires a specific or minimal version of Java you can use `//JAVA <version>(+)`.
 
-If jbang finds a java executable using `JAVA_HOME` or `PATH` which satisfies the stated java version jbang will use it.
-If no such version is found it will automatically download and install it into jbang's cache (`~/.jbang/cache/jdks` by default).
+If Jbang finds a java executable using `JAVA_HOME` or `PATH` which satisfies the stated java version jbang will use it.
+If no such version is found it will automatically download and install it.
 
 Examples:
 
@@ -724,6 +724,89 @@ In case no matching `java` is found `jbang` will fail.
 
 You can always force running with specific version of `java` using `--java` command line option, i.e.
 `jbang --java 8 hello.java`
+
+== Managing JDKs
+
+In the previous section it was mentioned that Jbang will automatically download and install JDKs when necessary.
+You can use the `jdk` command to manage JDKs, for example you can run the following:
+
+  jbang jdk list
+
+which will list all the JDKs that are currently installed by Jbang.
+
+It's easy to `install` additional JDKs by running:
+
+  jbang jdk install 14
+
+which will download and install JDK version 14 into Jbang's cache (`~/.jbang/cache/jdks` by default).
+The list of versions that are available for installation can be found here: https://adoptopenjdk.net/releases.html
+
+The first JDK that gets installed by Jbang will be set as the "default" JDK. This is from then on the JDK that will be
+used by Jbang if no Java could be found on the system (meaning `javac` wasn't found on the `PATH` and no `JAVA_HOME` is set).
+You can change the default JDK by running:
+
+  jbang jdk default 12
+
+Running it without an argument will return the version of the JDK that is currently set as the default.
+
+NOTE: On Windows you might need elevated privileges to create symbolic links. If you don't have permissions then
+running the above command  will result in an error. To use it https://stackoverflow.com/a/24353758[enable symbolic links]
+for your user or run your shell/terminal as administrator to have this feature working.
+
+When you `uninstall` a JDK by running:
+
+  jbang jdk uninstall 12
+
+and that JDK was set as the default, Jbang will set the next higher version JDK as the default. If no higher version is
+available it will select the next lower version.
+
++== Using managed JDKs yourself
+
+Given the fact that Jbang is able to easily download and install JDKs we thought that it might be a good option for
+our users to be able to access those JDKs for their own use instead of having to install yet another version themselves.
+
+To make that easy we added a couple of useful commands. The first can be used to set retrieve to location where the JDK
+is installed:
+
+  jbang jdk home
+
+This will return the path to the "default" JDK (by default `~/.jbang/currentjdk)`, if you want to know the location of a
+specific JDK you can pass the version as an argument: `jbang jdk home 14`. This command could be used by scripts to find
+a JDK to use to run a Java program for example (eg: `JAVA_HOME=$(jbang jdk home)`.
+
+For setting up your current command line environment there's something simpler. You can run:
+
+  jbang jdk java-env
+
+On Linux and Mac this will output something like:
+
+```
+export PATH="/home/user/.jbang/currentjdk/bin:$PATH"
+export JAVA_HOME="/home/user/.jbang/currentjdk"
+# Run this command to configure your shell:
+# eval $(jbang jdk java-env)
+```
+
+And the output itself shows how to properly use it to configure your command line to use the JDK. In this case it's by
+running:
+
+  eval $(jbang jdk java-env)
+
+To do this by default for all shells you start simply add the above line to your `~/.bashrc` file.
+
+Unfortunately on Windows using CMD things are not as easy as is show by the output of `jbang jdk java-env` on that  platform:
+
+```
+set PATH=C:\Users\user\.jbang\currentjdk\bin;%PATH%
+set JAVA_HOME=C:\Users\user\.jbang\currentjdk
+rem Copy & paste the above commands in your CMD window or add
+rem them to your Environment Variables in the System Settings.
+```
+
+Instead of copying and pasting lines you could also redirect the output to a .bat file and execute that instead:
+
+  > jbang jdk java-env > setenv.bat
+  > setenv
 
 == Editing
 
@@ -747,8 +830,8 @@ jbang --open=[editor] helloworld.java
 The editor used will be what is specified as argument to `--open` or default to `$JBANG_EDITOR`, `$VISUAL` or `$EDITOR` in that order.
 
 NOTE: On Windows you might need elevated privileges to create symbolic links. If you don't have permissions then
-the `edit` option will result in an error. To use it enable symbolic links for your user or run your shell/terminal as administrator
-to have this feature working.
+the `edit` option will result in an error. To use it https://stackoverflow.com/a/24353758[enable symbolic links]
+for your user or run your shell/terminal as administrator to have this feature working.
 
 === Live Editing
 

--- a/src/main/java/dev/jbang/JavaUtil.java
+++ b/src/main/java/dev/jbang/JavaUtil.java
@@ -2,7 +2,6 @@ package dev.jbang;
 
 import static java.lang.System.getenv;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -10,8 +9,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JavaUtil {
-
-	public static final int DEFAULT_JAVA_VERSION = 11;
 
 	private static Integer javaVersion;
 
@@ -32,23 +29,16 @@ public class JavaUtil {
 			} else {
 				int minVersion = JavaUtil.minRequestedVersion(requestedVersion);
 				if (isOpenVersion(requestedVersion)) {
-					try {
-						Optional<Integer> minInstalledVersion = JdkManager	.listInstalledJdks()
-																			.stream()
-																			.filter(v -> v >= minVersion)
-																			.min(Integer::compareTo);
-						if (minInstalledVersion.isPresent()) {
-							return minInstalledVersion.get();
-						}
-					} catch (IOException ex) {
-						Util.verboseMsg("Couldn't list installed JDKs", ex);
+					Optional<Integer> minInstalledVersion = JdkManager.nextInstalledJdk(minVersion);
+					if (minInstalledVersion.isPresent()) {
+						return minInstalledVersion.get();
 					}
 				}
 				return minVersion;
 			}
 		} else {
 			if (currentVersion < 8) {
-				return DEFAULT_JAVA_VERSION;
+				return Settings.getDefaultJavaVersion();
 			} else {
 				return currentVersion;
 			}
@@ -107,7 +97,7 @@ public class JavaUtil {
 
 	private static final Pattern javaVersionPattern = Pattern.compile("\"([^\"]+)\"");
 
-	private static int parseJavaOutput(String output) {
+	public static int parseJavaOutput(String output) {
 		if (output != null) {
 			Matcher m = javaVersionPattern.matcher(output);
 			if (m.find() && m.groupCount() == 2) {
@@ -147,7 +137,7 @@ public class JavaUtil {
 		}
 	}
 
-	private static int minRequestedVersion(String rv) {
+	public static int minRequestedVersion(String rv) {
 		return Integer.parseInt(isOpenVersion(rv) ? rv.substring(0, rv.length() - 1) : rv);
 	}
 

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -28,6 +28,11 @@ public class Settings {
 	public static final String TRUSTED_SOURCES_JSON = "trusted-sources.json";
 	public static final String DEPENDENCY_CACHE_TXT = "dependency_cache.txt";
 	public static final String DEPENDENCY_CACHE_JSON = "dependency_cache.json";
+	public static final String CURRENT_JDK = "currentjdk";
+
+	public static final String ENV_DEFAULT_JAVA_VERSION = "JBANG_DEFAULT_JAVA_VERSION";
+
+	public static final int DEFAULT_JAVA_VERSION = 11;
 
 	final public static String CP_SEPARATOR = File.pathSeparator;
 
@@ -63,6 +68,10 @@ public class Settings {
 		return getConfigDir(true);
 	}
 
+	public static Path getCurrentJdkDir() {
+		return getConfigDir(true).resolve(CURRENT_JDK);
+	}
+
 	public static void setupJbangDir(Path dir) {
 		// create JBang configuration dir if it does not yet exist
 		dir.toFile().mkdirs();
@@ -94,6 +103,14 @@ public class Settings {
 	private static void setupCache(Path dir) {
 		// create cache dir if it does not yet exist
 		dir.toFile().mkdirs();
+	}
+
+	public static int getDefaultJavaVersion() {
+		String v = System.getenv(ENV_DEFAULT_JAVA_VERSION);
+		if (v != null) {
+			return Integer.parseInt(v);
+		}
+		return DEFAULT_JAVA_VERSION;
 	}
 
 	public static Path getTrustedSourcesFile() {
@@ -146,12 +163,8 @@ public class Settings {
 			if (cc == CacheClass.jdks && Util.isWindows() && JdkManager.isCurrentJdkManaged()) {
 				// We're running using a managed JDK on Windows so we can't just delete the
 				// entire folder!
-				try {
-					for (Integer v : JdkManager.listInstalledJdks()) {
-						JdkManager.uninstallJdk(v);
-					}
-				} catch (IOException ex) {
-					Util.errorMsg("Error clearing JDK cache", ex);
+				for (Integer v : JdkManager.listInstalledJdks()) {
+					JdkManager.uninstallJdk(v);
 				}
 			} else {
 				Util.deleteFolder(getCacheDir(cc), true);

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -322,8 +322,7 @@ public class Util {
 
 				if (fileName.trim().isEmpty()) {
 					// extracts file name from URL if nothing found
-					fileName = fileURL.substring(fileURL.lastIndexOf("/") + 1,
-							fileURL.length());
+					fileName = fileURL.substring(fileURL.lastIndexOf("/") + 1);
 				}
 
 				/*
@@ -592,6 +591,37 @@ public class Util {
 			}
 		}
 		return result[0];
+	}
+
+	public static boolean createLink(Path src, Path target) {
+		if (!Files.exists(src)
+				&& !createSymbolicLink(src, target.toAbsolutePath())) {
+			return createHardLink(src, target.toAbsolutePath());
+		} else {
+			return false;
+		}
+	}
+
+	private static boolean createSymbolicLink(Path src, Path target) {
+		try {
+			Files.createSymbolicLink(src, target);
+			return true;
+		} catch (IOException e) {
+			infoMsg(e.toString());
+		}
+		infoMsg("Creation of symbolic link failed.");
+		return false;
+	}
+
+	private static boolean createHardLink(Path src, Path target) {
+		try {
+			infoMsg("Now try creating a hard link instead of symbolic.");
+			Files.createLink(src, target);
+		} catch (IOException e) {
+			infoMsg("Creation of hard link failed. Script must be on the same drive as $JBANG_CACHE_DIR (typically under $HOME) for hardlink creation to work. Or call the command with admin rights.");
+			throw new ExitException(1, e);
+		}
+		return true;
 	}
 
 }

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -1,9 +1,12 @@
 package dev.jbang.cli;
 
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.file.Path;
 
 import dev.jbang.JdkManager;
+import dev.jbang.Settings;
 import dev.jbang.Util;
 
 import picocli.CommandLine;
@@ -25,14 +28,21 @@ public class Jdk {
 		} else {
 			Util.infoMsg("JDK " + version + " is already installed");
 		}
-		return CommandLine.ExitCode.SOFTWARE;
+		return CommandLine.ExitCode.OK;
 	}
 
 	@CommandLine.Command(name = "list", description = "Lists installed JDKs.")
-	public Integer list() throws IOException {
+	public Integer list() {
+		int v = JdkManager.getDefaultJdk();
 		PrintWriter err = spec.commandLine().getErr();
-		JdkManager.listInstalledJdks().forEach(jdk -> err.println(jdk));
-		return CommandLine.ExitCode.SOFTWARE;
+		JdkManager.listInstalledJdks().forEach(jdk -> {
+			err.print(jdk);
+			if (jdk == v) {
+				err.print(" *");
+			}
+			err.println();
+		});
+		return CommandLine.ExitCode.OK;
 	}
 
 	@CommandLine.Command(name = "uninstall", description = "Uninstalls an existing JDK.")
@@ -44,6 +54,75 @@ public class Jdk {
 		} else {
 			Util.infoMsg("JDK " + version + " is not installed");
 		}
-		return CommandLine.ExitCode.SOFTWARE;
+		return CommandLine.ExitCode.OK;
+	}
+
+	@CommandLine.Command(name = "home", description = "Returns the folder where the given JDK is installed.")
+	public Integer home(
+			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version) {
+		Path home = getJdkPath(version);
+		System.out.println("echo " + home);
+		return CommandLine.ExitCode.OK;
+	}
+
+	@CommandLine.Command(name = "java-env", description = "Returns the folder where the given JDK is installed.")
+	public Integer javaEnv(
+			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version) {
+		Path home = getJdkPath(version);
+		if (home != null) {
+			PrintStream out = System.err; // TODO set this to System.out when #336 gets merged
+			if (Util.isWindows()) {
+				out.println("set PATH=" + home + "\\bin;%PATH%");
+				out.println("set JAVA_HOME=" + home);
+				out.println("rem Copy & paste the above commands in your CMD window or add");
+				out.println("rem them to your Environment Variables in the System Settings.");
+			} else {
+				out.println("export PATH=\"" + home + "/bin:$PATH\"");
+				out.println("export JAVA_HOME=\"" + home + "\"");
+				out.println("# Run this command to configure your shell:");
+				out.print("# eval $(jbang jdk java-env");
+				if (version != null) {
+					out.print(" " + version);
+				}
+				out.println(")");
+			}
+		}
+		return CommandLine.ExitCode.OK; // TODO set this to EXIT_PRINT when #336 gets merged
+	}
+
+	private Path getJdkPath(Integer version) {
+		Path home;
+		if (version == null) {
+			int v = JdkManager.getDefaultJdk();
+			if (v < 0) {
+				Util.infoMsg("No default JDK set, use 'jbang jdk default <version>' to set one.");
+				return null;
+			}
+			home = Settings.getCurrentJdkDir();
+		} else {
+			home = JdkManager.getInstalledJdk(version);
+		}
+		return home;
+	}
+
+	@CommandLine.Command(name = "default", description = "Sets the default JDK to be used by Jbang.")
+	public Integer defaultJdk(
+			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version)
+			throws IOException {
+		int v = JdkManager.getDefaultJdk();
+		if (version != null) {
+			if (v != version) {
+				JdkManager.setDefaultJdk(version);
+			} else {
+				Util.infoMsg("Default JDK already set to " + v);
+			}
+		} else {
+			if (v < 0) {
+				Util.infoMsg("No default JDK set, use 'jbang jdk default <version>' to set one.");
+			} else {
+				Util.infoMsg("Default JDK is currently set to " + v);
+			}
+		}
+		return CommandLine.ExitCode.OK;
 	}
 }

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -80,7 +80,12 @@ if [[ -z "$JAVA_EXEC" ]]; then
   # Determine if a (working) JDK is available on the PATH
   if [ -x "$(command -v javac)" ]; then
     JAVA_EXEC="java";
+  elif [ -x "$JBDIR/currentjdk/bin/javac" ]; then
+    export JAVA_HOME="$JBDIR/currentjdk"
+    JAVA_EXEC="$JBDIR/currentjdk/bin/java";
   else
+    export JAVA_HOME="$TDIR/jdks/$javaVersion"
+    JAVA_EXEC="$JAVA_HOME/bin/java"
     # Check if we installed a JDK before
     if [ ! -d "$TDIR/jdks/$javaVersion" ]; then
       # If not, download and install it
@@ -113,9 +118,9 @@ if [[ -z "$JAVA_EXEC" ]]; then
       if [ $retval -ne 0 ]; then echo "Error installing JDK" 1>&2; exit $retval; fi
       # Activate the downloaded JDK giving it its proper name
       mv "$TDIR/jdks/$javaVersion.tmp" "$TDIR/jdks/$javaVersion"
+      # Set the current JDK
+      ${JAVA_EXEC} -classpath ${jarPath} dev.jbang.Main jdk default $javaVersion
     fi
-    export JAVA_HOME="$TDIR/jdks/$javaVersion"
-    JAVA_EXEC="$JAVA_HOME/bin/java"
   fi
 fi
 

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -48,7 +48,12 @@ if "!JAVA_EXEC!"=="" (
   where javac > nul 2>&1
   if !errorlevel! equ 0 (
     set JAVA_EXEC=java.exe
+  ) else if exist "%JBDIR%\currentjdk\bin\javac" (
+    set JAVA_HOME=%JBDIR%\currentjdk
+    set JAVA_EXEC=%JBDIR%\currentjdk\bin\java
   ) else (
+    set JAVA_HOME=%TDIR%\jdks\%javaVersion%
+    set JAVA_EXEC=!JAVA_HOME!\bin\java.exe
     rem Check if we installed a JDK before
     if not exist "%TDIR%\jdks\%javaVersion%" (
       rem If not, download and install it
@@ -69,8 +74,8 @@ if "!JAVA_EXEC!"=="" (
       rem Activate the downloaded JDK giving it its proper name
       ren "%TDIR%\jdks\%javaVersion%.tmp" "%javaVersion%"
     )
-    set JAVA_HOME=%TDIR%\jdks\%javaVersion%
-    set JAVA_EXEC=!JAVA_HOME!\bin\java.exe
+    # Set the current JDK
+    !JAVA_EXEC! -classpath ${jarPath} dev.jbang.Main jdk default "%javaVersion%"
   )
 )
 


### PR DESCRIPTION
These commands were added to facilitate the use of the Jbang's JDKs
by the user. This way it's not necessary to install additional JDKs
if we want to use Java and have previously let Jbang install a JDK.
`jdk default` set the given JDK as "current".
`jdk home` returns the path of the current or the given JDK.
`jdk java-env` returns the shell commands to make the current or
the given JDK usable in the user's shell.