### PR TITLE
feat: initial info command for tools

### DIFF
--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -1,0 +1,79 @@
+package dev.jbang.cli;
+
+import static dev.jbang.Settings.CP_SEPARATOR;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import dev.jbang.Script;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "info", description = "Provides info about the script for tools (and humans who are tools).", subcommands = {
+		Tools.class, ClassPath.class })
+public class Info {
+}
+
+abstract class BaseInfoCommand extends BaseScriptCommand {
+
+	class ScriptInfo {
+
+		String originalResource;
+
+		String backingResource;
+
+		List<String> resolvedClasspath;
+
+		public ScriptInfo(Script script) {
+			List<String> collectDependencies = script.collectDependencies();
+			String cp = script.resolveClassPath(offline);
+
+			originalResource = script.getOriginalFile();
+			backingResource = script.getBackingFile().toString();
+
+			resolvedClasspath = Arrays.asList(cp.split(CP_SEPARATOR));
+		}
+	}
+
+	protected ScriptInfo getInfo() throws IOException {
+		if (insecure) {
+			enableInsecure();
+		}
+
+		script = prepareScript(scriptOrFile, userParams);
+
+		ScriptInfo info = new ScriptInfo(script);
+
+		return info;
+	}
+
+}
+
+@CommandLine.Command(name = "tools", description = "Prints a json description usable for tools/IDE's to get classpath and more info for a jbang script/application. Exact format is still quite experimental.")
+class Tools extends BaseInfoCommand {
+
+	@Override
+	public Integer doCall() throws IOException {
+
+		Gson parser = new GsonBuilder().setPrettyPrinting().create();
+		parser.toJson(getInfo(), System.out);
+
+		return EXIT_OK;
+	}
+}
+
+@CommandLine.Command(name = "classpath", description = "Prints classpath used for this application using operating system specific path separation.")
+class ClassPath extends BaseInfoCommand {
+
+	@Override
+	public Integer doCall() throws IOException {
+
+		System.out.println(String.join(CP_SEPARATOR, getInfo().resolvedClasspath));
+
+		return EXIT_OK;
+	}
+}

