### PR TITLE
refactor: `build()` now cleans up after itself

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -95,9 +95,6 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		File baseDir = Settings.getCacheDir(Settings.CacheClass.jars).toFile();
 		File tmpJarDir = new File(baseDir, script.getBackingFile().getName() +
 				"." + Util.getStableID(script.getBackingFile()));
-		if (tmpJarDir.exists() && fresh)
-			Util.deleteFolder(tmpJarDir.toPath(), true);
-		tmpJarDir.mkdirs();
 
 		File outjar = new File(tmpJarDir.getParentFile(), tmpJarDir.getName() + ".jar");
 
@@ -125,187 +122,207 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		// it allows integrations the options to produce the native image
 		if (!outjar.exists() || JavaUtil.javaVersion(requestedJavaVersion) < script.getBuildJdk()
 				|| nativeBuildRequired || fresh) {
-			List<String> optionList = new ArrayList<String>();
-			optionList.add(resolveInJavaHome("javac", requestedJavaVersion));
-			optionList.addAll(script.collectCompileOptions());
-			String path = script.resolveClassPath(offline);
-			if (!path.trim().isEmpty()) {
-				optionList.addAll(Arrays.asList("-classpath", path));
-			}
-			optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
-
-			// add source files to compile
-			optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
-			if (script.getResolvedSources() != null) {
-				optionList.addAll(
-						script	.getResolvedSources()
-								.stream()
-								.map(x -> x.getResolvedPath().toFile().getAbsolutePath())
-								.collect(Collectors.toList()));
-			}
-
-			// add additional files
-			List<FileRef> files = script.collectFiles();
-			for (FileRef file : files) {
-				file.copy(tmpJarDir.toPath(), Files.createTempDirectory(String.valueOf(System.currentTimeMillis())));
-			}
-
-			Template pomTemplate = Settings.getTemplateEngine().getTemplate("pom.qute.xml");
-
-			Path pomPath = null;
-			if (pomTemplate == null) {
-				// ignore
-				Util.warnMsg("Could not locate pom.xml template");
-			} else {
-				String pomfile = pomTemplate
-											.data("baseName", Util.getBaseName(script.getBackingFile().getName()))
-											.data("dependencies", script.getClassPath().getArtifacts())
-											.render();
-				pomPath = new File(tmpJarDir, "META-INF/maven/g/a/v/pom.xml").toPath();
-				Files.createDirectories(pomPath.getParent());
-				Util.writeString(pomPath, pomfile);
-			}
-
-			info("Building jar...");
-			debug("compile: " + String.join(" ", optionList));
-
-			Process process = new ProcessBuilder(optionList).inheritIO().start();
+			// set up temporary folder for compilation
+			Util.deleteFolder(tmpJarDir.toPath(), true);
+			tmpJarDir.mkdirs();
 			try {
-				process.waitFor();
-			} catch (InterruptedException e) {
-				throw new ExitException(1, e);
+				integrationResult = buildJar(script, tmpJarDir, outjar, requestedJavaVersion);
+			} finally {
+				// clean up temporary folder
+				Util.deleteFolder(tmpJarDir.toPath(), true);
 			}
-
-			if (process.exitValue() != 0) {
-				throw new ExitException(1, "Error during compile");
-			}
-
-			script.setBuildJdk(JavaUtil.javaVersion(requestedJavaVersion));
-			integrationResult = IntegrationManager.runIntegration(script.getRepositories(),
-					script.getClassPath().getArtifacts(),
-					tmpJarDir.toPath(), pomPath,
-					script, nativeImage);
-			if (integrationResult.mainClass != null) {
-				script.setMainClass(integrationResult.mainClass);
-			} else {
-				try {
-					// using Files.walk method with try-with-resources
-					try (Stream<Path> paths = Files.walk(tmpJarDir.toPath())) {
-						List<Path> items = paths.filter(Files::isRegularFile)
-												.filter(f -> !f.toFile().getName().contains("$"))
-												.filter(f -> f.toFile().getName().endsWith(".class"))
-												.collect(Collectors.toList());
-
-						if (items.size() > 1) { // todo: this feels like a very sketchy way to find the proper class
-												// name
-							// but it works.
-							String mainname = script.getBackingFile().getName().replace(".java", ".class");
-							items = items	.stream()
-											.filter(f -> f.toFile().getName().equalsIgnoreCase(mainname))
-											.collect(Collectors.toList());
-						}
-
-						if (items.size() != 1) {
-							throw new ExitException(1,
-									"Could not locate unique class. Found " + items.size() + " candidates.");
-						} else {
-							Path classfile = items.get(0);
-							// TODO: could we use jandex to find the right main class more sanely ?
-							// String mainClass = findMainClass(tmpJarDir.toPath(), classfile);
-
-							Indexer indexer = new Indexer();
-							InputStream stream = new FileInputStream(classfile.toFile());
-							indexer.index(stream);
-							Index index = indexer.complete();
-
-							Collection<ClassInfo> clazz = index.getKnownClasses();
-
-							Optional<ClassInfo> main = clazz.stream()
-															.filter(pubClass -> pubClass.method("main",
-																	STRINGARRAYTYPE) != null)
-															.findFirst();
-
-							if (main.isPresent()) {
-								script.setMainClass(main.get().name().toString());
-							}
-
-							if (script.isAgent()) {
-
-								Optional<ClassInfo> agentmain = clazz	.stream()
-																		.filter(pubClass -> pubClass.method("agentmain",
-																				STRINGTYPE,
-																				INSTRUMENTATIONTYPE) != null
-																				||
-																				pubClass.method("agentmain",
-																						STRINGTYPE) != null)
-																		.findFirst();
-
-								if (agentmain.isPresent()) {
-									script.setAgentMainClass(agentmain.get().name().toString());
-								}
-
-								Optional<ClassInfo> premain = clazz	.stream()
-																	.filter(pubClass -> pubClass.method("premain",
-																			STRINGTYPE,
-																			INSTRUMENTATIONTYPE) != null
-																			||
-																			pubClass.method("premain",
-																					STRINGTYPE) != null)
-																	.findFirst();
-
-								if (premain.isPresent()) {
-									script.setPreMainClass(premain.get().name().toString());
-								}
-							}
-
-						}
-					}
-				} catch (IOException e) {
-					throw new ExitException(1, e);
-				}
-			}
-			script.setPersistentJvmArgs(integrationResult.javaArgs);
-			script.createJarFile(tmpJarDir, outjar);
 		}
 
 		if (nativeBuildRequired) {
 			if (integrationResult.nativeImagePath != null) {
 				Files.move(integrationResult.nativeImagePath, getImageName(outjar).toPath());
 			} else {
-				List<String> optionList = new ArrayList<String>();
-				optionList.add(resolveInGraalVMHome("native-image", requestedJavaVersion));
-
-				optionList.add("-H:+ReportExceptionStackTraces");
-
-				optionList.add("--enable-https");
-
-				String classpath = script.resolveClassPath(offline);
-				if (!classpath.trim().isEmpty()) {
-					optionList.add("--class-path=" + classpath);
-				}
-
-				optionList.add("-jar");
-				optionList.add(outjar.toString());
-
-				optionList.add(getImageName(outjar).toString());
-
-				File nilog = File.createTempFile("jbang", "native-image");
-				debug("native-image: " + String.join(" ", optionList));
-				info("log: " + nilog.toString());
-
-				Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog).start();
-				try {
-					process.waitFor();
-				} catch (InterruptedException e) {
-					throw new ExitException(1, e);
-				}
-
-				if (process.exitValue() != 0) {
-					throw new ExitException(1, "Error during native-image");
-				}
+				buildNative(script, outjar, requestedJavaVersion);
 			}
 		}
