### PR TITLE
feat: run jar from a https url

### DIFF
--- a/src/main/java/dev/jbang/ArtifactInfo.java
+++ b/src/main/java/dev/jbang/ArtifactInfo.java
@@ -28,7 +28,7 @@ public class ArtifactInfo {
 
 	public String toString() {
 		String path = asFile().getAbsolutePath();
-		return getCoordinate().toCanonicalForm() + "=" + path;
+		return getCoordinate() == null ? "<null>" : getCoordinate().toCanonicalForm() + "=" + path;
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -265,7 +265,11 @@ public class Script {
 					classpath = new DependencyUtil().resolveDependencies(additionalDeps,
 							Collections.emptyList(), offline, !Util.isQuiet());
 				} else {
-					classpath = new ModularClassPath(Arrays.asList(new ArtifactInfo(null, new File(originalFile))));
+					if (getBackingFile() == null) {
+						classpath = new ModularClassPath(Arrays.asList(new ArtifactInfo(null, new File(originalFile))));
+					} else {
+						classpath = new ModularClassPath(Arrays.asList(new ArtifactInfo(null, getBackingFile())));
+					}
 				}
 				// fetch main class as we can't use -jar to run as it ignores classpath.
 				if (getMainClass() == null) {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -149,6 +149,31 @@ public class TestRun {
 	}
 
 	@Test
+	void testJarViaHttps(@TempDir Path tdir) throws IOException {
+
+		String jar = "https://bintray.com/cardillo/maven/download_file?file_path=joinery%2Fjoinery-dataframe%2F1.9%2Fjoinery-dataframe-1.9-jar-with-dependencies.jar";
+
+		try {
+			Settings.getTrustedSources().add(jar, tdir.resolve("test.trust").toFile());
+
+			environmentVariables.clear("JAVA_HOME");
+			Jbang jbang = new Jbang();
+
+			CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
+			Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+			Script result = prepareScript(jar, run.userParams, run.properties, run.dependencies, run.classpaths);
+
+			String cmdline = run.generateCommandLine(result);
+
+			assertThat(cmdline, not(containsString("https")));
+
+		} finally {
+			Settings.getTrustedSources().remove(Arrays.asList(jar), tdir.resolve("test.trust").toFile());
+		}
+	}
+
+	@Test
 	void testHelloWorldGAVWithNoMain() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");


### PR DESCRIPTION
Can now do `jbang https://bintray.com/cardillo/maven/download_file?file_path=joinery%2Fjoinery-dataframe%2F1.9%2Fjoinery-dataframe-1.9-jar-with-dependencies.jar`
without it resolving bad classpath.

Fixes #490



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->