--- a/src/main/java/dev/jbang/cli/Jbang.java
+++ b/src/main/java/dev/jbang/cli/Jbang.java
@@ -12,12 +12,19 @@ import static picocli.CommandLine.ScopeType;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 
-import dev.jbang.*;
+import dev.jbang.DeprecatedMessageHandler;
+import dev.jbang.ExitException;
+import dev.jbang.Util;
+import dev.jbang.VersionProvider;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Help.TextTable;
@@ -39,7 +46,7 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 
 		"" }, versionProvider = VersionProvider.class, subcommands = {
 				Run.class, Build.class, Edit.class, Init.class, Alias.class, Catalog.class, Trust.class, Cache.class,
-				Completion.class, Jdk.class, Version.class, Wrapper.class })
+				Completion.class, Jdk.class, Version.class, Wrapper.class, Info.class })
 public class Jbang extends BaseCommand {
 
 	@CommandLine.ArgGroup(exclusive = true)
@@ -120,7 +127,7 @@ public class Jbang extends BaseCommand {
 		sections.put("Editing", asList("init", "edit"));
 		sections.put("Caching", asList("cache", "jdk"));
 		sections.put("Configuration", asList("trust", "alias", "catalog"));
-		sections.put("Other", asList("completion", "version", "wrapper"));
+		sections.put("Other", asList("completion", "version", "wrapper", "info"));
 		CommandGroupRenderer renderer = new CommandGroupRenderer(sections);
 		return renderer;
 	}
@@ -163,7 +170,7 @@ public class Jbang extends BaseCommand {
 			}
 
 			if (actualcmds.size() > 0) {
-				throw new IllegalStateException(("Commands found with no section" + actualcmds));
+				throw new IllegalStateException(("Commands found with no assigned section" + actualcmds));
 			}
 
 			sections.forEach((key, value) -> cmds.addAll(value));


### PR DESCRIPTION
initial version of `jbang info <script>`.

currently dumps a json doc like:

```
 jbang info examples/smee.java
{
  "originalResource": "examples/smee.java",
  "backingResource": "examples/smee.java",
  "resolvedClasspath": [
    "/Users/max/.m2/repository/info/picocli/picocli/4.5.0/picocli-4.5.0.jar",
    "/Users/max/.m2/repository/org/jboss/resteasy/resteasy-client/4.4.1.Final/resteasy-client-4.4.1.Final.jar",
    "/Users/max/.m2/repository/org/jboss/resteasy/resteasy-client-api/4.4.1.Final/resteasy-client-api-4.4.1.Final.jar",
    "/Users/max/.m2/repository/org/jboss/resteasy/resteasy-core-spi/4.4.1.Final/resteasy-core-spi-4.4.1.Final.jar",
    "/Users/max/.m2/repository/org/jboss/spec/javax/xml/bind/jboss-jaxb-api_2.3_spec/1.0.1.Final/jboss-jaxb-api_2.3_spec-1.0.1.Final.jar",
    "/Users/max/.m2/repository/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.jar",
    "/Users/max/.m2/repository/jakarta/validation/jakarta.validation-api/2.0.2/jakarta.validation-api-2.0.2.jar",
    "/Users/max/.m2/repository/org/jboss/spec/javax/annotation/jboss-annotations-api_1.3_spec/2.0.1.Final/jboss-annotations-api_1.3_spec-2.0.1.Final.jar",
    "/Users/max/.m2/repository/com/sun/activation/jakarta.activation/1.2.1/jakarta.activation-1.2.1.jar",
    "/Users/max/.m2/repository/org/jboss/resteasy/resteasy-core/4.4.1.Final/resteasy-core-4.4.1.Final.jar",
    "/Users/max/.m2/repository/org/eclipse/microprofile/config/microprofile-config-api/1.3/microprofile-config-api-1.3.jar",
    "/Users/max/.m2/repository/org/osgi/org.osgi.annotation.versioning/1.0.0/org.osgi.annotation.versioning-1.0.0.jar",
    "/Users/max/.m2/repository/io/smallrye/smallrye-config/1.3.9/smallrye-config-1.3.9.jar",
    "/Users/max/.m2/repository/javax/enterprise/cdi-api/2.0.SP1/cdi-api-2.0.SP1.jar",
    "/Users/max/.m2/repository/javax/el/javax.el-api/3.0.0/javax.el-api-3.0.0.jar",
    "/Users/max/.m2/repository/javax/interceptor/javax.interceptor-api/1.2/javax.interceptor-api-1.2.jar",
    "/Users/max/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar",
    "/Users/max/.m2/repository/org/jboss/logging/jboss-logging/3.3.2.Final/jboss-logging-3.3.2.Final.jar",
    "/Users/max/.m2/repository/org/apache/httpcomponents/httpclient/4.5.10/httpclient-4.5.10.jar",
    "/Users/max/.m2/repository/org/apache/httpcomponents/httpcore/4.4.12/httpcore-4.4.12.jar",
    "/Users/max/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar",
    "/Users/max/.m2/repository/commons-codec/commons-codec/1.13/commons-codec-1.13.jar",
    "/Users/max/.m2/repository/commons-io/commons-io/2.5/commons-io-2.5.jar",
    "/Users/max/.m2/repository/org/jboss/spec/javax/ws/rs/jboss-jaxrs-api_2.1_spec/2.0.1.Final/jboss-jaxrs-api_2.1_spec-2.0.1.Final.jar",
    "/Users/max/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.2.3/jackson-databind-2.2.3.jar",
    "/Users/max/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.2.3/jackson-annotations-2.2.3.jar",
    "/Users/max/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.2.3/jackson-core-2.2.3.jar"
  ]
}

```


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->