### PR TITLE
chore: enable code coverage

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -77,6 +77,9 @@ jobs:
           echo "::add-matcher::.github/karatewindows-matcher.json"   
           .\itests.cmd
           echo "::remove-matcher owner=karate-windows::"
+      - name: codecoverage-report
+        run: |
+          ./gradlew jacocoTestReport
       - name: build-choco-package
         if: runner.os == 'Windows'
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -80,6 +80,12 @@ jobs:
       - name: codecoverage-report
         run: |
           ./gradlew jacocoTestReport
+      - uses: codecov/codecov-action@v2
+        with:
+          #files: ./coverage1.xml,./coverage2.xml # optional
+          flags: ${{ runner.os }} # optional
+          name: ${{ runner.os }}-tests # optional
+          verbose: true # optional (default = false)
       - name: build-choco-package
         if: runner.os == 'Windows'
         uses: actions/setup-dotnet@v1

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 	id "org.asciidoctor.jvm.convert" version "3.3.2"
 	id "org.ajoberstar.grgit" version "4.1.0"
 	id "org.sonarqube" version "3.1.1"
-
+	id 'jacoco'
 }
 
 repositories {
@@ -185,6 +185,26 @@ test {
 	//testLogging.showStandardStreams = true
 
 }
+
+jacoco {
+	toolVersion = '0.8.7'
+}
+
+jacocoTestReport {
+
+	afterEvaluate {
+		executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+	}
+
+	reports {
+		html.enabled true
+		xml.enabled  true
+		csv.enabled  false
+	}
+}
+
+
+
 
 task karateExecute(type: JavaExec) {
 	classpath = sourceSets.test.runtimeClasspath

--- a/itests/itests.cmd
+++ b/itests/itests.cmd
@@ -7,4 +7,4 @@ where jbang
 where java
 echo JAVA_HOME=%JAVA_HOME%
 
-jbang karate.java -o ..\build\karate *.feature
+jbang --javaagent=org.jacoco:org.jacoco.agent:0.8.7:runtime=destfile=..\build\jacoco\test.exec karate.java -o ..\build\karate *.feature

--- a/itests/itests.sh
+++ b/itests/itests.sh
@@ -3,4 +3,4 @@ export PATH=`realpath ../build/install/jbang/bin`:$PATH
 ## github seem to be setting this thus trying to ensure it does not affect it here.
 unset JAVA_TOOL_OPTIONS
 
-jbang ./karate.java -o ../build/karate *.feature
+jbang --javaagent=org.jacoco:org.jacoco.agent:0.8.7:runtime=destfile=../build/jacoco/test.exec ./karate.java -o ../build/karate *.feature


### PR DESCRIPTION
basic enablement of code coverage with jacoco.

we are about 60%, not bad but should get integration test included too.

just need to find a way to get the jacoco agent locatipon and set JBANG_TOOL_OPTION and it should "just" work
﻿
<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
