### PR TITLE
fix: stop using -jar

### DIFF
--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.Scanner;
 import java.util.jar.Attributes;
+import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -261,7 +262,16 @@ public class Script {
 					classpath = new DependencyUtil().resolveDependencies(additionalDeps,
 							Collections.emptyList(), offline, !Util.isQuiet());
 				} else {
-					classpath = new ModularClassPath(Collections.emptyList());
+					classpath = new ModularClassPath(Arrays.asList(new ArtifactInfo(null, new File(originalFile))));
+				}
+				// fetch main class as we can't use -jar to run as it ignores classpath.
+				if (getMainClass() == null) {
+					try (JarFile jf = new JarFile(getBackingFile())) {
+						setMainClass(
+								jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS));
+					} catch (IOException e) {
+						Util.warnMsg("Problem reading manifest from " + getBackingFile());
+					}
 				}
 			} else {
 				List<String> dependencies = collectDependencies();

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -208,7 +208,12 @@ public class Run extends BaseBuildCommand {
 			if (script.getMainClass() != null) {
 				fullArgs.add(script.getMainClass());
 			} else {
-				fullArgs.add(script.getBackingFile().toString());
+				if (script.forJar()) {
+					throw new ExitException(EXIT_INVALID_INPUT,
+							"no main class deduced, specified nor found in a manifest");
+				} else {
+					fullArgs.add(script.getBackingFile().toString());
+				}
 			}
 		}
 

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -208,9 +208,6 @@ public class Run extends BaseBuildCommand {
 			if (script.getMainClass() != null) {
 				fullArgs.add(script.getMainClass());
 			} else {
-				if (script.forJar()) {
-					fullArgs.add("-jar");
-				}
 				fullArgs.add(script.getBackingFile().toString());
 			}
 		}


### PR DESCRIPTION
 When running jars like org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r we
    got noclassdefounderrors since we need to put the dependencies in the classpath, but
    with `-jar` java ignores the classpath.
    
    Thus we need to simulate a -jar run instead.


note: this is technically a breaking change but i can not imagine anyone using -jar that worked before being affected by this change.