### PR TITLE
Jar output via jbang export

### DIFF
--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -64,7 +64,7 @@ public class AliasUtil {
 		 */
 		public String resolve(Path cwd) {
 			if (cwd == null) {
-				cwd = getCwd();
+				cwd = Util.getCwd();
 			}
 			String baseRef = catalog.getScriptBase();
 			String ref = scriptRef;
@@ -384,7 +384,7 @@ public class AliasUtil {
 			List<String> arguments,
 			Map<String, String> properties) {
 		if (cwd == null) {
-			cwd = getCwd();
+			cwd = Util.getCwd();
 		}
 		catalogFile = cwd.resolve(catalogFile);
 		Catalog catalog = getCatalog(catalogFile, true);
@@ -531,7 +531,7 @@ public class AliasUtil {
 	 */
 	public static Catalog getMergedCatalog(Path cwd, boolean includeImplicits) {
 		if (cwd == null) {
-			cwd = getCwd();
+			cwd = Util.getCwd();
 		}
 		Catalog result = new Catalog(null, null, null);
 		if (includeImplicits) {
@@ -656,7 +656,7 @@ public class AliasUtil {
 	public static CatalogRef addCatalog(Path cwd, Path catalogFile, String name, String catalogRef,
 			String description) {
 		if (cwd == null) {
-			cwd = getCwd();
+			cwd = Util.getCwd();
 		}
 		catalogFile = cwd.resolve(catalogFile);
 		Catalog catalog = getCatalog(catalogFile, true);
@@ -715,7 +715,7 @@ public class AliasUtil {
 
 	private static Path findNearestFileWith(Path dir, String fileName, Function<Path, Boolean> accept) {
 		if (dir == null) {
-			dir = getCwd();
+			dir = Util.getCwd();
 		}
 		while (dir != null) {
 			Path catalog = dir.resolve(fileName);
@@ -758,7 +758,4 @@ public class AliasUtil {
 						.flatMap(o -> o.map(Stream::of).orElseGet(Stream::empty));
 	}
 
-	private static Path getCwd() {
-		return Paths.get("").toAbsolutePath();
-	}
 }

--- a/src/main/java/dev/jbang/ModularClassPath.java
+++ b/src/main/java/dev/jbang/ModularClassPath.java
@@ -14,6 +14,7 @@ public class ModularClassPath {
 	static final String JAVAFX_PREFIX = "javafx";
 
 	private String classPath;
+	private String manifestPath;
 	private final List<ArtifactInfo> artifacts;
 	private Optional<Boolean> javafx = Optional.empty();
 
@@ -31,6 +32,18 @@ public class ModularClassPath {
 		}
 
 		return classPath;
+	}
+
+	public String getManifestPath() {
+		if (manifestPath == null) {
+			manifestPath = artifacts.stream()
+									.map(it -> it.asFile().getAbsoluteFile().toURI())
+									.map(it -> it.getPath())
+									.distinct()
+									.collect(Collectors.joining(" "));
+		}
+
+		return manifestPath;
 	}
 
 	boolean hasJavaFX() {

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -921,4 +921,8 @@ public class Util {
 		return false;
 	}
 
+	public static Path getCwd() {
+		return Paths.get("").toAbsolutePath();
+	}
+
 }

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -346,10 +346,11 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 				manifest.getMainAttributes().put(k, v);
 			}
 
-			String bootClasspath = script.getClassPath().getClassPath().replace(Settings.CP_SEPARATOR, " ");
-			if (!bootClasspath.isEmpty()) {
-				manifest.getMainAttributes()
-						.put(new Attributes.Name("Boot-Class-Path"), script.getClassPath().getClassPath());
+			if (script.getClassPath() != null) {
+				String bootClasspath = script.getClassPath().getManifestPath();
+				if (!bootClasspath.isEmpty()) {
+					manifest.getMainAttributes().put(new Attributes.Name("Boot-Class-Path"), bootClasspath);
+				}
 			}
 		}
 

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -352,6 +352,13 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 					manifest.getMainAttributes().put(new Attributes.Name("Boot-Class-Path"), bootClasspath);
 				}
 			}
+		} else {
+			if (script.getClassPath() != null) {
+				String classpath = script.getClassPath().getManifestPath();
+				if (!classpath.isEmpty()) {
+					manifest.getMainAttributes().put(new Attributes.Name("Class-Path"), classpath);
+				}
+			}
 		}
 
 		if (script.getPersistentJvmArgs() != null) {

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
+import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,15 +28,7 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
-import dev.jbang.ExitException;
-import dev.jbang.FileRef;
-import dev.jbang.IntegrationManager;
-import dev.jbang.IntegrationResult;
-import dev.jbang.JavaUtil;
-import dev.jbang.JdkManager;
-import dev.jbang.Script;
-import dev.jbang.Settings;
-import dev.jbang.Util;
+import dev.jbang.*;
 
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
@@ -89,6 +82,8 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	boolean fresh;
 
 	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
+
+	protected boolean createdJar;
 
 	// build with javac and then jar... todo: split up in more testable chunks
 	void build(Script script) throws IOException {
@@ -287,7 +282,8 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			}
 		}
 		script.setPersistentJvmArgs(integrationResult.javaArgs);
-		script.createJarFile(tmpJarDir, outjar);
+		createJarFile(script, tmpJarDir, outjar);
+		createdJar = true;
 		return integrationResult;
 	}
 
@@ -325,8 +321,55 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		}
 	}
 
+	static void createJarFile(Script script, File path, File output) throws IOException {
+		String mainclass = script.getMainClass();
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		if (mainclass != null) {
+			manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, mainclass);
+		}
+
+		if (script.isAgent()) {
+			if (script.getPreMainClass() != null) {
+				manifest.getMainAttributes().put(new Attributes.Name("Premain-Class"), script.getPreMainClass());
+			}
+			if (script.getAgentMainClass() != null) {
+				manifest.getMainAttributes().put(new Attributes.Name("Agent-Class"), script.getAgentMainClass());
+			}
+
+			for (KeyValue kv : script.getAgentOptions()) {
+				if (kv.getKey().trim().isEmpty()) {
+					continue;
+				}
+				Attributes.Name k = new Attributes.Name(kv.getKey());
+				String v = kv.getValue() == null ? "true" : kv.getValue();
+				manifest.getMainAttributes().put(k, v);
+			}
+
+			String bootClasspath = script.getClassPath().getClassPath().replace(Settings.CP_SEPARATOR, " ");
+			if (!bootClasspath.isEmpty()) {
+				manifest.getMainAttributes()
+						.put(new Attributes.Name("Boot-Class-Path"), script.getClassPath().getClassPath());
+			}
+		}
+
+		if (script.getPersistentJvmArgs() != null) {
+			manifest.getMainAttributes()
+					.putValue("JBang-Java-Options", String.join(" ", script.getPersistentJvmArgs()));
+		}
+		int buildJdk = script.getBuildJdk();
+		if (buildJdk > 0) {
+			String val = buildJdk >= 9 ? Integer.toString(buildJdk) : "1." + buildJdk;
+			manifest.getMainAttributes().putValue("Build-Jdk", val);
+		}
+
+		FileOutputStream target = new FileOutputStream(output);
+		JarUtil.jar(target, path.listFiles(), null, null, manifest);
+		target.close();
+	}
+
 	/** based on jar what will the binary image name be. **/
-	protected File getImageName(File outjar) {
+	static protected File getImageName(File outjar) {
 		if (Util.isWindows()) {
 			return new File(outjar.toString() + ".exe");
 		} else {
@@ -343,7 +386,7 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		return mainClass.toString();
 	}
 
-	String resolveInJavaHome(String cmd, String requestedVersion) {
+	protected static String resolveInJavaHome(String cmd, String requestedVersion) {
 		Path jdkHome = JdkManager.getCurrentJdk(requestedVersion);
 		if (jdkHome != null) {
 			if (Util.isWindows()) {
@@ -354,7 +397,7 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		return cmd;
 	}
 
-	String resolveInGraalVMHome(String cmd, String requestedVersion) {
+	private static String resolveInGraalVMHome(String cmd, String requestedVersion) {
 		String newcmd = resolveInEnv("GRAALVM_HOME", cmd);
 
 		if (newcmd.equals(cmd) &&

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -59,9 +59,6 @@ public abstract class BaseScriptCommand extends BaseCommand {
 	@CommandLine.Parameters(index = "0", arity = "1", description = "A file with java code or if named .jsh will be run with jshell")
 	String scriptOrFile;
 
-	@CommandLine.Parameters(index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
-	List<String> userParams = new ArrayList<>();
-
 	protected Script script;
 
 	protected void enableInsecure() {

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -13,7 +13,7 @@ public class Build extends BaseBuildCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths);
+		script = prepareScript(scriptOrFile, null, properties, dependencies, classpaths);
 
 		if (script.needsJar()) {
 			build(script);

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -1,18 +1,11 @@
 package dev.jbang.cli;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "build", description = "Compiles and stores script in the cache.")
 public class Build extends BaseBuildCommand {
-
-	@CommandLine.Option(names = { "-O",
-			"--output" }, description = "Directory to write application binary to.")
-	Path outputDir;
 
 	@Override
 	public Integer doCall() throws IOException {
@@ -24,17 +17,6 @@ public class Build extends BaseBuildCommand {
 
 		if (script.needsJar()) {
 			build(script);
-		}
-
-		if (outputDir != null) {
-			// TODO make sure the output names are nicer
-			Path jar = script.getJar().toPath();
-			if (nativeImage) {
-				Path img = getImageName(jar.toFile()).toPath();
-				Files.copy(img, outputDir.resolve(img.getFileName()));
-			} else {
-				Files.copy(jar, outputDir.resolve(jar.getFileName()));
-			}
 		}
 
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -1,11 +1,18 @@
 package dev.jbang.cli;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "build", description = "Compiles and stores script in the cache.")
 public class Build extends BaseBuildCommand {
+
+	@CommandLine.Option(names = { "-O",
+			"--output" }, description = "Directory to write application binary to.")
+	Path outputDir;
 
 	@Override
 	public Integer doCall() throws IOException {
@@ -17,6 +24,17 @@ public class Build extends BaseBuildCommand {
 
 		if (script.needsJar()) {
 			build(script);
+		}
+
+		if (outputDir != null) {
+			// TODO make sure the output names are nicer
+			Path jar = script.getJar().toPath();
+			if (nativeImage) {
+				Path img = getImageName(jar.toFile()).toPath();
+				Files.copy(img, outputDir.resolve(img.getFileName()));
+			} else {
+				Files.copy(jar, outputDir.resolve(jar.getFileName()));
+			}
 		}
 
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -51,7 +51,7 @@ public class Edit extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams);
+		script = prepareScript(scriptOrFile);
 		File project = createProjectForEdit(script, false);
 		// err.println(project.getAbsolutePath());
 
@@ -106,7 +106,7 @@ public class Edit extends BaseScriptCommand {
 							try {
 								// TODO only regenerate when dependencies changes.
 								info("Regenerating project.");
-								script = prepareScript(scriptOrFile, userParams);
+								script = prepareScript(scriptOrFile);
 								createProjectForEdit(script, true);
 							} catch (RuntimeException ee) {
 								warn("Error when re-generating project. Ignoring it, but state might be undefined: "

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -24,7 +24,7 @@ public class Export extends BaseBuildCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths);
+		script = prepareScript(scriptOrFile, null, properties, dependencies, classpaths);
 
 		if (script.needsJar()) {
 			build(script);

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -1,0 +1,61 @@
+package dev.jbang.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import dev.jbang.Util;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name = "export", description = "Export the result of a build.")
+public class Export extends BaseBuildCommand {
+
+	@CommandLine.Option(names = { "-O",
+			"--output" }, description = "The name or path to use for the exported file. If not specified a name will be determined from the original source ref")
+	Path outputFile;
+
+	@Override
+	public Integer doCall() throws IOException {
+		if (insecure) {
+			enableInsecure();
+		}
+
+		script = prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths);
+
+		if (script.needsJar()) {
+			build(script);
+		}
+
+		// Determine the output file location and name
+		Path cwd = Util.getCwd();
+		Path outputPath;
+		if (outputFile != null) {
+			outputPath = outputFile;
+		} else {
+			String outName = AppInstall.chooseCommandName(script);
+			if (nativeImage) {
+				outName = getImageName(new File(outName)).getName();
+			} else {
+				outName += ".jar";
+			}
+			outputPath = Paths.get(outName);
+		}
+		outputPath = cwd.resolve(outputPath);
+
+		// Copy the JAR or native binary
+		Path jar = script.getJar().toPath();
+		if (nativeImage) {
+			Path img = getImageName(jar.toFile()).toPath();
+			Files.copy(img, outputPath);
+		} else {
+			Files.copy(jar, outputPath);
+		}
+
+		info("Exported to " + outputPath);
+		return EXIT_OK;
+	}
+}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -54,7 +54,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile, userParams);
+		script = prepareScript(scriptOrFile);
 
 		ScriptInfo info = new ScriptInfo(script);
 

--- a/src/main/java/dev/jbang/cli/Jbang.java
+++ b/src/main/java/dev/jbang/cli/Jbang.java
@@ -46,7 +46,7 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 
 		"" }, versionProvider = VersionProvider.class, subcommands = {
 				Run.class, Build.class, Edit.class, Init.class, Alias.class, Catalog.class, Trust.class, Cache.class,
-				Completion.class, Jdk.class, Version.class, Wrapper.class, Info.class, App.class })
+				Completion.class, Jdk.class, Version.class, Wrapper.class, Info.class, App.class, Export.class })
 public class Jbang extends BaseCommand {
 
 	@CommandLine.ArgGroup(exclusive = true)
@@ -125,7 +125,7 @@ public class Jbang extends BaseCommand {
 		Map<String, List<String>> sections = new LinkedHashMap<>();
 		sections.put("Essentials", asList("run", "build"));
 		sections.put("Editing", asList("init", "edit"));
-		sections.put("Caching", asList("cache", "jdk"));
+		sections.put("Caching", asList("cache", "export", "jdk"));
 		sections.put("Configuration", asList("trust", "alias", "catalog", "app"));
 		sections.put("Other", asList("completion", "info", "version", "wrapper"));
 		CommandGroupRenderer renderer = new CommandGroupRenderer(sections);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -50,6 +50,9 @@ public class Run extends BaseBuildCommand {
 	@CommandLine.Option(names = { "--interactive" }, description = "activate interactive mode")
 	boolean interactive;
 
+	@CommandLine.Parameters(index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
+	List<String> userParams = new ArrayList<>();
+
 	@Override
 	public Integer doCall() throws IOException {
 		if (insecure) {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -166,7 +166,7 @@ public class Run extends BaseBuildCommand {
 
 				if (optionActive(cds(), script.enableCDS())) {
 					String cdsJsa = script.getJar().getAbsolutePath() + ".jsa";
-					if (script.wasJarCreated()) {
+					if (createdJar) {
 						debug("CDS: Archiving Classes At Exit at " + cdsJsa);
 						optionalArgs.add("-XX:ArchiveClassesAtExit=" + cdsJsa);
 					} else {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -846,7 +846,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
-		Script s = prepareScript(p.toFile().getAbsolutePath(), run.userParams, run.properties, run.dependencies,
+		Script s = prepareScript(p.toFile().getAbsolutePath(), null, run.properties, run.dependencies,
 				run.classpaths);
 
 		run.build(s);
@@ -875,7 +875,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
-		Script s = prepareScript(p.toFile().getAbsolutePath(), run.userParams, run.properties, run.dependencies,
+		Script s = prepareScript(p.toFile().getAbsolutePath(), null, run.properties, run.dependencies,
 				run.classpaths);
 
 		run.build(s);

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -465,7 +465,7 @@ public class TestRun extends BaseTest {
 
 		Script s = new Script("", null, null);
 		s.setMainClass("wonkabear");
-		s.createJarFile(dir, out);
+		BaseBuildCommand.createJarFile(s, dir, out);
 
 		try (JarFile jf = new JarFile(out)) {
 


### PR DESCRIPTION
This has become a bit of a mix of related changes. The 2 main features are:

1. get a copy of the script JAR by specifying ~`--output` / `-O`~ `jbang export <script-ref>`

But that JAR won't work without setting up all the necessary deps, so:

2. add dependencies to the JAR manifest so the JAR can simply be executed with `java -jar` **on the same system**. (It won't work on other computers, but it also won't hurt)

3. There was already code for setting Boot-Class-Path but it was using the wrong format, so fixed that while adding 2. 

4. Refactored the Script object to make it stateless which was a change I had lying around for weeks already and given the fact that these changes used that exact same code I decided to add it in the PR.
