### PR TITLE
fix(#18): enable gradle run

### DIFF
--- a/src/main/resources/build.qute.gradle
+++ b/src/main/resources/build.qute.gradle
@@ -1,14 +1,21 @@
-apply plugin: 'java'
+plugins {
+	id 'java'
+	id 'application'
+}
 
 repositories {
 	mavenLocal()
-		jcenter()
+	jcenter()
 }
 
 dependencies {
-		{#for item in dependencies}
-			compile "{item}"
-		{/for}
+{#for item in dependencies}
+	compile "{item}"
+{/for}
+}
+
+application {
+	mainClass = '{baseName}'
 }
 
 sourceSets.main.java.srcDirs 'src'

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -102,7 +102,10 @@ public class TestEdit {
 
 		File gradle = new File(project, "build.gradle");
 		assert (gradle.exists());
-		assertThat(Util.readString(gradle.toPath()), not(containsString("bogus")));
+		String buildGradle = Util.readString(gradle.toPath());
+		assertThat(buildGradle, not(containsString("bogus")));
+		assertThat(buildGradle, containsString("id 'application'"));
+		assertThat(buildGradle, containsString("mainClass = 'edit'"));
 
 		File java = new File(project, "src/edit.java");
 


### PR DESCRIPTION
Without the support of `gradle run`, first users could be a little bit disappointed if they are used to execute:
![image](https://user-images.githubusercontent.com/1235009/99512411-b6db0f00-2989-11eb-84b0-7c4615254248.png)
Or if in the terminal of their IDE they try `./gradlew run` instead of `./gradlew build`

The fix also removes redundant tabs in `build.gradle`.

**Before**
```
apply plugin: 'java'

repositories {
	mavenLocal()
		jcenter()
}

dependencies {
			compile "org.openjfx:javafx-graphics:11.0.2"
}

sourceSets.main.java.srcDirs 'src'
sourceSets.test.java.srcDirs 'src'
```

**After**
```
plugins {
	id 'java'
	id 'application'
}

repositories {
	mavenLocal()
	jcenter()
}

dependencies {
	compile "org.openjfx:javafx-graphics:11.0.2"
}

application {
	mainClass = 'edit'
}

sourceSets.main.java.srcDirs 'src'
sourceSets.test.java.srcDirs 'src'
```





