### PR TITLE
refactor: The Jbang zero-install cache is now an official category

### DIFF
--- a/itests/cache.feature
+++ b/itests/cache.feature
@@ -8,7 +8,7 @@ When command('jbang cache clear')
 Scenario: clear cache default
 When command('jbang cache clear --all')
 * match exit == 0
-* match err == "[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n"
+* match err == "[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jbangs\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n"
 
 Scenario: clear cache default
 When command('jbang cache clear --all --no-jdk --no-url --no-jar --no-project --no-script --no-stdin')

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -153,7 +153,7 @@ public class Settings {
 	}
 
 	public enum CacheClass {
-		urls, jars, jdks, projects, scripts, stdins
+		urls, jars, jbangs, jdks, projects, scripts, stdins
 	}
 
 	public static void clearCache(CacheClass... classes) {

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -19,6 +19,8 @@ public class Cache {
 			@CommandLine.Option(names = {
 					"--jar" }, description = "clear JAR cache only", negatable = true) Boolean jars,
 			@CommandLine.Option(names = {
+					"--jbang" }, description = "clear Jbang zero-install cache only", negatable = true) Boolean jbangs,
+			@CommandLine.Option(names = {
 					"--jdk" }, description = "clear JDK cache only", negatable = true) Boolean jdks,
 			@CommandLine.Option(names = {
 					"--project" }, description = "clear temporary projects cache only", negatable = true) Boolean projects,
@@ -34,6 +36,7 @@ public class Cache {
 			classes.addAll(Arrays.asList(Settings.CacheClass.values()));
 		} else if (urls == null
 				&& jars == null
+				&& jbangs == null
 				&& jdks == null
 				&& projects == null
 				&& scripts == null
@@ -48,6 +51,7 @@ public class Cache {
 		// we only toggle on or off those that are actually present
 		toggleCache(urls, Settings.CacheClass.urls, classes);
 		toggleCache(jars, Settings.CacheClass.jars, classes);
+		toggleCache(jars, Settings.CacheClass.jbangs, classes);
 		toggleCache(jdks, Settings.CacheClass.jdks, classes);
 		toggleCache(projects, Settings.CacheClass.projects, classes);
 		toggleCache(scripts, Settings.CacheClass.scripts, classes);

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -56,21 +56,22 @@ if [ -f "$(dirname $abs_jbang_path)/jbang.jar" ]; then
 elif [ -f "$(dirname $abs_jbang_path)/.jbang/jbang.jar" ]; then
   jarPath=$(dirname $abs_jbang_path)/.jbang/jbang.jar
 else
-  jarPath="$TDIR/jars/jbang/jbang/bin/jbang.jar"
+  jarPath="$TDIR/jbangs/jbang/jbang/bin/jbang.jar"
   if [ ! -f "$jarPath" ]; then
     echo "Downloading JBang..." 1>&2
-    mkdir -p "$TDIR/jars"
+    mkdir -p "$TDIR/jbangs"
     jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar"
-    download $jburl "$TDIR/jbang.tar"
+    download $jburl "$TDIR/jbangs/jbang.tar"
     if [ $retval -ne 0 ]; then echo "Error downloading JBang" 1>&2; exit $retval; fi
     echo "Installing JBang..." 1>&2
-    rm -rf "$TDIR/jars/jbang(|.tmp)"
-    mkdir -p "$TDIR/jars/jbang.tmp"
-    tar xf "$TDIR/jbang.tar" -C "$TDIR/jars/jbang.tmp"
+    rm -rf "$TDIR/jbangs/jbang.tmp"
+    mkdir -p "$TDIR/jbangs/jbang.tmp"
+    tar xf "$TDIR/jbangs/jbang.tar" -C "$TDIR/jbangs/jbang.tmp"
     if [ $retval -ne 0 ]; then echo "Error installing JBang" 1>&2; exit $retval; fi
-    mv "$TDIR/jars/jbang.tmp" "$TDIR/jars/jbang"
+    rm -rf "$TDIR/jbangs/jbang"
+    mv "$TDIR/jbangs/jbang.tmp" "$TDIR/jbangs/jbang"
   fi
-  eval "exec $TDIR/jars/jbang/jbang/bin/jbang $*"
+  eval "exec $TDIR/jbangs/jbang/jbang/bin/jbang $*"
 fi
 
 case "$(uname -s)" in

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -20,20 +20,20 @@ if exist "%~dp0jbang.jar" (
 ) else if exist "%~dp0.jbang\jbang.jar" (
   set jarPath=%~dp0.jbang\jbang.jar
 ) else (
-  set jarPath=%TDIR%\jars\jbang\jbang\bin\jbang.jar
+  set jarPath=%TDIR%\jbangs\jbang\jbang\bin\jbang.jar
   if not exist "!jarPath!" (
     echo Downloading JBang... 1>&2
-    if not exist "%TDIR%\jars" ( mkdir "%TDIR%\jars" )
-    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest %jburl% -OutFile %TDIR%\jbang.zip"
+    if not exist "%TDIR%\jbangs" ( mkdir "%TDIR%\jbangs" )
+    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest %jburl% -OutFile %TDIR%\jbangs\jbang.zip"
     if !ERRORLEVEL! NEQ 0 ( echo Error downloading JBang 1>&2 & exit /b %ERRORLEVEL% )
     echo Installing JBang... 1>&2
-    if exist "%TDIR%\jars\jbang" ( rd /s /q "%TDIR%\jars\jbang" > nul 2>&1 )
-    if exist "%TDIR%\jars\jbang.tmp" ( rd /s /q "%TDIR%\jars\jbang.tmp" > nul 2>&1 )
-    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "$ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path %TDIR%\jbang.zip -DestinationPath %TDIR%\jars\jbang.tmp"
+    if exist "%TDIR%\jbangs\jbang.tmp" ( rd /s /q "%TDIR%\jbangs\jbang.tmp" > nul 2>&1 )
+    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "$ProgressPreference = 'SilentlyContinue'; Expand-Archive -Path %TDIR%\jbangs\jbang.zip -DestinationPath %TDIR%\jbangs\jbang.tmp"
     if !ERRORLEVEL! NEQ 0 ( echo Error installing JBang 1>&2 & exit /b %ERRORLEVEL% )
-    ren "%TDIR%\jars\jbang.tmp" "jbang"
+    if exist "%TDIR%\jbangs\jbang" ( rd /s /q "%TDIR%\jbangs\jbang" > nul 2>&1 )
+    ren "%TDIR%\jbangs\jbang.tmp" "jbang"
   )
-  call "%TDIR%\jars\jbang\jbang\bin\jbang.cmd" %*
+  call "%TDIR%\jbangs\jbang\jbang\bin\jbang.cmd" %*
   exit /b %ERRORLEVEL%
 )
 

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -54,35 +54,35 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
 } elseif (Test-Path "$PSScriptRoot\.jbang\jbang.jar") {
   $jarPath="$PSScriptRoot\.jbang\jbang.jar"
 } else {
-  $jarPath="$TDIR\jars\jbang\jbang\bin\jbang.jar"
+  $jarPath="$TDIR\jbangs\jbang\jbang\bin\jbang.jar"
   if (-not (Test-Path "$jarPath")) {
     [Console]::Error.WriteLine("Downloading JBang...")
-    New-Item -ItemType Directory -Force -Path "$TDIR\jars" >$null 2>&1
+    New-Item -ItemType Directory -Force -Path "$TDIR\jbangs" >$null 2>&1
     $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
-    try { Invoke-WebRequest "$jburl" -OutFile "$TDIR\jbang.zip"; $ok=$? } catch { 
+    try { Invoke-WebRequest "$jburl" -OutFile "$TDIR\jbangs\jbang.zip"; $ok=$? } catch {
       $ok=$false
       $error=$_
     }
     if (-not ($ok)) { 
-      [Console]::Error.WriteLine("Error downloading JBang from $jburl to $TDIR\jbang.zip")
+      [Console]::Error.WriteLine("Error downloading JBang from $jburl to $TDIR\jbangs\jbang.zip")
       [Console]::Error.WriteLine($error)
       break 
     }
     [Console]::Error.WriteLine("Installing JBang...")
-    Remove-Item -LiteralPath "$TDIR\jars\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
-    Remove-Item -LiteralPath "$TDIR\jars\jbang.tmp" -Force -Recurse -ErrorAction Ignore >$null 2>&1
-    try { Expand-Archive -Path "$TDIR\jbang.zip" -DestinationPath "$TDIR\jars\jbang.tmp"; $ok=$? } catch { 
+    Remove-Item -LiteralPath "$TDIR\jbangs\jbang.tmp" -Force -Recurse -ErrorAction Ignore >$null 2>&1
+    try { Expand-Archive -Path "$TDIR\jbangs\jbang.zip" -DestinationPath "$TDIR\jbangs\jbang.tmp"; $ok=$? } catch {
       $ok=$false 
       $error=$_
     }
     if (-not ($ok)) { 
-      [Console]::Error.WriteLine("Error unzipping JBang from $TDIR\jbang.zip to $TDIR\jars\jbang.tmp")
+      [Console]::Error.WriteLine("Error unzipping JBang from $TDIR\jbangs\jbang.zip to $TDIR\jbangs\jbang.tmp")
       [Console]::Error.WriteLine($error)
       break 
     }
-    Rename-Item -Path "$TDIR\jars\jbang.tmp" -NewName "jbang" >$null 2>&1
+    Remove-Item -LiteralPath "$TDIR\jbangs\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
+    Rename-Item -Path "$TDIR\jbangs\jbang.tmp" -NewName "jbang" >$null 2>&1
   }
-  . "$TDIR\jars\jbang\jbang\bin\jbang.ps1" $args
+  . "$TDIR\jbangs\jbang\jbang\bin\jbang.ps1" $args
   break
 }
 


### PR DESCRIPTION
NB: Needs to be merged after #402

refactor: The Jbang zero-install cache is now an official category

Instead of putting the Jbang zero-install download in `cache/urls`
it's now put in its own `jbang` directory. This means it won't be
deleted when doing a normal `cache clean`, just like the JDKs.
(It will still be deleted when explicitely mentioned or when using
`cache clear -all`).

See #396