### PR TITLE
make the edit examples randomly choose between known editors rather than hardcoded to edit... and also use the portable way to run rather than what only works on linux/osx/winbash.

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -1,30 +1,29 @@
 Feature: catalog testing
 
 Scenario: java catalog list
-  When command('jbang catalog add tc jbang-catalog.json')
+  When command('jbang catalog add --global tc jbang-catalog.json')
   And command('jbang catalog list')
   Then match out contains "tc = JBang test scripts"
 
 Scenario: add catalog and run catalog named reference
-  When command('jbang catalog add tc jbang-catalog.json')
+  When command('jbang catalog add --global tc jbang-catalog.json')
   Then command('jbang echo@tc tako')
   Then match out == "0:tako\n"
 
 Scenario: add catalog and remove
-  When command('jbang catalog add tc jbang-catalog.json')
+  When command('jbang catalog add --global tc jbang-catalog.json')
   Then command('jbang catalog remove tc')
   Then command('jbang echo@tc tako')
   Then match err contains "Unknown catalog 'tc'"
 
 Scenario: add catalog twice with same name
-  When command('jbang catalog add tc jbang-catalog.json')
-  Then command('jbang catalog add tc jbang-catalog.json')
-  Then match exit == 2
-  Then match err contains "A catalog with that name already exists"
+  When command('jbang catalog add --global tc jbang-catalog.json')
+  Then command('jbang catalog add --global tc jbang-catalog.json')
+  Then match exit == 0
 
 Scenario: add catalog twice with different name
