### PR TITLE
Fixes two jsh issues

### DIFF
--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -19,3 +19,8 @@ Then match out == "hello\n"
 Scenario: jsh quoted system property
 When command('jbang -Dvalue="a quoted" hello.jsh')
 Then match out == "a quoted\n"
+
+
+Scenario: jsh fail on --native
+  When command('jbang --native hello.jsh')
+  Then match err contains ".jsh cannot be used with --native. Please remove --native and try again."

--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -23,4 +23,4 @@ Then match out == "a quoted\n"
 
 Scenario: jsh fail on --native
   When command('jbang --native hello.jsh')
-  Then match err contains ".jsh cannot be used with --native. Please remove --native and try again."
+  Then match err contains ".jsh cannot be used with --native"

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -1,7 +1,5 @@
 package dev.jbang;
 
-import static dev.jbang.FileRef.isURL;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -23,6 +21,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static dev.jbang.FileRef.isURL;
 
 public class Script {
 
@@ -95,7 +95,7 @@ public class Script {
 		if (!forJar()) {
 			try (Scanner sc = new Scanner(this.getBackingFile())) {
 				sc.useDelimiter("\\Z");
-				this.script = sc.next();
+				this.script = sc.hasNext() ? sc.next() : "";
 			}
 		}
 	}

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -1,5 +1,7 @@
 package dev.jbang;
 
+import static dev.jbang.FileRef.isURL;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -21,8 +23,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static dev.jbang.FileRef.isURL;
 
 public class Script {
 

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -115,11 +115,6 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			}
 		}
 
-		if (nativeImage && script.forJShell()) {
-			throw new ExitException(EXIT_INVALID_INPUT,
-					".jsh cannot be used with --native. Please remove --native and try again.");
-		}
-
 		boolean nativeBuildRequired = nativeImage && !getImageName(outjar).exists();
 		IntegrationResult integrationResult = new IntegrationResult(null, null, null);
 		String requestedJavaVersion = javaVersion != null ? javaVersion : script.javaVersion();

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -115,6 +115,11 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			}
 		}
 
+		if (nativeImage && script.forJShell()) {
+			throw new ExitException(EXIT_INVALID_INPUT,
+					".jsh cannot be used with --native. Please remove --native and try again.");
+		}
+
 		boolean nativeBuildRequired = nativeImage && !getImageName(outjar).exists();
 		IntegrationResult integrationResult = new IntegrationResult(null, null, null);
 		String requestedJavaVersion = javaVersion != null ? javaVersion : script.javaVersion();

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -93,9 +93,10 @@ public class Run extends BaseBuildCommand {
 		List<String> fullArgs = new ArrayList<>();
 
 		if (nativeImage && script.forJShell()) {
-			throw new ExitException(EXIT_INVALID_INPUT,
-					".jsh cannot be used with --native. Please remove --native and try again.");
+			warn(".jsh cannot be used with --native thus ignoring --native.");
+			nativeImage = false;
 		}
+
 		if (nativeImage) {
 			String imagename = getImageName(script.getJar()).toString();
 			if (new File(imagename).exists()) {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -92,6 +92,10 @@ public class Run extends BaseBuildCommand {
 
 		List<String> fullArgs = new ArrayList<>();
 
+		if (nativeImage && script.forJShell()) {
+			throw new ExitException(EXIT_INVALID_INPUT,
+					".jsh cannot be used with --native. Please remove --native and try again.");
+		}
 		if (nativeImage) {
 			String imagename = getImageName(script.getJar()).toString();
 			if (new File(imagename).exists()) {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -124,6 +124,29 @@ public class TestRun {
 	}
 
 	@Test
+	void testEmptyInteractiveShell(@TempDir File dir) throws IOException {
+
+		environmentVariables.clear("JAVA_HOME");
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "a");
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		File empty = new File(dir, "empty.jsh");
+		empty.createNewFile();
+
+		Script s = prepareScript(empty.toString(), run.userParams, run.properties, run.dependencies, run.classpaths);
+
+		String result = run.generateCommandLine(s);
+
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, not(containsString("  ")));
+		assertThat(result, containsString("empty.jsh"));
+		assertThat(result, not(containsString("--source 11")));
+		assertThat(result, containsString("--startup=DEFAULT"));
+		assertThat(result, matchesPattern(".*--startup=[^ ]*empty.jsh.*"));
+	}
+
+	@Test
 	void testHelloWorldJar() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");


### PR DESCRIPTION
- error instead of 'null' when --native is used.
 - don't fail on empty .jsh when doing --interactive
 



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->