### PR TITLE
docs: Add clang-format formatting settings to FAQ

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1218,7 +1218,23 @@ By using the `//` form it is treated as both a bash/shell file AND a valid java 
 +
 It's worth noting that Go https://golangcookbook.com/chapters/running/shebang/[uses a similar approach] which is also where I learned it from.
 
+HELP! My code formatter keeps breaking my `//` directives!::
+  When using automated code formatting tools, some care and configuration must be made to prevent the tooling from rewriting and preventing `jbang` from working as expected.
++
+Use the following configuration blocks to correctly configure your tool:
++
+.Configuration Tool Settings:
+|====
+| Formatting Tool | Configuration
+
+| Clang Format
+a|
+[source]
+----
+CommentPragmas:  '^[^ ]'
+----
+|====
+
 == Thanks
 
 `jbang` was heavily inspired by how `https://github.com/holgerbrandl/kscript[kscript]` by Holger Brand works.
-


### PR DESCRIPTION
This changes adds a new FAQ section for automated configuration tool support. Currently I've only added `clang-format` as that's what I'm currently using, but we can expand this with more tool settings going forward.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
