### PR TITLE
fix: `//usr/bin/env jbang` not working on Windows 

### DIFF
--- a/examples/Two.java
+++ b/examples/Two.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/examples/analytics.java
+++ b/examples/analytics.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS com.brsanthu:google-analytics-java:2.0.0
 //DEPS info.picocli:picocli:4.5.0
 

--- a/examples/asciidoc.java
+++ b/examples/asciidoc.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS org.asciidoctor:asciidoctorj:2.2.0
 

--- a/examples/asciidoctor.java
+++ b/examples/asciidoctor.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS org.asciidoctor:asciidoctorj:2.3.1
 //DEPS org.asciidoctor:asciidoctorj-diagram:2.0.2

--- a/examples/benchmark/perftest.java
+++ b/examples/benchmark/perftest.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS org.openjdk.jmh:jmh-core:1.19 org.openjdk.jmh:jmh-generator-annprocess:1.19
 //DEPS com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.2.3

--- a/examples/camel.java
+++ b/examples/camel.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS org.apache.camel:camel-core:3.0.1
 //DEPS org.apache.camel:camel-main:3.0.1

--- a/examples/checksum.java
+++ b/examples/checksum.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS info.picocli:picocli-codegen:4.5.0
 

--- a/examples/classpath_example.java
+++ b/examples/classpath_example.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS log4j:log4j:1.2.17
 

--- a/examples/classpath_example.jsh
+++ b/examples/classpath_example.jsh
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS log4j:log4j:1.2.17
 

--- a/examples/docker.java
+++ b/examples/docker.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS com.github.docker-java:docker-java:3.2.1
 //DEPS javax.activation:activation:1.1.1
 //DEPS org.slf4j:slf4j-simple:1.7.25

--- a/examples/envdetector.java
+++ b/examples/envdetector.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS com.brsanthu:google-analytics-java:2.0.0
 //DEPS kr.motd.maven:os-maven-plugin:1.6.1

--- a/examples/findmodule.java
+++ b/examples/findmodule.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 
 import picocli.CommandLine;

--- a/examples/gh_fetch_release_assets.java
+++ b/examples/gh_fetch_release_assets.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA_OPTIONS --add-opens java.base/java.net=ALL-UNNAMED
 //JAVA_OPTIONS --add-opens java.base/sun.net.www.protocol.https=ALL-UNNAMED
 //DEPS info.picocli:picocli:4.5.0

--- a/examples/githubinfo.java
+++ b/examples/githubinfo.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS org.kohsuke:github-api:1.101
 

