### PR TITLE
fix: original source must be what's in ScriptResource.originalSource

### DIFF
--- a/src/main/java/dev/jbang/TrustedSources.java
+++ b/src/main/java/dev/jbang/TrustedSources.java
@@ -21,7 +21,7 @@ public class TrustedSources {
 	final static Pattern rLocalhost = Pattern.compile("(?i)^localhost(:\\d+)?$");
 	final static Pattern r127 = Pattern.compile("(?i)^127.0.0.1(:\\d+)?$");
 
-	public String trustedSources[];
+	private String trustedSources[];
 
 	public TrustedSources(String[] trustedSources) {
 		this.trustedSources = trustedSources;

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -173,7 +173,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		// Collect sources from the entry point (main file)
 		List<FileRef> fileRefs = script.collectSources();
 		for (FileRef fileRef : fileRefs) {
-			sources.add(new String[] { fileRef.getSource().getOriginalFile(), fileRef.getDestination() });
+			sources.add(new String[] { script.getScriptResource().getOriginalResource(), fileRef.getDestination() });
 		}
 
 		while (!sources.isEmpty()) {

--- a/src/main/java/dev/jbang/cli/Trust.java
+++ b/src/main/java/dev/jbang/cli/Trust.java
@@ -27,7 +27,7 @@ public class Trust {
 	public Integer list() {
 		int idx = 0;
 		PrintStream out = System.out;
-		for (String src : Settings.getTrustedSources().trustedSources) {
+		for (String src : Settings.getTrustedSources().getTrustedSources()) {
 			out.println(++idx + " = " + src);
 		}
 		return EXIT_OK;
@@ -44,7 +44,7 @@ public class Trust {
 	}
 
 	private String toDomain(String src) {
-		String[] sources = Settings.getTrustedSources().trustedSources;
+		String[] sources = Settings.getTrustedSources().getTrustedSources();
 		try {
 			int idx = Integer.parseInt(src) - 1;
 			if (idx >= 0 && idx < sources.length) {

--- a/src/test/java/dev/jbang/TestScript.java
+++ b/src/test/java/dev/jbang/TestScript.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -206,6 +207,31 @@ public class TestScript {
 	public static void writeContentToFile(Path path, String content) throws IOException {
 		try (BufferedWriter writer = Files.newBufferedWriter(path)) {
 			writer.write(content);
+		}
+	}
+
+	@Test
+	public void testSourceInGistURL(@TempDir Path temp) throws IOException {
+		String url = "https://gist.github.com/tivrfoa/8e6ea001f168fd4ef14763ceca3e5ab6#file-one-java";
+
+		File tempFile = temp.resolve("temptrust.json").toFile();
+
+		try {
+			Settings.getTrustedSources().add(url, tempFile);
+
+			Script script = prepareScript(url);
+			assertEquals(script.getResolvedSources().size(), 2);
+			boolean foundtwo = false;
+			boolean foundt3 = false;
+			for (Source source : script.getResolvedSources()) {
+				if (source.getResolvedPath().getFileName().toString().equals("two.java"))
+					foundtwo = true;
+				if (source.getResolvedPath().getFileName().toString().equals("t3.java"))
+					foundt3 = true;
+			}
+			assertTrue(foundtwo && foundt3);
+		} finally {
+			Settings.getTrustedSources().remove(Collections.singletonList(url), tempFile);
 		}
 	}
 


### PR DESCRIPTION
This PR fixes the error below:

```java
./jbang/bin/jbang --verbose https://gist.github.com/tivrfoa/8e6ea001f168fd4ef14763ceca3e5ab6#file-one-java
[jbang] Gist url api: https://api.github.com/gists/8e6ea001f168fd4ef14763ceca3e5ab6
[jbang] Downloaded file https://gist.githubusercontent.com/tivrfoa/8e6ea001f168fd4ef14763ceca3e5ab6/raw/f378d987f0f863d0b3bcecce1c91fa4290ec4816/one.java
[jbang] Gist url api: https://gist.github.com/tivrfoa/two.java
[jbang] Error when extracting file from gist url.
[jbang] [ERROR] java.io.FileNotFoundException: https://gist.github.com/tivrfoa/two.java
```

ScriptResource.originalSource has the value after swizzleURL, and that's important to find the other sources.