### PR TITLE
fix: Windows testing broken

### DIFF
--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -19,6 +19,6 @@ public class Build extends BaseBuildCommand {
 			build(script);
 		}
 
-		return EXIT_EXECUTE;
+		return EXIT_OK;
 	}
 }

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -41,6 +41,27 @@ download() {
 
 abs_jbang_path=$(resolve_symlink $(absolute_path $0))
 
+case "$(uname -s)" in
+  Linux*)
+    os=linux;;
+  Darwin*)
+    os=mac;;
+  CYGWIN*|MINGW*)
+    os=windows;;
+  *)        echo "Unsupported Operating System: $(uname -s)" 1>&2; exit 1;;
+esac
+
+case "$(uname -m)" in
+  i?86)
+    arch=x32;;
+  x86_64|amd64)
+    arch=x64;;
+  aarch64)
+    arch=aarch64;;
+  *)
+    echo "Unsupported Architecture: $(uname -m)" 1>&2; exit 1;;
+esac
+
 ## when mingw/git bash or cygwin fall out to just running the bat file.
 if [[ $os == windows ]]; then
   $(dirname $abs_jbang_path)/jbang.cmd $*
@@ -71,27 +92,6 @@ else
   fi
   eval "exec $JBDIR/bin/jbang $*"
 fi
-
-case "$(uname -s)" in
-  Linux*)
-    os=linux;;
-  Darwin*)
-    os=mac;;
-  CYGWIN*|MINGW*)
-    os=windows;;
-  *)        echo "Unsupported Operating System: $(uname -s)" 1>&2; exit 1;;
-esac
-
-case "$(uname -m)" in
-  i?86)
-    arch=x32;;
-  x86_64|amd64)
-    arch=x64;;
-  aarch64)
-    arch=aarch64;;
-  *)
-    echo "Unsupported Architecture: $(uname -m)" 1>&2; exit 1;;
-esac
 
 # Find/get a JDK
 unset JAVA_EXEC

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -83,7 +83,8 @@ if "!JAVA_EXEC!"=="" (
   )
 )
 
-set tmpfile=%TDIR%\%RANDOM%.tmp
+if not exist "%TDIR%" ( mkdir "%TDIR%" )
+set tmpfile=%TDIR%\%RANDOM%.jbang.tmp
 rem execute jbang and pipe to temporary random file
 set "CMD=!JAVA_EXEC!"
 SETLOCAL DISABLEDELAYEDEXPANSION


### PR DESCRIPTION
The jbang.cmd script wasn't handling the creation
of temp files correctly. Also the *nix verion of
the script wasn't properly detecting runing on
Cygwin anymore either. Both are now fixed.

Fixes: #421

