### PR TITLE
fix: don't look for sources if not needed

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -127,6 +127,8 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			}
 			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
 
+			script.collectSourcesRecursively();
+
 			// add source files to compile
 			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
 			if (script.getResolvedSources() != null) {

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -146,7 +146,7 @@ public class Edit extends BaseScriptCommand {
 		Path srcFile = srcDir.toPath().resolve(name);
 		Util.createLink(srcFile, originalFile.toPath());
 
-		for (Source source : script.getResolvedSources()) {
+		for (Source source : script.collectSourcesRecursively()) {
 			File sfile = null;
 			if (source.getJavaPackage().isPresent()) {
 				File packageDir = new File(srcDir, source.getJavaPackage().get().replace(".", File.separator));

--- a/src/test/java/dev/jbang/TestSameSourceInDifferentPaths.java
+++ b/src/test/java/dev/jbang/TestSameSourceInDifferentPaths.java
@@ -68,7 +68,7 @@ public class TestSameSourceInDifferentPaths {
 		TestScript.createTmpFileWithContent(mainPath.getParent(), "model", "C.java", classModelC);
 		TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classPersonModelC);
 		Script script = BaseScriptCommand.prepareScript(mainPath.toString());
-		assertTrue(script.getResolvedSources().size() == 3);
+		assertTrue(script.collectSourcesRecursively().size() == 3);
 	}
 
 }

--- a/src/test/java/dev/jbang/TestScript.java
+++ b/src/test/java/dev/jbang/TestScript.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import dev.jbang.cli.BaseScriptCommand;
-
 public class TestScript {
 
 	String example = "//#!/usr/bin/env jbang\n" + "\n"
@@ -172,8 +170,8 @@ public class TestScript {
 		String scriptURL = mainPath.toString();
 		Script script = prepareScript(scriptURL);
 
-		List<Source> resolvesourceRecursively = BaseScriptCommand.resolvesourceRecursively(script);
-		assertTrue(resolvesourceRecursively.size() == 7);
+		List<Source> resolvedSources = script.collectSourcesRecursively();
+		assertTrue(resolvedSources.size() == 7);
 	}
 
 	public static Path createTmpFileWithContent(String strPath, String fileName, String content) throws IOException {
@@ -220,10 +218,10 @@ public class TestScript {
 			Settings.getTrustedSources().add(url, tempFile);
 
 			Script script = prepareScript(url);
-			assertEquals(script.getResolvedSources().size(), 2);
+			assertEquals(script.collectSourcesRecursively().size(), 2);
 			boolean foundtwo = false;
 			boolean foundt3 = false;
-			for (Source source : script.getResolvedSources()) {
+			for (Source source : script.collectSourcesRecursively()) {
 				if (source.getResolvedPath().getFileName().toString().equals("two.java"))
 					foundtwo = true;
 				if (source.getResolvedPath().getFileName().toString().equals("t3.java"))

--- a/src/test/java/dev/jbang/TestSourcesMutualDependency.java
+++ b/src/test/java/dev/jbang/TestSourcesMutualDependency.java
@@ -40,7 +40,7 @@ public class TestSourcesMutualDependency {
 		TestScript.createTmpFileWithContent("", "B.java", classB);
 		String scriptURL = mainPath.toString();
 		Script script = BaseScriptCommand.prepareScript(scriptURL);
-		assertTrue(script.getResolvedSources().size() == 2);
+		assertTrue(script.collectSourcesRecursively().size() == 2);
 	}
 
 }

--- a/src/test/java/dev/jbang/TestSourcesRecursivelyMultipleFiles.java
+++ b/src/test/java/dev/jbang/TestSourcesRecursivelyMultipleFiles.java
@@ -13,8 +13,6 @@ import java.util.TreeSet;
 
 import org.junit.jupiter.api.Test;
 
-import dev.jbang.cli.BaseScriptCommand;
-
 class TestSourcesRecursivelyMultipleFiles {
 
 	String classA = "//SOURCES person/B.java\n"
@@ -85,7 +83,7 @@ class TestSourcesRecursivelyMultipleFiles {
 		ScriptResource scriptResource = new ScriptResource(scriptURL, urlCache, mainPath.toFile());
 		Script script = new Script(scriptResource, new ArrayList<>(), new HashMap<>());
 		script.setOriginal(mainPath.toString());
-		List<Source> resolvesourceRecursively = BaseScriptCommand.resolvesourceRecursively(script);
+		List<Source> resolvesourceRecursively = script.collectSourcesRecursively();
 		assertTrue(resolvesourceRecursively.size() == 4);
 		TreeSet<String> fileNames = new TreeSet<>();
 		for (Source source : resolvesourceRecursively) {


### PR DESCRIPTION
If you run the command below twice, it shouldn't download the urls the second time.
And they are not used, because jbang uses the existing jar:
`jbang --verbose https://gist.github.com/tivrfoa/475c4add1b3df035d13820cb756dacfc`