### PR TITLE
feat: add minimal jitpack and //REPOS support to edit mode

### DIFF
--- a/src/main/java/dev/jbang/DependencyUtil.java
+++ b/src/main/java/dev/jbang/DependencyUtil.java
@@ -3,7 +3,6 @@ package dev.jbang;
 import static dev.jbang.Settings.CP_SEPARATOR;
 import static dev.jbang.Util.*;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -41,9 +40,13 @@ public class DependencyUtil {
 
 	/**
 	 *
-	 * @param deps
-	 * @param repos
+	 * @param deps           dependencies; is modified with resolved deps (eg,
+	 *                       jitpack)
+	 * @param repos          repositories, is also modified with added repos (eg,
+	 *                       also jitpack)
+	 * @param offline
 	 * @param loggingEnabled
+	 * @param transitivity
 	 * @return string with resolved classpath
 	 */
 	public ModularClassPath resolveDependencies(List<String> deps, List<MavenRepo> repos,
@@ -55,7 +58,6 @@ public class DependencyUtil {
 		}
 
 		if (repos.isEmpty()) {
-			repos = new ArrayList<MavenRepo>();
 			repos.add(toMavenRepo("jcenter"));
 		}
 
@@ -68,6 +70,11 @@ public class DependencyUtil {
 		if (!depIds.equals(deps) && !repos.stream().anyMatch(r -> REPO_JITPACK.equals(r.getUrl()))) {
 			repos.add(toMavenRepo(ALIAS_JITPACK));
 		}
+
+		// Put those resolved depIds back into deps (so the caller gets them)
+		// TODO: refactor, extract class method with intermediary repos/deps
+		deps.clear();
+		deps.addAll(depIds);
 
 		String depsHash = String.join(CP_SEPARATOR, depIds);
 

--- a/src/main/resources/build.qute.gradle
+++ b/src/main/resources/build.qute.gradle
@@ -3,9 +3,14 @@ plugins {
 	id 'application'
 }
 
+
 repositories {
 	mavenLocal()
-	jcenter()
+{#for url in repositories}
+	maven {
+		url  "{url}"
+	}
+{/for}
 }
 
 dependencies {


### PR DESCRIPTION
This abuses half of DependencyUtil.resolveDependencies(deps, repos) to get the jitpack-resolved deps and jcenter/jitpack-added repos, and pass that to the template. In the template I removed the hardcoded repos and used the semi-resolved ones instead.