### PR TITLE
fix: jitpack no long assumes default branch is master

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -560,7 +560,7 @@ And finally if the link you provide is to a specific branch of the project then 
 |===
 |Link | Locator
 |https://github.com/jbangdev/jbang
-|com.github.jbangdev:jbang:master-SNAPSHOT
+|com.github.jbangdev:jbang:HEAD-SNAPSHOT
 
 |https://github.com/jbangdev/jbang/tree/v1.2.3
 |com.github.jbangdev:jbang:v1.2.3
@@ -569,7 +569,7 @@ And finally if the link you provide is to a specific branch of the project then 
 |com.github.jbangdev:jbang:f1f34b031d
 
 |https://github.com/jbangdev/jbang#mymodule
-|com.github.jbangdev.jbang:mymodule:master-SNAPSHOT
+|com.github.jbangdev.jbang:mymodule:HEAD-SNAPSHOT
 
 |https://github.com/jbangdev/jbang/tree/mybranch#:SNAPSHOT
 |com.github.jbangdev:jbang:mybranch-SNAPSHOT

--- a/src/main/java/dev/jbang/JitPackUtil.java
+++ b/src/main/java/dev/jbang/JitPackUtil.java
@@ -110,7 +110,7 @@ public class JitPackUtil {
 		String toGav() {
 			String v;
 			if (version == null) {
-				v = "master-SNAPSHOT";
+				v = "HEAD-SNAPSHOT"; // using HEAD as no longer possible to know what default branch is called.
 			} else if (POSSIBLE_SHA1_PATTERN.matcher(version).matches()) {
 				v = version.substring(0, 10);
 			} else {

--- a/src/test/java/dev/jbang/TestJitPack.java
+++ b/src/test/java/dev/jbang/TestJitPack.java
@@ -9,7 +9,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGithubUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang"),
-				"com.github.jbangdev:jbang:master-SNAPSHOT");
+				"com.github.jbangdev:jbang:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master"),
 				"com.github.jbangdev:jbang:master-SNAPSHOT");
@@ -30,7 +30,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGithubUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang#foo"),
-				"com.github.jbangdev.jbang:foo:master-SNAPSHOT");
+				"com.github.jbangdev.jbang:foo:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo"),
 				"com.github.jbangdev.jbang:foo:master-SNAPSHOT");
@@ -69,7 +69,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGitlabUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab"),
-				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
+				"com.gitlab.gitlab-org:gitlab:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master"),
 				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
@@ -90,7 +90,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGitlabUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab#foo"),
-				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
+				"com.gitlab.gitlab-org.gitlab:foo:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master#foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
@@ -111,7 +111,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractBitbucketUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler"),
-				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
+				"org.bitbucket.ceylon:ceylon-compiler:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/"),
 				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
@@ -131,7 +131,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractBitbucketUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler#foo"),
-				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
+				"org.bitbucket.ceylon.ceylon-compiler:foo:HEAD-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/#foo"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");


### PR DESCRIPTION
Fixes #564

instead of defaulting to master  we use HEAD which should get us latest and greatest.



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->