### PR TITLE
feat: Added support downloading JDK if not found on Raspberry Pi

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -58,6 +58,8 @@ case "$(uname -m)" in
     arch=x64;;
   aarch64)
     arch=aarch64;;
+  armv7l)
+    arch=arm;;
   *)
     echo "Unsupported Architecture: $(uname -m)" 1>&2; exit 1;;
 esac


### PR DESCRIPTION
Added Raspberry Pi armv7l architecture (arm) to the list of known architecture for download.
Raspberry Pi OS come without java installed, and with this addition to the architecture "list" jbang can auto download java.
I have tested with helloworld.java from the example dir on my Pi with fresh Raspberry Pi OS.