### PR TITLE
docs: Make sure zero-install on Windows always works

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -291,10 +291,10 @@ Windows Powershell:
 
 [source, powershell]
 ----
-iex "& { $(iwr https://ps.jbang.dev) } <arguments>"
+iex "& { $(iwr -useb https://ps.jbang.dev) } <arguments>"
 ----
 
-For example `iex "& { $(iwr https://ps.jbang.dev) } properties@jbangdev"`
+For example `iex "& { $(iwr -useb https://ps.jbang.dev) } properties@jbangdev"`
 
 == Usage
 


### PR DESCRIPTION
with the `-useb` (short for `-UseBasicParsing`) we can make sure that it will always run correctly