### PR TITLE
fix: allow MSYS2 to pass OS check in jbang script

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -46,7 +46,7 @@ case "$(uname -s)" in
     os=linux;;
   Darwin*)
     os=mac;;
-  CYGWIN*|MINGW*)
+  CYGWIN*|MINGW*|MSYS*)
     os=windows;;
   *)        echo "Unsupported Operating System: $(uname -s)" 1>&2; exit 1;;
 esac


### PR DESCRIPTION
Using MSYS2 in Windows causes uname -s returns a string like: MSYS_NT-10.0-19041
Added MSYS* to case statement so that using MSYS2 is detected as Windows.
This is a fix for the issue I created here: https://github.com/jbangdev/jbang/issues/452