### PR TITLE
docs: Clarify that .jsh are not cached and no native support (fixes #506)

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -424,6 +424,8 @@ The script will have the output:
  Hello World
  value
 
+Please note that `.jsh` files are not cached ([#506](https://github.com/jbangdev/jbang/issues/506)) and cannot be built as native images ([#510](https://github.com/jbangdev/jbang/issues/510)).
+
 
 ==== Running script from standard input
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -424,7 +424,7 @@ The script will have the output:
  Hello World
  value
 
-Please note that `.jsh` files are not cached ([#506](https://github.com/jbangdev/jbang/issues/506)) and cannot be built as native images ([#510](https://github.com/jbangdev/jbang/issues/510)).
+Please note that `.jsh` files are source only, they are not compiled thus they are https://github.com/jbangdev/jbang/issues/506[not cached] nor can they be https://github.com/jbangdev/jbang/issues/510[built as native images].
 
 
 ==== Running script from standard input


### PR DESCRIPTION
fixes #506

also mentions no native image support for .jsh (re. #510)