+
 		script.setJar(outjar);
+	}
+
+	private IntegrationResult buildJar(Script script, File tmpJarDir, File outjar, String requestedJavaVersion)
+			throws IOException {
+		IntegrationResult integrationResult;
+		List<String> optionList = new ArrayList<String>();
+		optionList.add(resolveInJavaHome("javac", requestedJavaVersion));
+		optionList.addAll(script.collectCompileOptions());
+		String path = script.resolveClassPath(offline);
+		if (!path.trim().isEmpty()) {
+			optionList.addAll(Arrays.asList("-classpath", path));
+		}
+		optionList.addAll(Arrays.asList("-d", tmpJarDir.getAbsolutePath()));
+
+		// add source files to compile
+		optionList.addAll(Arrays.asList(script.getBackingFile().getPath()));
+		if (script.getResolvedSources() != null) {
+			optionList.addAll(
+					script	.getResolvedSources()
+							.stream()
+							.map(x -> x.getResolvedPath().toFile().getAbsolutePath())
+							.collect(Collectors.toList()));
+		}
+
+		// add additional files
+		List<FileRef> files = script.collectFiles();
+		for (FileRef file : files) {
+			file.copy(tmpJarDir.toPath(), Files.createTempDirectory(String.valueOf(System.currentTimeMillis())));
+		}
+
+		Template pomTemplate = Settings.getTemplateEngine().getTemplate("pom.qute.xml");
+
+		Path pomPath = null;
+		if (pomTemplate == null) {
+			// ignore
+			Util.warnMsg("Could not locate pom.xml template");
+		} else {
+			String pomfile = pomTemplate
+										.data("baseName", Util.getBaseName(script.getBackingFile().getName()))
+										.data("dependencies", script.getClassPath().getArtifacts())
+										.render();
+			pomPath = new File(tmpJarDir, "META-INF/maven/g/a/v/pom.xml").toPath();
+			Files.createDirectories(pomPath.getParent());
+			Util.writeString(pomPath, pomfile);
+		}
+
+		info("Building jar...");
+		debug("compile: " + String.join(" ", optionList));
+
+		Process process = new ProcessBuilder(optionList).inheritIO().start();
+		try {
+			process.waitFor();
+		} catch (InterruptedException e) {
+			throw new ExitException(1, e);
+		}
+
+		if (process.exitValue() != 0) {
+			throw new ExitException(1, "Error during compile");
+		}
+
+		script.setBuildJdk(JavaUtil.javaVersion(requestedJavaVersion));
+		integrationResult = IntegrationManager.runIntegration(script.getRepositories(),
+				script.getClassPath().getArtifacts(),
+				tmpJarDir.toPath(), pomPath,
+				script, nativeImage);
+		if (integrationResult.mainClass != null) {
+			script.setMainClass(integrationResult.mainClass);
+		} else {
+			try {
+				// using Files.walk method with try-with-resources
+				try (Stream<Path> paths = Files.walk(tmpJarDir.toPath())) {
+					List<Path> items = paths.filter(Files::isRegularFile)
+											.filter(f -> !f.toFile().getName().contains("$"))
+											.filter(f -> f.toFile().getName().endsWith(".class"))
+											.collect(Collectors.toList());
+
+					if (items.size() > 1) { // todo: this feels like a very sketchy way to find the proper class
+											// name
+						// but it works.
+						String mainname = script.getBackingFile().getName().replace(".java", ".class");
+						items = items	.stream()
+										.filter(f -> f.toFile().getName().equalsIgnoreCase(mainname))
+										.collect(Collectors.toList());
+					}
+
+					if (items.size() != 1) {
+						throw new ExitException(1,
+								"Could not locate unique class. Found " + items.size() + " candidates.");
+					} else {
+						Path classfile = items.get(0);
+						// TODO: could we use jandex to find the right main class more sanely ?
+						// String mainClass = findMainClass(tmpJarDir.toPath(), classfile);
+
+						Indexer indexer = new Indexer();
+						InputStream stream = new FileInputStream(classfile.toFile());
+						indexer.index(stream);
+						Index index = indexer.complete();
+
+						Collection<ClassInfo> clazz = index.getKnownClasses();
+
+						Optional<ClassInfo> main = clazz.stream()
+														.filter(pubClass -> pubClass.method("main",
+																STRINGARRAYTYPE) != null)
+														.findFirst();
+
+						if (main.isPresent()) {
+							script.setMainClass(main.get().name().toString());
+						}
+
+						if (script.isAgent()) {
+
+							Optional<ClassInfo> agentmain = clazz	.stream()
+																	.filter(pubClass -> pubClass.method("agentmain",
+																			STRINGTYPE,
+																			INSTRUMENTATIONTYPE) != null
+																			||
+																			pubClass.method("agentmain",
+																					STRINGTYPE) != null)
+																	.findFirst();
+
+							if (agentmain.isPresent()) {
+								script.setAgentMainClass(agentmain.get().name().toString());
+							}
+
+							Optional<ClassInfo> premain = clazz	.stream()
+																.filter(pubClass -> pubClass.method("premain",
+																		STRINGTYPE,
+																		INSTRUMENTATIONTYPE) != null
+																		||
+																		pubClass.method("premain",
+																				STRINGTYPE) != null)
+																.findFirst();
+
+							if (premain.isPresent()) {
+								script.setPreMainClass(premain.get().name().toString());
+							}
+						}
+
+					}
+				}
+			} catch (IOException e) {
+				throw new ExitException(1, e);
+			}
+		}
+		script.setPersistentJvmArgs(integrationResult.javaArgs);
+		script.createJarFile(tmpJarDir, outjar);
+		return integrationResult;
+	}
+
+	private void buildNative(Script script, File outjar, String requestedJavaVersion) throws IOException {
+		List<String> optionList = new ArrayList<String>();
+		optionList.add(resolveInGraalVMHome("native-image", requestedJavaVersion));
+
+		optionList.add("-H:+ReportExceptionStackTraces");
+
+		optionList.add("--enable-https");
+
+		String classpath = script.resolveClassPath(offline);
+		if (!classpath.trim().isEmpty()) {
+			optionList.add("--class-path=" + classpath);
+		}
+
+		optionList.add("-jar");
+		optionList.add(outjar.toString());
+
+		optionList.add(getImageName(outjar).toString());
+
+		File nilog = File.createTempFile("jbang", "native-image");
+		debug("native-image: " + String.join(" ", optionList));
+		info("log: " + nilog.toString());
+
+		Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog).start();
+		try {
+			process.waitFor();
+		} catch (InterruptedException e) {
+			throw new ExitException(1, e);
+		}
+
+		if (process.exitValue() != 0) {
+			throw new ExitException(1, "Error during native-image");
+		}
 	}
 
 	/** based on jar what will the binary image name be. **/


### PR DESCRIPTION
Just a minor refactor so it's easier to have `build()` clean up after itself.

It now deletes the directory with sources that was used to compile and create the JAR file.