### PR TITLE
Remove interactive flag from sh

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -71,7 +71,7 @@ public class Edit extends BaseScriptCommand {
 				if (isWindows()) {
 					cmd = new String[] { "cmd", "/c", optionList.stream().collect(Collectors.joining(" ")) };
 				} else {
-					cmd = new String[] { "sh", "-i", "-c", optionList.stream().collect(Collectors.joining(" ")) };
+					cmd = new String[] { "sh", "-c", optionList.stream().collect(Collectors.joining(" ")) };
 				}
 				info("Running `" + String.join(" ", cmd) + "`");
 				Process process = new ProcessBuilder(cmd).start();


### PR DESCRIPTION
This makes the CLI impossible to quit in Fedora 32.

Fixes #407