### PR TITLE
docs: Some additional instructions for zero-install with PowerShell

### DIFF
--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -5,6 +5,12 @@
 # (where <args>... are the arguments you want to pass to Jbang):
 #   iex "& { $(iwr https://ps.jbang.dev) } <args>..."
 #
+# An alternative way is to type:
+#   & ([scriptblock]::Create($(iwr https://ps.jbang.dev))) <args>...
+# Which even allows you to store the command in a variable for re-use:
+#   $jbang = ([scriptblock]::Create($(iwr https://ps.jbang.dev)))
+#   & $jbang <args>...
+#
 
 $old_erroractionpreference=$erroractionpreference
 $erroractionpreference='stop'


### PR DESCRIPTION
The instruction now show 2 alternatives, one is shorter but might
be somewhat less flexible while the other is somewht more verbose
but has the interesting property that you can store it in a variable
and re-use it.
