### PR TITLE
fix(#519): Fix disabled ::add-path:: command in ci-build

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
           ./test_suite.sh
           ./itests.sh
       - name: add-to-path
-        run: echo "::add-path::../build/install/jbang/bin"
+        run: echo "../build/install/jbang/bin" >> $env:GITHUB_PATH
       - name: integration-test-windows
         if: runner.os == 'Windows'
         working-directory: itests


### PR DESCRIPTION
The ci-build / build-and-testing job is failing at add-to-path because the ::add-path:: is now disabled.
See #519 