### PR TITLE
fix: long classpath problem on Windows

### DIFF
--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -915,11 +915,8 @@ public class TestRun {
 
 		assertThat(result, containsString("-javaagent"));
 		assertThat(result, containsString("=optionA"));
-
 		assertThat(result, containsString("byteman"));
-
 		assertThat(result, not(containsString("null")));
-
 	}
 
 	@Test


### PR DESCRIPTION
It uses @argument file if it's Windows and Java version >= 9

fixes #476 