### PR TITLE
fix: handles when main file is inside a package

### DIFF
--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -74,6 +74,7 @@ public class Script {
 	private List<KeyValue> agentOptions;
 	private String preMainClass;
 	private String agentMainClass;
+
 	/**
 	 * if this script is used as an agent, agentOption is the option needed to pass
 	 * in

--- a/src/main/java/dev/jbang/ScriptResource.java
+++ b/src/main/java/dev/jbang/ScriptResource.java
@@ -1,10 +1,12 @@
 package dev.jbang;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Scanner;
 
 public class ScriptResource {
 	// original requested resource
@@ -13,11 +15,19 @@ public class ScriptResource {
 	private File sourceCacheDir;
 	// physical file it is mapped to
 	private File file;
+	// This handles when main script file is in a package.
+	// eg: /home/user/scripts/org/acme/Main.java, then
+	// originalSourceFileBaseDir = /home/user/scripts
+	private final File originalSourceFileBaseDir;
 
 	public ScriptResource(String scriptURL, File urlCache, File file) {
 		this.originalResource = scriptURL;
 		this.sourceCacheDir = urlCache;
 		this.file = file;
+		if (Util.isJavaFile(scriptURL))
+			this.originalSourceFileBaseDir = setOriginalSourceFileBaseDir(scriptURL);
+		else
+			this.originalSourceFileBaseDir = null;
 	}
 
 	public static ScriptResource forFile(File file) {
@@ -43,19 +53,49 @@ public class ScriptResource {
 	public Path fetchIfNeeded(String resource, String originalResource) {
 		if (Util.isURL(resource) || Util.isURL(originalResource)) {
 			try {
-				URI includeContext = new URI(originalResource);
-				URI thingToFetch = includeContext.resolve(resource);
+				URI thingToFetch = null;
+				if (Util.isURL(resource)) {
+					thingToFetch = new URI(resource);
+				} else {
+					URI includeContext = new URI(originalResource);
+					thingToFetch = includeContext.resolve(resource);
+				}
 				return Util.downloadAndCacheFile(thingToFetch.toString(), true);
 			} catch (URISyntaxException | IOException e) {
 				throw new IllegalStateException("Could not download " + resource + " relatively to " + originalResource,
 						e);
 			}
 		} else {
-			return file
-						.getAbsoluteFile()
-						.toPath()
-						.getParent()
-						.resolve(resource);
+			return originalSourceFileBaseDir
+											.getAbsoluteFile()
+											.toPath()
+											.resolve(resource);
 		}
+	}
+
+	private File setOriginalSourceFileBaseDir(String scriptURL) {
+		try (Scanner sc = new Scanner(new File(scriptURL))) {
+			while (sc.hasNextLine()) {
+				String line = sc.nextLine();
+				if (!line.trim().startsWith("package"))
+					continue;
+				String[] pkgLine = line.split("package");
+				if (pkgLine.length == 1)
+					continue;
+				String packageName = pkgLine[1];
+				packageName = packageName.split(";")[0].trim(); // remove ';'
+				String pkg = packageName.replace(".", File.separator); // a.b.c -> linux a/b/c, windows a\b\c
+				String pkgFile = pkg + File.separator + Util.getFileName(scriptURL);
+				return new File(scriptURL.substring(0, scriptURL.lastIndexOf(pkgFile)));
+			}
+		} catch (FileNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+		// if reached here, the script has default package
+		return new File(Util.getFilePath(scriptURL));
+	}
+
+	public File getOriginalSourceFileBaseDir() {
+		return originalSourceFileBaseDir;
 	}
 }

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -747,7 +747,27 @@ public class Util {
 	}
 
 	public static boolean isURL(String str) {
+		if (str == null)
+			return false;
 		return str.startsWith("https://") || str.startsWith("http://")
 				|| str.startsWith("file:///");
+	}
+
+	public static String getFilePath(String filePath) {
+		return filePath.substring(0, filePath.lastIndexOf(File.separator) + 1);
+	}
+
+	public static String getFileName(String filePath) {
+		return filePath.substring(filePath.lastIndexOf(File.separator) + 1);
+	}
+
+	public static boolean isFile(String str) {
+		if (str == null || str.isEmpty())
+			return false;
+		return new File(str).isFile();
+	}
+
+	public static boolean isJavaFile(String str) {
+		return isFile(str) && str.trim().endsWith(".java");
 	}
 }

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -127,6 +127,11 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			}
 			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
 
+			if (script.getScriptResource().getOriginalSourceFileBaseDir() != null) {
+				optionList.add("-sourcepath");
+				optionList.add(script.getScriptResource().getOriginalSourceFileBaseDir().toString());
+			}
+
 			// add source files to compile
 			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
 			if (script.getResolvedSourcePaths() != null) {

--- a/src/test/java/dev/jbang/TestScript.java
+++ b/src/test/java/dev/jbang/TestScript.java
@@ -7,8 +7,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +53,87 @@ class TestScript {
 			+ "\t\tout.println(\"\\nHello from Java!\");\n" + "\t\tfor (String arg : args) {\n"
 			+ "\t\t\tout.println(\"arg: $arg\");\n" + "\t\t}\n" + "\t\n" + "\t}\n" + "}";
 
+	String exampleURLInSOURCEMain = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n"
+			+ "\n"
+			+ "//JAVA 15\n"
+			+ "\n"
+			+ "//SOURCES Hi.java\n"
+			+ "//SOURCES https://gist.github.com/tivrfoa/bb5deb269de39eb8fca9636dd3c9f123#file-gsonhelper-java\n"
+			+ "//SOURCES pkg1/Bye.java\n"
+			+ "\n"
+			+ "import pkg1.Bye;\n"
+			+ "\n"
+			+ "public class Main {\n"
+			+ "	\n"
+			+ "	private static final String JSON = \"\"\"\n"
+			+ "	{\n"
+			+ "	  \"title\": \"Free Music Archive - Albums\",\n"
+			+ "	  \"message\": \"\",\n"
+			+ "	  \"errors\": [],\n"
+			+ "	  \"total\": \"11259\",\n"
+			+ "	  \"total_pages\": 2252,\n"
+			+ "	  \"page\": 1,\n"
+			+ "	  \"limit\": \"5\",\n"
+			+ "	  \"dataset\": [\n"
+			+ "		{\n"
+			+ "		  \"album_id\": \"7596\",\n"
+			+ "		  \"album_title\": \"Album 1\",\n"
+			+ "		  \"album_images\": [\n"
+			+ "			{\n"
+			+ "			  \"image_id\": \"1\",\n"
+			+ "			  \"user_id\": null\n"
+			+ "			}\n"
+			+ "		  ]\n"
+			+ "		}\n"
+			+ "	  ]\n"
+			+ "	}\n"
+			+ "	\"\"\";\n"
+			+ "\n"
+			+ "    public static void main(String... args) {\n"
+			+ "    	System.out.println(\"Testing //SOURCES url, where url \" +\n"
+			+ "				\"also contains //SOURCES and //DEPS\");\n"
+			+ "\n"
+			+ "		Hi.say();\n"
+			+ "		\n"
+			+ "		Albums albums = GsonHelper.getAlbums(JSON);\n"
+			+ "		System.out.println(albums.title);\n"
+			+ "		System.out.println(albums.dataset.get(0).album_title);\n"
+			+ "		System.out.println(albums.dataset.get(0).album_images);\n"
+			+ "\n"
+			+ "		Bye.say();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String exampleURLInSOURCEHi = "//SOURCES pkg1/Hello.java\n"
+			+ "\n"
+			+ "import pkg1.Hello;\n"
+			+ "\n"
+			+ "public class Hi {\n"
+			+ "    \n"
+			+ "    public static void say() {\n"
+			+ "		System.out.println(\"Hi!!!\");\n"
+			+ "		Hello.say();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String exampleURLInSOURCEHello = "package pkg1;\n"
+			+ "\n"
+			+ "public class Hello {\n"
+			+ "    \n"
+			+ "    public static void say() {\n"
+			+ "		System.out.println(\"Hello!!!\");\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String exampleURLInSOURCEBye = "package pkg1;\n"
+			+ "\n"
+			+ "public class Bye {\n"
+			+ "    \n"
+			+ "    public static void say() {\n"
+			+ "		System.out.println(\"Bye!!!\");\n"
+			+ "    }\n"
+			+ "}";
+
 	@Test
 	void testFindDependencies() {
 		Script script = new Script(example, null, null);
@@ -73,6 +159,37 @@ class TestScript {
 
 		assertTrue(dependencies.contains("com.offbytwo:docopt:0.6.0.20150202"));
 		assertTrue(dependencies.contains("log4j:log4j:1.2.9"));
+
+	}
+
+	@Test
+	void testFindDependenciesWithURLInSOURCE() throws IOException {
+		File urlCache = null;
+		Path mainPath = createTmpFile("", "Main.java", exampleURLInSOURCEMain);
+		createTmpFile("", "Hi.java", exampleURLInSOURCEHi);
+		createTmpFile("pkg1", "Hello.java", exampleURLInSOURCEHello);
+		createTmpFile("pkg1", "Bye.java", exampleURLInSOURCEBye);
+		String scriptURL = mainPath.toString();
+		ScriptResource scriptResource = new ScriptResource(scriptURL, urlCache, mainPath.toFile());
+		Script script = new Script(scriptResource, new ArrayList<>(), new HashMap<>());
+		List<Path> resolveSOURCESRecursively = BaseScriptCommand.resolveSOURCESRecursively(script);
+		assertTrue(resolveSOURCESRecursively.size() == 7);
+	}
+
+	private static Path createTmpFile(String strPath, String fileName, String content) throws IOException {
+		String defaultBaseDir = System.getProperty("java.io.tmpdir");
+		Path dir = Paths.get(defaultBaseDir + File.separator + strPath);
+		if (!Files.exists(dir))
+			dir = Files.createDirectory(dir);
+		Path path = dir.resolve(fileName);
+		try (BufferedWriter writer = Files.newBufferedWriter(path)) {
+			writer.write(content);
+		}
+		return path;
+	}
+
+	// TODO
+	void testSourcePathFlag() {
 
 	}
 


### PR DESCRIPTION
PR https://github.com/jbangdev/jbang/pull/469 introduced ability to search for `//SOURCES` and `//DEPS` in multiple files.
But there is one case (at least) where it doesn't work:
  1. main file is a local file that has `package` declared;
  2. It references other file(s) in `//SOURCES`  that is not in the same or child package.

Then it is not able to find the classes in the other packages because it tries to resolve their paths using the base path of the main file.

This PR does two things:
  1. it takes into account the package name and sets --source-path accordingly. eg:
      jbang /home/user/scripts/com/company/Main.java
      then --source-path will be /home/user/scripts
    This change should help cases where `//SOURCES` is not used, so javac will be able to resolve the paths. *ps: by not using `//SOURCES` you would not be able to use some of the JBang features.*
  2. it correctly resolves base path for `//SOURCES` when main file is in a package.

~~This PR does not handle `//SOURCES` with absolute path to local files. And relative paths only work if it's the same level or a sublevel of the main file.~~
The code below already works in JBang!! That is really cool!
```java
//SOURCES ../../../b.java
//SOURCES /home/leandro/dev/java/jbang/c.java

public class oi {
    
    public static void main(String args[]) {
        System.out.println("oi");
		b.say();
		c.say();
    }
}
```
```shell
leandro:distributions$ pwd
/home/leandro/dev/githubprojects/tmp-jbang/jbang/build/distributions
leandro:distributions$ rm -fR ~/.jbang/cache/jars/oi.java.*
leandro:distributions$ ./jbang/bin/jbang oi.java 
[jbang] Building jar...
oi
I am b
I am c
```