### PR TITLE
fix: use shell comment in direct run example

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -299,7 +299,7 @@ Below is an (almost) minimal example you can save in `helloworld.java` or simply
 
 [source,java]
 ----
-///usr/bin/env jbang "$0" "$@" ; exit $? // <.>
+///usr/bin/env jbang "$0" "$@" ; exit $? # <.>
 
 class helloworld { // <.>
 


### PR DESCRIPTION
Just a minor thing.
It's because I copied and pasted and got the error:
```
./A.java 
./A.java: line 1: syntax error near unexpected token `('
./A.java: line 1: `///usr/bin/env jbang "$0" "$@" ; exit $? // (1)'
```
Changing it to shell comment it works.
wdyt?