--- a/examples/helloworld.java
+++ b/examples/helloworld.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 class helloworld {
 

--- a/examples/helloworld.jsh
+++ b/examples/helloworld.jsh
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 System.out.println("Hello " + (args.length>0?args[0]:"World"));
 for(String a : args) {

--- a/examples/hibernate.java
+++ b/examples/hibernate.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS com.h2database:h2:1.4+
 //DEPS org.hibernate:hibernate-core:5.4.10.Final
 //

--- a/examples/imap.java
+++ b/examples/imap.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS javax.mail:mail:1.4.7
 

--- a/examples/inetTest.java
+++ b/examples/inetTest.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //SOURCES NanoClock.java
 
 // This example tests the time taken in ms to resolve localhostname.

--- a/examples/jetty.jsh
+++ b/examples/jetty.jsh
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS org.eclipse.jetty:jetty-server:9.4.25.v20191220,org.eclipse.jetty:jetty-servlet:9.4.25.v20191220
 

--- a/examples/junit-run.java
+++ b/examples/junit-run.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS org.junit.platform:junit-platform-console-standalone:1.6.2
 
 import org.junit.platform.console.ConsoleLauncher;

--- a/examples/junitrun.java
+++ b/examples/junitrun.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS org.junit.platform:junit-platform-console-standalone:1.6.2
 
 import org.junit.platform.console.ConsoleLauncher;

--- a/examples/lang.java
+++ b/examples/lang.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/examples/one.java
+++ b/examples/one.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 //SOURCES Two.java
 

--- a/examples/piping.java
+++ b/examples/piping.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import java.io.BufferedReader;

--- a/examples/plantuml.java
+++ b/examples/plantuml.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS net.sourceforge.plantuml:plantuml:1.2020.11
 import net.sourceforge.plantuml.Run;
 

--- a/examples/progress.java
+++ b/examples/progress.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS me.tongfei:progressbar:0.8.1
 

--- a/examples/quarkus.java
+++ b/examples/quarkus.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /**
  * Run this with `jbang -Dquarkus.container-image.build=true build quarkus.java`
  * and it builds a docker image.

--- a/examples/quarkuscli.java
+++ b/examples/quarkuscli.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /**
  * Run this with `jbang -Dquarkus.container-image.build=true build quarkus.java`
  * and it builds a docker image.

--- a/examples/quarkusclidb.java
+++ b/examples/quarkusclidb.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /**
  * Run this with `jbang -Dquarkus.container-image.build=true build quarkus.java`
  * and it builds a docker image.

--- a/examples/quarkusclireddis.java
+++ b/examples/quarkusclireddis.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /**
  * Run this with `jbang -Dquarkus.container-image.build=true build quarkus.java`
  * and it builds a docker image.

--- a/examples/quarkusjib.java
+++ b/examples/quarkusjib.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /**
  * Run this with `jbang -Dquarkus.container-image.build=true build quarkus.java`
  * and it builds a docker image.

--- a/examples/quarkusmetrics.java
+++ b/examples/quarkusmetrics.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-resteasy:1.8.1.Final
 //DEPS io.quarkus:quarkus-smallrye-metrics:1.8.1.Final
 //JAVAC_OPTIONS -parameters

--- a/examples/quarkusnew.java
+++ b/examples/quarkusnew.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //REPOS xamdk=https://xam.dk/maven
 //DEPS io.quarkus:quarkus-resteasy:1.8.1.Final

--- a/examples/ratpack.java
+++ b/examples/ratpack.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS org.slf4j:slf4j-simple:1.7.30,io.ratpack:ratpack-core:1.7.5
 

--- a/examples/records.java
+++ b/examples/records.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVA 14
 //JAVAC_OPTIONS --enable-preview --release 14
 //JAVA_OPTIONS --enable-preview

--- a/examples/resource.java
+++ b/examples/resource.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //FILES resource.properties renamed.properties=resource.properties
 //FILES META-INF/application.properties=resource.properties
 

--- a/examples/resteasyclient.java
+++ b/examples/resteasyclient.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.9.8
 //DEPS org.jboss.reasteasy:resteasy-client:4.5.2.Final

--- a/examples/script.java
+++ b/examples/script.java
@@ -1,4 +1,4 @@
-///usr/bin/env jbang "$0" "$@" ; exit $?
+////usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS com.offbytwo:docopt:0.6.0.20150202,log4j:log4j:1.2.14
 

--- a/examples/shrinkwrap.java
+++ b/examples/shrinkwrap.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api:3.1.4 org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.4
 

--- a/examples/smee.java
+++ b/examples/smee.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS org.jboss.resteasy:resteasy-client:4.4.1.Final
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.2.3

--- a/examples/sparkjava.java
+++ b/examples/sparkjava.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS com.sparkjava:spark-core:2.9.1,com.fasterxml.jackson.core:jackson-databind:2.10.2
 

--- a/examples/tz.java
+++ b/examples/tz.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0 
 
 import picocli.CommandLine;

--- a/examples/undertow.java
+++ b/examples/undertow.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS io.undertow:undertow-core:2.0.29.Final
 

--- a/examples/update_catalog.java
+++ b/examples/update_catalog.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS info.picocli:picocli:4.5.0
 //DEPS com.google.code.gson:gson:2.8.6

--- a/examples/urldep.java
+++ b/examples/urldep.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS https://github.com/kohsuke/github-api/tree/github-api-1.103
 import static java.lang.System.out;

--- a/examples/vertx.java
+++ b/examples/vertx.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.vertx:vertx-core:3.8.5
 //DEPS io.vertx:vertx-web:3.8.5
 

--- a/examples/webdriver.java
+++ b/examples/webdriver.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.github.bonigarcia:webdrivermanager:3.8.1
 //DEPS org.seleniumhq.selenium:selenium-java:3.141.59
 //DEPS org.slf4j:slf4j-simple:1.7.30

--- a/itests/Two.java
+++ b/itests/Two.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/itests/classpath_log.java
+++ b/itests/classpath_log.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 //DEPS log4j:log4j:1.2.17
 

--- a/itests/classpath_log_grab.java
+++ b/itests/classpath_log_grab.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 import static java.lang.System.out;
 

--- a/itests/dualclass.java
+++ b/itests/dualclass.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/itests/echo.java
+++ b/itests/echo.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/itests/helloworld.java
+++ b/itests/helloworld.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/itests/helloworld.jsh
+++ b/itests/helloworld.jsh
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 System.out.println("Hello " + (args.length>0?args[0]:"World"));
 

--- a/itests/karate.java
+++ b/itests/karate.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //REPOS jitpack
 // Using jitpack to get latest dev version of karate to be able
 // to use the just added fork() methods to test clis.

--- a/itests/one.java
+++ b/itests/one.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 //SOURCES Two.java
 

--- a/itests/quote.java
+++ b/itests/quote.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 import java.util.Map;
 
 import picocli.CommandLine;

--- a/otp.java
+++ b/otp.java
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 //DEPS com.amdelamar:jotp:1.2.2
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -268,7 +268,7 @@ Below is an (almost) minimal example you can save in `helloworld.java` or simply
 
 [source, java]
 ```
-//usr/bin/env jbang "$0" "$@" ; exit $? // <.>
+///usr/bin/env jbang "$0" "$@" ; exit $? // <.>
 
 class helloworld { // <.>
 
@@ -449,7 +449,7 @@ To specify dependencies you use gradle-style locators or links to Git sources. B
 
 [source, java]
 ```
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // <.>
 //DEPS log4j:log4j:1.2.17
 
@@ -579,7 +579,7 @@ There is also support for using Groovy lang style `@Grab` syntax.
 
 [source, java]
 ----
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 
 import static java.lang.System.out;
 
@@ -826,7 +826,7 @@ If you want to tweak memory settings or enable preview features you can setup th
 
 [source, java]
 ----
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //JAVAC_OPTIONS --enable-preview -source 14 <.>
 //JAVA_OPTIONS --enable-preview // <.>
 

--- a/src/main/resources/init-cli.java.qute
+++ b/src/main/resources/init-cli.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
 
 import picocli.CommandLine;

--- a/src/main/resources/init-hello.java.qute
+++ b/src/main/resources/init-hello.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/src/main/resources/init-qcli.java.qute
+++ b/src/main/resources/init-qcli.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-picocli:1.8.1.Final
 //Q:CONFIG quarkus.banner.enabled=false
 //Q:CONFIG quarkus.log.level=WARN

--- a/src/main/resources/init-qmetrics.java.qute
+++ b/src/main/resources/init-qmetrics.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-resteasy:1.8.1.Final
 //DEPS io.quarkus:quarkus-smallrye-metrics:1.8.1.Final
 //JAVAC_OPTIONS -parameters

--- a/src/main/resources/init-qrest.java.qute
+++ b/src/main/resources/init-qrest.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.quarkus:quarkus-resteasy:1.8.1.Final
 // //DEPS io.quarkus:quarkus-smallrye-openapi:1.8.1.Final
 // //DEPS io.quarkus:quarkus-swagger-ui:1.8.1.Final

--- a/src/main/resources/initClass.java.qute
+++ b/src/main/resources/initClass.java.qute
@@ -1,4 +1,4 @@
-//usr/bin/env jbang "$0" "$@" ; exit $?
+///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
 import static java.lang.System.*;

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -394,7 +394,7 @@ public class TestRun {
 	@Test
 	void testBuildPom(@TempDir File output) throws IOException, ParserConfigurationException, SAXException {
 
-		String base = "//usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
+		String base = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
 				"//DEPS info.picocli:picocli:4.5.0\n" +
 				"\n" +
 				"import static java.lang.System.*;\n" +
@@ -441,7 +441,7 @@ public class TestRun {
 	@Test
 	void testDualClasses(@TempDir File output) throws IOException, ParserConfigurationException, SAXException {
 
-		String base = "//usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
+		String base = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
 				"// //DEPS <dependency1> <dependency2>\n" +
 				"\n" +
 				"import static java.lang.System.*;\n" +


### PR DESCRIPTION
The trick of using double slashes to make executable java files
automatically invoke Jbang doesn't work on Windows when using
something like Cygwin. Turns out that triple slashes do work!

Fixes #341 