### PR TITLE
fix: attempt of a more explicit edit message

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -45,8 +45,9 @@ public class Init extends BaseScriptCommand {
 			}
 
 			info("File initialized. You can now run it with 'jbang " + scriptOrFile
-					+ "' or edit it using 'jbang edit --open=" + knowneditors[new Random().nextInt(knowneditors.length)]
-					+ " " + scriptOrFile + "`'");
+					+ "' or edit it using 'jbang edit --open=[editor] "
+					+ scriptOrFile + "' where [editor] is your editor or IDE, e.g. '"
+					+ knowneditors[new Random().nextInt(knowneditors.length)] + "'");
 		}
 		return EXIT_OK;
 	}


### PR DESCRIPTION
Fixes #551

Now `jbang init test2.java` prints: 

`[jbang] File initialized. You can now run it with 'jbang test2.java' or edit it using 'jbang edit --open=[editor] test2.java' where [editor] is your editor or IDE, e.g. 'code'`

the editor is one of the known supported ones (code, idea, eclipse, etc.)
ok or too short ? 
<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
