### PR TITLE
fix: it must allow same //SOURCES in different paths

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -180,10 +180,10 @@ public abstract class BaseScriptCommand extends BaseCommand {
 			String[] tmp = sources.remove(0);
 			String originalSource = tmp[0];
 			String destinationSource = tmp[1];
-			if (!visited.add(destinationSource))
-				continue;
 			destinationSource = Util.swizzleURL(destinationSource); // base path for new sources
 			Path path = script.getScriptResource().fetchIfNeeded(destinationSource, originalSource);
+			if (!visited.add(path.toString()))
+				continue;
 			String sourceContent = new String(Files.readAllBytes(path), Charset.defaultCharset());
 			// TODO would we not be better of with Script ref here rather than Source?
 			Source source = new Source(path, Util.getSourcePackage(sourceContent));

--- a/src/test/java/dev/jbang/TestSameSourceInDifferentPaths.java
+++ b/src/test/java/dev/jbang/TestSameSourceInDifferentPaths.java
@@ -1,0 +1,74 @@
+package dev.jbang;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.cli.BaseScriptCommand;
+
+/**
+ * Both class A and person.B have //SOURCES model/C.java
+ */
+public class TestSameSourceInDifferentPaths {
+
+	String classA = "//SOURCES person/B.java\n"
+			+ "//SOURCES model/C.java\n"
+			+ "\n"
+			+ "import person.B;\n"
+			+ "import model.C;\n"
+			+ "\n"
+			+ "public class A {\n"
+			+ "    \n"
+			+ "    public static void main(String args[]) {\n"
+			+ "        new B();\n"
+			+ "        new C();\n"
+			+ "		   new HiJbang();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String classB = "package person;\n"
+			+ "\n"
+			+ "//SOURCES model/C.java\n"
+			+ "\n"
+			+ "import person.model.C;\n"
+			+ "\n"
+			+ "public class B {\n"
+			+ "    \n"
+			+ "	public B() {\n"
+			+ "		System.out.println(\"B constructor\");\n"
+			+ "		new C();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String classModelC = "package model;\n"
+			+ "\n"
+			+ "public class C {\n"
+			+ "    \n"
+			+ "	public C() {\n"
+			+ "		System.out.println(\"C in model\");\n"
+			+ "        }\n"
+			+ "}\n";
+
+	String classPersonModelC = "package person.model;\n"
+			+ "\n"
+			+ "public class C {\n"
+			+ "    \n"
+			+ "	public C() {\n"
+			+ "		System.out.println(\"C in person.model\");\n"
+			+ "        }\n"
+			+ "}\n";
+
+	@Test
+	void testFindSourcesInMultipleFilesRecursively() throws IOException {
+		Path mainPath = TestScript.createTmpFileWithContent("", "Main.java", classA);
+		Path BPath = TestScript.createTmpFileWithContent(mainPath.getParent(), "person", "B.java", classB);
+		TestScript.createTmpFileWithContent(mainPath.getParent(), "model", "C.java", classModelC);
+		TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classPersonModelC);
+		Script script = BaseScriptCommand.prepareScript(mainPath.toString());
+		assertTrue(script.getResolvedSources().size() == 3);
+	}
+
+}

--- a/src/test/java/dev/jbang/TestSourcesMutualDependency.java
+++ b/src/test/java/dev/jbang/TestSourcesMutualDependency.java
@@ -1,0 +1,46 @@
+package dev.jbang;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.cli.BaseScriptCommand;
+
+public class TestSourcesMutualDependency {
+
+	String classMain = "//SOURCES A.java\n"
+			+ "\n"
+			+ "public class Main {    \n"
+			+ "    public static void main(String args[]) {\n"
+			+ "        new A();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String classA = "//SOURCES B.java\n"
+			+ "\n"
+			+ "public class A {\n"
+			+ "    public A() { new B(); }\n"
+			+ "}\n";
+
+	String classB = "//SOURCES A.java\n"
+			+ "\n"
+			+ "public class B {\n"
+			+ "	public B() {\n"
+			+ "		System.out.println(\"B constructor.\");\n"
+			+ "	}\n"
+			+ "}\n";
+
+	@Test
+	void testFindSourcesInMultipleFilesRecursively() throws IOException {
+		Path mainPath = TestScript.createTmpFileWithContent("", "Main.java", classMain);
+		TestScript.createTmpFileWithContent("", "A.java", classA);
+		TestScript.createTmpFileWithContent("", "B.java", classB);
+		String scriptURL = mainPath.toString();
+		Script script = BaseScriptCommand.prepareScript(scriptURL);
+		assertTrue(script.getResolvedSources().size() == 2);
+	}
+
+}


### PR DESCRIPTION

This PR fixes the logic that checks if a source was already visited.
Today it considers exactly how it's declared in the //SOURCES

eg: `//SOURCES model/C`

So in the scenario below:
```
.
├── A.java
├── model
│   └── C.java
└── person
    ├── B.java
    └── model
        └── C.java
```

This error happens:
```java
/home/leandro/dev/java/jbang/scripts/test-multiple-child-folders-package/person/B.java:5: error: package person.model does not exist
import person.model.C;
```

So the solution is to check if the full resolved path was already visited.

And why is the visited logic needed? What can go wrong if it's removed?

Two reasons:
  1. It avoids doing redundant work;
  2. It avoids a possible infinite loop if there's a mutual dependency

eg:
Main.java
```java
//SOURCES A.java

public class Main {
    
    public static void main(String args[]) {
        new A();
    }
}
```

A.java
```java
//SOURCES B.java

public class A {
    public A() { new B(); }
}
```

B.java
```java
//SOURCES A.java

public class B {
	public B() {
		System.out.println("B constructor.");
	}
}
```