### PR TITLE
fix: have random edit examples for jbang init

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -4,6 +4,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Random;
 
 import dev.jbang.ExitException;
 import dev.jbang.Settings;
@@ -14,6 +15,8 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "init", description = "Initialize a script.")
 public class Init extends BaseScriptCommand {
+
+	static String[] knowneditors = { "code", "eclipse", "idea", "vi", "emacs", "netbeans" };
 
 	@CommandLine.Option(names = { "--template",
 			"-t" }, description = "Init script with a java class useful for scripting", defaultValue = "hello")
@@ -38,8 +41,10 @@ public class Init extends BaseScriptCommand {
 				// file.
 				throw e;
 			}
+
 			info("File initialized. You can now run it with 'jbang " + scriptOrFile
-					+ "' or edit it using 'code `jbang edit " + scriptOrFile + "`'");
+					+ "' or edit it using 'jbang edit --open=" + knowneditors[new Random().nextInt(knowneditors.length)]
+					+ " " + scriptOrFile + "`'");
 		}
 		return EXIT_OK;
 	}


### PR DESCRIPTION
Fixes #310


example:

```shell
❯ jbang init t.java
[jbang] File initialized. You can now run it with 'jbang t.java' or edit it using 'jbang edit --open=idea t.java`'
❯ jbang init t2.java
[jbang] File initialized. You can now run it with 'jbang t2.java' or edit it using 'jbang edit --open=code t2.java`'
❯ jbang init t3.java
[jbang] File initialized. You can now run it with 'jbang t3.java' or edit it using 'jbang edit --open=code t3.java`'
❯ jbang init t4.java
[jbang] File initialized. You can now run it with 'jbang t4.java' or edit it using 'jbang edit --open=eclipse t4.java`'
❯ jbang init t5.java
[jbang] File initialized. You can now run it with 'jbang t5.java' or edit it using 'jbang edit --open=netbeans t5.java`'
```




<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->