### PR TITLE
support --javaagent:xyz.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api:3.1.4'
 	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.4'
 	implementation "org.slf4j:slf4j-nop:1.7.25"
+	implementation "org.jboss:jandex:2.2.1.Final"
 	//implementation 'org.apache.maven:maven-aether-provider:3.0.5'
 	//implementation 'com.google.guava:guava:28.2-jre'
 

--- a/itests/JULAgent.java
+++ b/itests/JULAgent.java
@@ -1,0 +1,7 @@
+//JAVAAGENT
+public class JULAgent {
+
+    public static void premain(String agentArgs, java.lang.instrument.Instrumentation instrumentation) {
+        System.out.println(agentArgs);
+    }
+}

--- a/itests/JULTest.java
+++ b/itests/JULTest.java
@@ -1,0 +1,21 @@
+
+import java.util.logging.Logger;
+
+/**
+ * Just some application
+ * @author Phillip Kruger (phillip.kruger@redhat.com)
+ */
+public class JULTest {
+    private static final Logger log = Logger.getLogger(JULTest.class.getName());
+
+    public void printSomeStuff(String message){
+        log.info("info " + message);
+        log.finest("finest " + message);
+
+    }
+
+
+    public static void main(String[] args) {
+        new JULTest().printSomeStuff(args[0]);
+    }
+}

--- a/itests/run.feature
+++ b/itests/run.feature
@@ -19,4 +19,7 @@ Scenario: java run multiple sources
   When command('jbang --verbose one.java')
   Then match out contains "Two"
 
-
+Scenario: java run with agent
+    When command('jbang --verbose --javaagent=JULAgent.java=options JULTest.java World')
+    Then match err contains "info World"
+    Then match err contains "options"

--- a/readme.adoc
+++ b/readme.adoc
@@ -1047,6 +1047,14 @@ You can list the available catalogs by running:
 NB: The output will not only show the catalogs you defined yourself but also the ones that get added implicitly when
 running aliases as described in the section <<Implicit Alias Catalogs>>.
 
+== Java Agents
+
+You can activate a javaagent using `--javaagent=<agent>[=<options>]` where agent can be a already packaged agent jar from file, http url or Maven Coordinate.
+
+It can also be a jbang script itself where you have put `//JAVAAGENT` to activate agent packaging.
+
+You can create a basic agent using `jbang init -t agent myagent.java` to get started.
+
 == Bash/Zsh auto-completion
 
 If you are using bash or zsh in your terminal you can get auto-completion by running the following:

--- a/src/main/java/dev/jbang/KeyValue.java
+++ b/src/main/java/dev/jbang/KeyValue.java
@@ -1,0 +1,29 @@
+package dev.jbang;
+
+public class KeyValue {
+
+	final String key;
+	final String value;
+
+	public KeyValue(String key, String value) {
+		this.key = key;
+		this.value = value;
+	}
+
+	public String getKey() {
+		return key;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public String toManifestString() {
+		return getKey() + ": " + value;
+	}
+
+	@Override
+	public String toString() {
+		return getKey() + "=" + getValue() == null ? "" : getValue();
+	}
+}

--- a/src/main/java/dev/jbang/cli/KeyOptionalValueConsumer.java
+++ b/src/main/java/dev/jbang/cli/KeyOptionalValueConsumer.java
@@ -1,0 +1,36 @@
+package dev.jbang.cli;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import picocli.CommandLine;
+
+public class KeyOptionalValueConsumer implements CommandLine.IParameterConsumer {
+
+	Pattern p = Pattern.compile("(\\S*?)(=(\\S+))?");
+
+	@Override
+	public void consumeParameters(Stack<String> args, CommandLine.Model.ArgSpec argSpec,
+			CommandLine.Model.CommandSpec commandSpec) {
+		String arg = args.pop();
+		Matcher m = p.matcher(arg);
+		if (m.matches()) {
+
+			Map<String, Optional<String>> kv = argSpec.getValue();
+
+			if (kv == null) {
+				kv = new LinkedHashMap<>();
+			}
+
+			kv.put(m.group(1), Optional.ofNullable(m.group(3)));
+
+			argSpec.setValue(kv);
+		} else {
+
+		}
+	}
+}

--- a/src/main/resources/init-agent.java.qute
+++ b/src/main/resources/init-agent.java.qute
@@ -1,0 +1,45 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//// DEPS <avoid dependencies>
+//JAVAAGENT Can-Redefine-Classes Can-Retransform-Classes Can-Set-Native-Method-Prefix
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.ProtectionDomain;
+
+
+public class {baseName} {
+
+    public static void premain(String agentArgs, Instrumentation instrumentation) {
+        System.out.println("jbang agent {baseName} loaded. Will dump all loaded classes into `classes/`");
+
+        ClassLogger transformer = new ClassLogger();
+        instrumentation.addTransformer(transformer);
+    }
+
+    public static void main(String[] args) {
+        System.out.println("This is a (jbang) javaagent.\n" +
+                           "Usage: \n" +
+                           "   jbang --javaagent={baseName}.java yourApp.java");
+    }
+
+    static public class ClassLogger implements ClassFileTransformer {
+      @Override
+      public byte[] transform(ClassLoader loader,
+                              String className,
+                              Class<?> classBeingRedefined,
+                              ProtectionDomain protectionDomain,
+                              byte[] classfileBuffer) throws IllegalClassFormatException {
+        try {
+          Path path = Paths.get("classes/" + className + ".class");
+          Files.createDirectories(path.getParent());
+          Files.write(path, classfileBuffer);
+        } catch (Throwable ignored) {
+            System.err.println(ignored);
+        } finally { return classfileBuffer; }
+      }
+    }
+}

--- a/src/test/java/dev/jbang/TestScript.java
+++ b/src/test/java/dev/jbang/TestScript.java
@@ -9,7 +9,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
everything is in place, javageent gets built if needed  *EXCEPT* I now realize I need a way to set
premain-class and agent-class in the manifest.

I kinda think we should have a //JAVAAGENT option which if present will search the java class for premain( and agentmain(
and set the respective class name.