-  When command('jbang catalog add tc jbang-catalog.json')
-  Then command('jbang catalog add ct jbang-catalog.json')
+  When command('jbang catalog add --global tc jbang-catalog.json')
+  Then command('jbang catalog add --global ct jbang-catalog.json')
   Then command('jbang echo@tc tako')
   And  match exit == 0
   Then command('jbang echo@ct tako')

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class AliasUtil {
 	public static final String JBANG_CATALOG_JSON = "jbang-catalog.json";
+	public static final String JBANG_IMPLICIT_CATALOG_JSON = "implicit-catalog.json";
 	public static final String JBANG_DOT_DIR = ".jbang";
 
 	private static final String GITHUB_URL = "https://github.com/";
@@ -255,7 +256,7 @@ public class AliasUtil {
 																													.findFirst();
 			if (url.isPresent()) {
 				Catalog implicitCatalog = AliasUtil.getCatalogByRef(url.get(), false);
-				catalogRef = addCatalog(cwd, Settings.getUserCatalogFile(), catalogName, url.get(),
+				catalogRef = addCatalog(cwd, Settings.getUserImplicitCatalogFile(), catalogName, url.get(),
 						implicitCatalog.description);
 			}
 		}
@@ -453,7 +454,7 @@ public class AliasUtil {
 		Path catalogPath = null;
 		try {
 			catalogPath = Util.obtainFile(catalogRef, updateCache);
-			Util.verboseMsg(String.format("Downloaded catalog from %s", catalogRef));
+			Util.verboseMsg(String.format("Obtained catalog from %s", catalogRef));
 			Catalog catalog = getCatalog(catalogPath, updateCache);
 			int p = catalogRef.lastIndexOf('/');
 			if (p > 0) {
@@ -488,6 +489,9 @@ public class AliasUtil {
 			cwd = getCwd();
 		}
 		Catalog result = new Catalog(null, null, null);
+		Catalog implicitCatalog = getCatalog(Settings.getUserImplicitCatalogFile(), false);
+		result.aliases.putAll(implicitCatalog.aliases);
+		result.catalogs.putAll(implicitCatalog.catalogs);
 		Catalog userCatalog = getCatalog(Settings.getUserCatalogFile(), false);
 		result.aliases.putAll(userCatalog.aliases);
 		result.catalogs.putAll(userCatalog.catalogs);

--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -489,12 +489,8 @@ public class AliasUtil {
 			cwd = getCwd();
 		}
 		Catalog result = new Catalog(null, null, null);
-		Catalog implicitCatalog = getCatalog(Settings.getUserImplicitCatalogFile(), false);
-		result.aliases.putAll(implicitCatalog.aliases);
-		result.catalogs.putAll(implicitCatalog.catalogs);
-		Catalog userCatalog = getCatalog(Settings.getUserCatalogFile(), false);
-		result.aliases.putAll(userCatalog.aliases);
-		result.catalogs.putAll(userCatalog.catalogs);
+		mergeCatalog(Settings.getUserImplicitCatalogFile(), result);
+		mergeCatalog(Settings.getUserCatalogFile(), result);
 		mergeLocalCatalogs(cwd, result);
 		return result;
 	}
@@ -505,16 +501,22 @@ public class AliasUtil {
 		}
 		Path catalogFile = dir.resolve(JBANG_DOT_DIR).resolve(JBANG_CATALOG_JSON);
 		if (Files.isRegularFile(catalogFile) && Files.isReadable(catalogFile)) {
-			Catalog catalog = getCatalog(catalogFile, false);
-			result.aliases.putAll(catalog.aliases);
-			result.catalogs.putAll(catalog.catalogs);
+			mergeCatalog(catalogFile, result);
 		}
 		catalogFile = dir.resolve(JBANG_CATALOG_JSON);
 		if (Files.isRegularFile(catalogFile) && Files.isReadable(catalogFile)) {
-			Catalog catalog = getCatalog(catalogFile, false);
-			result.aliases.putAll(catalog.aliases);
-			result.catalogs.putAll(catalog.catalogs);
+			mergeCatalog(catalogFile, result);
 		}
+	}
+
+	private static void mergeCatalog(Path catalogFile, Catalog result) {
+		Catalog catalog = getCatalog(catalogFile, false);
+		for (CatalogRef ref : catalog.catalogs.values()) {
+			Catalog cat = getCatalogByRef(ref.catalogRef, false);
+			result.aliases.putAll(cat.aliases);
+		}
+		result.aliases.putAll(catalog.aliases);
+		result.catalogs.putAll(catalog.catalogs);
 	}
 
 	private static Path findNearestLocalCatalog(Path dir) {

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -5,7 +5,6 @@ import static dev.jbang.Util.warnMsg;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -18,15 +17,11 @@ import com.google.gson.reflect.TypeToken;
 import io.quarkus.qute.Template;
 
 public class Settings {
-	static AliasUtil.CatalogInfo catalogInfo = null;
-
 	public static final String JBANG_REPO = "JBANG_REPO";
 	public static final String JBANG_DIR = "JBANG_DIR";
 	public static final String JBANG_CACHE_DIR = "JBANG_CACHE_DIR";
 
-	public static final String CATALOGS_JSON = "catalogs.json";
 	public static final String TRUSTED_SOURCES_JSON = "trusted-sources.json";
-	public static final String DEPENDENCY_CACHE_TXT = "dependency_cache.txt";
 	public static final String DEPENDENCY_CACHE_JSON = "dependency_cache.json";
 	public static final String CURRENT_JDK = "currentjdk";
 
@@ -181,54 +176,12 @@ public class Settings {
 		return te;
 	}
 
-	public static Path getAliasesFile() {
+	public static Path getUserCatalogFile() {
 		return getConfigDir().resolve(AliasUtil.JBANG_CATALOG_JSON);
 	}
 
-	public static Path getCatalogsFile() {
-		return getConfigDir().resolve(CATALOGS_JSON);
-	}
-
-	public static AliasUtil.CatalogInfo getCatalogInfo() {
-		if (catalogInfo == null) {
-			catalogInfo = AliasUtil.readCatalogInfo(getCatalogsFile());
-		}
-		return catalogInfo;
-	}
-
-	public static Map<String, AliasUtil.Catalog> getCatalogs() {
-		return getCatalogInfo().catalogs;
-	}
-
-	public static AliasUtil.Catalog addCatalog(String name, String catalogRef, String description) {
-		try {
-			Path cat = Paths.get(catalogRef);
-			if (!cat.isAbsolute() && Files.isRegularFile(cat)) {
-				catalogRef = cat.toAbsolutePath().toString();
-			}
-		} catch (InvalidPathException ex) {
-			// Ignore
-		}
-		AliasUtil.Catalog catalog = new AliasUtil.Catalog(catalogRef, description);
-		getCatalogs().put(name, catalog);
-		try {
-			AliasUtil.writeCatalogInfo(getCatalogsFile());
-			return catalog;
-		} catch (IOException ex) {
-			Util.warnMsg("Unable to add catalog: " + ex.getMessage());
-			return null;
-		}
-	}
-
-	public static void removeCatalog(String name) {
-		if (getCatalogs().containsKey(name)) {
-			getCatalogs().remove(name);
-			try {
-				AliasUtil.writeCatalogInfo(getCatalogsFile());
-			} catch (IOException ex) {
-				Util.warnMsg("Unable to remove catalog: " + ex.getMessage());
-			}
-		}
+	public static Path getUserCatalogIndexFile() {
+		return getConfigDir().resolve(AliasUtil.JBANG_CATALOGS_JSON);
 	}
 
 	static protected void clearDependencyCache() {

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -180,10 +180,6 @@ public class Settings {
 		return getConfigDir().resolve(AliasUtil.JBANG_CATALOG_JSON);
 	}
 
-	public static Path getUserCatalogIndexFile() {
-		return getConfigDir().resolve(AliasUtil.JBANG_CATALOGS_JSON);
-	}
-
 	static protected void clearDependencyCache() {
 		cache = null;
 	}

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -180,6 +180,10 @@ public class Settings {
 		return getConfigDir().resolve(AliasUtil.JBANG_CATALOG_JSON);
 	}
 
+	public static Path getUserImplicitCatalogFile() {
+		return getConfigDir().resolve(AliasUtil.JBANG_IMPLICIT_CATALOG_JSON);
+	}
+
 	static protected void clearDependencyCache() {
 		cache = null;
 	}

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -396,6 +396,8 @@ public class Util {
 		if (httpConn != null)
 			httpConn.disconnect();
 
+		Util.verboseMsg(String.format("Downloaded file %s", fileURL));
+
 		return saveFilePath;
 
 	}
@@ -449,6 +451,7 @@ public class Util {
 				throw th;
 			}
 		} else {
+			Util.verboseMsg(String.format("Retrieved file from cache %s = %s", fileURL, file));
 			return urlCache.resolve(file);
 		}
 	}

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -3,7 +3,6 @@ package dev.jbang.cli;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,21 +26,27 @@ abstract class BaseAliasCommand extends BaseCommand {
 	@CommandLine.Option(names = { "--file", "-f" }, description = "Path to the catalog file to use")
 	Path catalogFile;
 
-	protected Path getCatalog() {
+	protected Path getCatalog(boolean strict) {
+		Path cat;
 		if (global) {
-			return Settings.getUserCatalogFile();
-		} else if (catalogFile != null && Files.isDirectory(catalogFile)) {
-			Path defaultJbangCatalog = Paths.get(catalogFile.toString(), AliasUtil.JBANG_CATALOG_JSON);
-			Path hiddenJbangCatalog = Paths.get(catalogFile.toString(), AliasUtil.JBANG_DOT_DIR,
-					AliasUtil.JBANG_CATALOG_JSON);
-			if (!Files.exists(defaultJbangCatalog) && Files.exists(hiddenJbangCatalog)) {
-				return hiddenJbangCatalog;
-			} else {
-				return defaultJbangCatalog;
-			}
+			cat = Settings.getUserCatalogFile();
 		} else {
-			return catalogFile;
+			if (catalogFile != null && Files.isDirectory(catalogFile)) {
+				Path defaultCatalog = catalogFile.resolve(AliasUtil.JBANG_CATALOG_JSON);
+				Path hiddenCatalog = catalogFile.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
+				if (!Files.exists(defaultCatalog) && Files.exists(hiddenCatalog)) {
+					cat = hiddenCatalog;
+				} else {
+					cat = defaultCatalog;
+				}
+			} else {
+				cat = catalogFile;
+			}
+			if (strict && cat != null && !Files.isRegularFile(cat)) {
+				throw new IllegalArgumentException("Catalog file not found at: " + catalogFile);
+			}
 		}
+		return cat;
 	}
 }
 
@@ -70,11 +75,13 @@ class AliasAdd extends BaseAliasCommand {
 			throw new IllegalArgumentException(
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 		}
-		if (getCatalog() != null) {
-			AliasUtil.addAlias(null, getCatalog(), name, scriptOrFile, description, userParams, properties);
+		Path catFile = getCatalog(false);
+		if (catFile != null) {
+			AliasUtil.addAlias(null, catFile, name, scriptOrFile, description, userParams, properties);
 		} else {
-			AliasUtil.addNearestAlias(null, name, scriptOrFile, description, userParams, properties);
+			catFile = AliasUtil.addNearestAlias(null, name, scriptOrFile, description, userParams, properties);
 		}
+		info(String.format("Alias added to %s", catFile));
 		return EXIT_OK;
 	}
 }
@@ -92,14 +99,10 @@ class AliasList extends BaseAliasCommand {
 	public Integer doCall() {
 		PrintStream out = System.out;
 		AliasUtil.Catalog catalog;
-		Path cat = getCatalog();
+		Path cat = getCatalog(true);
 		if (catalogName != null) {
-			catalog = AliasUtil.getCatalogByName(catalogName, false);
+			catalog = AliasUtil.getCatalogByName(null, catalogName, false);
 		} else if (cat != null) {
-			if (!Files.exists(cat)) {
-				throw new IllegalArgumentException(
-						String.format("Invalid catalog file, file does not exist '%s'", cat));
-			}
 			catalog = AliasUtil.getCatalog(cat, false);
 		} else {
 			catalog = AliasUtil.getMergedCatalog(null);
@@ -189,12 +192,8 @@ class AliasRemove extends BaseAliasCommand {
 
 	@Override
 	public Integer doCall() {
-		final Path cat = getCatalog();
+		final Path cat = getCatalog(true);
 		if (cat != null) {
-			if (!Files.exists(cat)) {
-				throw new IllegalArgumentException(
-						String.format("Invalid catalog file, file does not exist '%s'", cat));
-			}
 			AliasUtil.removeAlias(cat, name);
 		} else {
 			AliasUtil.removeNearestAlias(null, name);

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -116,7 +116,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 				properties = alias.properties;
 				if (scriptFile == null) {
 					throw new IllegalArgumentException(
-							"Alias " + scriptResource + " from " + alias.aliases.catalogFile + " failed to resolve "
+							"Alias " + scriptResource + " from " + alias.catalog.catalogFile + " failed to resolve "
 									+ alias.scriptRef);
 				}
 			}

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -67,15 +67,12 @@ class CatalogAdd extends BaseCatalogCommand {
 			throw new IllegalArgumentException(
 					"Invalid catalog name, it should start with a letter followed by 0 or more letters, digits, underscores, hyphens or dots");
 		}
-		AliasUtil.Catalog catalog = AliasUtil.getCatalogByRef(urlOrFile, true);
-		if (description == null) {
-			description = catalog.description;
-		}
+		AliasUtil.CatalogRef ref = AliasUtil.getCatalogRefByRefOrImplicit(urlOrFile, true);
 		Path catFile = getCatalog(false);
 		if (catFile != null) {
-			AliasUtil.addCatalog(null, catFile, name, urlOrFile, description);
+			AliasUtil.addCatalog(null, catFile, name, ref.catalogRef, ref.description);
 		} else {
-			catFile = AliasUtil.addNearestCatalog(null, name, urlOrFile, description);
+			catFile = AliasUtil.addNearestCatalog(null, name, ref.catalogRef, ref.description);
 		}
 		info(String.format("Catalog added to %s", catFile));
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Random;
 
 import dev.jbang.ExitException;
 import dev.jbang.Settings;
@@ -14,6 +15,8 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "init", description = "Initialize a script.")
 public class Init extends BaseScriptCommand {
+
+	static String[] knowneditors = { "code", "eclipse", "idea", "vi", "emacs", "netbeans" };
 
 	@CommandLine.Option(names = { "--template",
 			"-t" }, description = "Init script with a java class useful for scripting", defaultValue = "hello")
@@ -38,8 +41,10 @@ public class Init extends BaseScriptCommand {
 				// file.
 				throw e;
 			}
+
 			info("File initialized. You can now run it with 'jbang " + scriptOrFile
-					+ "' or edit it using 'code `jbang edit " + scriptOrFile + "`'");
+					+ "' or edit it using 'jbang edit --open=" + knowneditors[new Random().nextInt(knowneditors.length)]
+					+ " " + scriptOrFile + "`'");
 		}
 		return EXIT_OK;
 	}

--- a/src/test/java/dev/jbang/TestUtil.java
+++ b/src/test/java/dev/jbang/TestUtil.java
@@ -3,6 +3,5 @@ package dev.jbang;
 public class TestUtil {
 	public static void clearSettingsCaches() {
 		AliasUtil.catalogCache.clear();
-		AliasUtil.catalogIndex = null;
 	}
 }

--- a/src/test/java/dev/jbang/TestUtil.java
+++ b/src/test/java/dev/jbang/TestUtil.java
@@ -3,6 +3,6 @@ package dev.jbang;
 public class TestUtil {
 	public static void clearSettingsCaches() {
 		AliasUtil.catalogCache.clear();
-		Settings.catalogInfo = null;
+		AliasUtil.catalogIndex = null;
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -120,8 +120,8 @@ public class TestAliasNearest {
 
 	@Test
 	void testList() throws IOException {
-		AliasUtil.Aliases aliases = AliasUtil.getAllAliasesFromLocalCatalogs(cwd);
-		assertThat(aliases, notNullValue());
+		AliasUtil.Catalog catalog = AliasUtil.getMergedCatalog(cwd);
+		assertThat(catalog, notNullValue());
 
 		HashSet<String> keys = new HashSet<String>(Arrays.asList(
 				"global1",
@@ -134,21 +134,21 @@ public class TestAliasNearest {
 				"dotlocal1",
 				"dotlocal2",
 				"local1"));
-		assertThat(aliases.aliases.keySet(), equalTo(keys));
+		assertThat(catalog.aliases.keySet(), equalTo(keys));
 
-		assertThat(aliases.aliases.get("global1").scriptRef, is("global1ref"));
-		assertThat(aliases.aliases.get("global2").scriptRef, is("global2inparent"));
-		assertThat(aliases.aliases.get("global3").scriptRef, is("global3indotlocal"));
-		assertThat(aliases.aliases.get("global4").scriptRef, is("global4inlocal"));
+		assertThat(catalog.aliases.get("global1").scriptRef, is("global1ref"));
+		assertThat(catalog.aliases.get("global2").scriptRef, is("global2inparent"));
+		assertThat(catalog.aliases.get("global3").scriptRef, is("global3indotlocal"));
+		assertThat(catalog.aliases.get("global4").scriptRef, is("global4inlocal"));
 
-		assertThat(aliases.aliases.get("parent1").scriptRef, is("parent1ref"));
-		assertThat(aliases.aliases.get("parent2").scriptRef, is("parent2indotlocal"));
-		assertThat(aliases.aliases.get("parent3").scriptRef, is("parent3inlocal"));
+		assertThat(catalog.aliases.get("parent1").scriptRef, is("parent1ref"));
+		assertThat(catalog.aliases.get("parent2").scriptRef, is("parent2indotlocal"));
+		assertThat(catalog.aliases.get("parent3").scriptRef, is("parent3inlocal"));
 
-		assertThat(aliases.aliases.get("dotlocal1").scriptRef, is("dotlocal1ref"));
-		assertThat(aliases.aliases.get("dotlocal2").scriptRef, is("dotlocal2inlocal"));
+		assertThat(catalog.aliases.get("dotlocal1").scriptRef, is("dotlocal1ref"));
+		assertThat(catalog.aliases.get("dotlocal2").scriptRef, is("dotlocal2inlocal"));
 
-		assertThat(aliases.aliases.get("local1").scriptRef, is("local1ref"));
+		assertThat(catalog.aliases.get("local1").scriptRef, is("local1ref"));
 	}
 
 	@Test
@@ -165,9 +165,9 @@ public class TestAliasNearest {
 		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.addNearestAlias(cwd, "new", ref, null, null, null);
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo(result));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(localCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
 	}
 
 	@Test
@@ -175,9 +175,9 @@ public class TestAliasNearest {
 		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.addAlias(cwd, Paths.get(AliasUtil.JBANG_CATALOG_JSON), "new", "dummy.java", null, null, null);
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo("dummy.java"));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(localCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo("dummy.java"));
 	}
 
 	@Test
@@ -197,9 +197,9 @@ public class TestAliasNearest {
 		AliasUtil.addNearestAlias(cwd, "new", ref, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo(result));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(dotLocalCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
 	}
 
 	@Test
@@ -222,9 +222,9 @@ public class TestAliasNearest {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo(result));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(parentCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
 	}
 
 	@Test
@@ -249,9 +249,9 @@ public class TestAliasNearest {
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(Settings.getAliasesFile(), true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo(result));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(Settings.getUserCatalogFile(), true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
 	}
 
 	@Test
@@ -259,8 +259,8 @@ public class TestAliasNearest {
 		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.removeNearestAlias(cwd, "local1");
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
-		assertThat(aliases.aliases.keySet(), not(hasItem("local1")));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(localCatalog, true);
+		assertThat(catalog.aliases.keySet(), not(hasItem("local1")));
 	}
 
 	@Test
@@ -268,8 +268,8 @@ public class TestAliasNearest {
 		Path dotLocalCatalog = cwd.resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.removeNearestAlias(cwd, "dotlocal1");
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
-		assertThat(aliases.aliases.keySet(), not(hasItem("dotlocal1")));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(dotLocalCatalog, true);
+		assertThat(catalog.aliases.keySet(), not(hasItem("dotlocal1")));
 	}
 
 	@Test
@@ -277,17 +277,17 @@ public class TestAliasNearest {
 		Path parentCatalog = cwd.getParent().resolve(AliasUtil.JBANG_DOT_DIR).resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.removeNearestAlias(cwd, "parent1");
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
-		assertThat(aliases.aliases.keySet(), not(hasItem("parent1")));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(parentCatalog, true);
+		assertThat(catalog.aliases.keySet(), not(hasItem("parent1")));
 	}
 
 	@Test
 	void testRemoveGlobal() throws IOException {
-		Path globalCatalog = Settings.getAliasesFile();
+		Path globalCatalog = Settings.getUserCatalogFile();
 		AliasUtil.removeNearestAlias(cwd, "global1");
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(globalCatalog, true);
-		assertThat(aliases.aliases.keySet(), not(hasItem("global1")));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(globalCatalog, true);
+		assertThat(catalog.aliases.keySet(), not(hasItem("global1")));
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
@@ -78,9 +78,9 @@ public class TestAliasNearestWithBaseRef {
 		Path localCatalog = cwd.resolve(AliasUtil.JBANG_CATALOG_JSON);
 		AliasUtil.addNearestAlias(cwd, "new", "scripts/local.java", null, null, null);
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(localCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo("local.java"));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(localCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo("local.java"));
 	}
 
 	@Test
@@ -91,9 +91,9 @@ public class TestAliasNearestWithBaseRef {
 		AliasUtil.addNearestAlias(cwd, "new", "scripts/local.java", null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(dotLocalCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo("local.java"));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(dotLocalCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo("local.java"));
 	}
 
 	@Test
@@ -107,9 +107,9 @@ public class TestAliasNearestWithBaseRef {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef.replace('\\', '/'), equalTo("../test/scripts/local.java"));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(parentCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef.replace('\\', '/'), equalTo("../test/scripts/local.java"));
 	}
 
 	@Test
@@ -123,9 +123,9 @@ public class TestAliasNearestWithBaseRef {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
-		AliasUtil.Aliases aliases = AliasUtil.getAliasesFromCatalogFile(parentCatalog, true);
-		assertThat(aliases.aliases.keySet(), hasItem("new"));
-		assertThat(aliases.aliases.get("new").scriptRef, equalTo("parent.java"));
+		AliasUtil.Catalog catalog = AliasUtil.getCatalog(parentCatalog, true);
+		assertThat(catalog.aliases.keySet(), hasItem("new"));
+		assertThat(catalog.aliases.get("new").scriptRef, equalTo("parent.java"));
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -16,7 +16,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import dev.jbang.AliasUtil;
-import dev.jbang.Settings;
 
 import picocli.CommandLine;
 
@@ -35,14 +34,14 @@ public class TestCatalog {
 			"  }\n" +
 			"}";
 
-	static Path catInfoFile = null;
+	static Path catsFile = null;
 	static Path testCatalogFile = null;
 
 	@BeforeEach
 	void init() throws IOException {
 		jbangTempDir.create();
 		catalogTempDir.create();
-		catInfoFile = jbangTempDir.getRoot().toPath().resolve("catalogs.json");
+		catsFile = jbangTempDir.getRoot().toPath().resolve("jbang-catalogs.json");
 		environmentVariables.set("JBANG_DIR", jbangTempDir.getRoot().getPath());
 		testCatalogFile = catalogTempDir.getRoot().toPath().resolve("test-catalog.json");
 		Files.write(testCatalogFile, testCatalog.getBytes());
@@ -66,13 +65,14 @@ public class TestCatalog {
 
 	@Test
 	void testAddSucceeded() throws IOException {
-		assertThat(Files.isRegularFile(catInfoFile), is(true));
-		String cat = new String(Files.readAllBytes(catInfoFile));
+		assertThat(Files.isRegularFile(catsFile), is(true));
+		String cat = new String(Files.readAllBytes(catsFile));
 		assertThat(cat, containsString("\"test\""));
 		assertThat(cat, containsString("test-catalog.json\""));
 
-		assertThat(Settings.getCatalogs(), hasKey("test"));
-		assertThat(Settings.getCatalogs().get("test").catalogRef, is(testCatalogFile.toAbsolutePath().toString()));
+		assertThat(AliasUtil.getCatalogIndex().catalogRefs, hasKey("test"));
+		assertThat(AliasUtil.getCatalogIndex().catalogRefs.get("test").catalogRef,
+				is(testCatalogFile.toAbsolutePath().toString()));
 	}
 
 	@Test
@@ -98,9 +98,9 @@ public class TestCatalog {
 
 	@Test
 	void testRemove() throws IOException {
-		assertThat(Settings.getCatalogs(), hasKey("test"));
+		assertThat(AliasUtil.getCatalogIndex().catalogRefs, hasKey("test"));
 		Jbang jbang = new Jbang();
 		new CommandLine(jbang).execute("catalog", "remove", "test");
-		assertThat(Settings.getCatalogs(), not(hasKey("test")));
+		assertThat(AliasUtil.getCatalogIndex().catalogRefs, not(hasKey("test")));
 	}
 }


### PR DESCRIPTION
example:

```shell
❯ jbang init t.java
[jbang] File initialized. You can now run it with 'jbang t.java' or edit it using 'jbang edit --open=idea t.java`'
❯ jbang init t2.java
[jbang] File initialized. You can now run it with 'jbang t2.java' or edit it using 'jbang edit --open=code t2.java`'
❯ jbang init t3.java
[jbang] File initialized. You can now run it with 'jbang t3.java' or edit it using 'jbang edit --open=code t3.java`'
❯ jbang init t4.java
[jbang] File initialized. You can now run it with 'jbang t4.java' or edit it using 'jbang edit --open=eclipse t4.java`'
❯ jbang init t5.java
[jbang] File initialized. You can now run it with 'jbang t5.java' or edit it using 'jbang edit --open=netbeans t5.java`'
```




<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->