### PR TITLE
docs: Clarify how to install the native-image utility binary

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -391,8 +391,11 @@ There is support for using `native-image` from GraalVM project to produce a bina
 
 Since not all java libraries can automatically be built with `native-image` - especially if using reflection feature are considered highly experimental.
 
-Just run `jbang --native helloworld.java` and `jbang` will use `native-image` from either `JAVA_HOME/bin` or `GRAALVM_HOME/bin` to
+Just run `jbang --native helloworld.java` and `jbang` will use `native-image` from either `$JAVA_HOME/bin` or `$GRAALVM_HOME/bin` or `$PATH` to
 produce a native image binary.
+
+You can install the `native-image` utility binary e.g. by installing GraalVM from https://www.graalvm.org/downloads, and then once running `gu install native-image` as per https://www.graalvm.org/reference-manual/native-image.
+
 
 [TIP]
 ====


### PR DESCRIPTION
This wasn't super obvious to me at first and took me a second to figure out - perhaps it's useful to explicitly document this here.

If there is an easier way, especially e.g. for Fedora users, let's add that here as well? (What was that GraalVM distribution from Red Hat again?)