### PR TITLE
fix: Edit JBang start script to allow use with MSYS2

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -46,7 +46,7 @@ case "$(uname -s)" in
     os=linux;;
   Darwin*)
     os=mac;;
-  CYGWIN*|MINGW*)
+  CYGWIN*|MINGW*|MSYS*)
     os=windows;;
   *)        echo "Unsupported Operating System: $(uname -s)" 1>&2; exit 1;;
 esac


### PR DESCRIPTION
This is a fix to the JBang start script to allow it to be used with MSYS2.
This addresses the issue I created here: https://github.com/jbangdev/jbang/issues/452