### PR TITLE
refactor: Avoid loading files to look for //DEPS

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -188,6 +188,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 			// TODO would we not be better of with Script ref here rather than Source?
 			Source source = new Source(path, Util.getSourcePackage(sourceContent));
 			resolvedSourcePaths.add(source);
+			script.addSourceDependencies(sourceContent);
 
 			String refSource;
 

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -125,7 +125,8 @@ public class Edit extends BaseScriptCommand {
 
 		File originalFile = new File(script.getOriginalFile());
 
-		List<String> collectDependencies = script.collectDependencies();
+		// dependencies are already resolved by resolveClassPath
+		List<String> collectDependencies = new ArrayList<>();
 		String cp = script.resolveClassPath(offline);
 		List<String> resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
 

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -32,7 +32,6 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 		String javaVersion;
 
 		public ScriptInfo(Script script) {
-			List<String> collectDependencies = script.collectDependencies();
 			String cp = script.resolveClassPath(offline);
 
 			originalResource = script.getOriginalFile();


### PR DESCRIPTION
Today it loads files once to look for //SOURCES and package,
and then later in another place it loads all files to search for //DEPS.
This change makes it read only once, at the same place where it
searches for //SOURCES and package.

I'm also caching the call to `collectDependencies`