### PR TITLE
Don't add tar.gz files to classpath

### DIFF
--- a/src/main/java/dev/jbang/ModularClassPath.java
+++ b/src/main/java/dev/jbang/ModularClassPath.java
@@ -25,6 +25,7 @@ public class ModularClassPath {
 	public String getClassPath() {
 		if (classPath == null) {
 			classPath = artifacts	.stream()
+									.filter(it -> it.asFile().getPath().endsWith(".jar"))
 									.map(it -> it.asFile().getAbsolutePath())
 									.map(it -> it.contains(" ") ? '"' + it + '"' : it)
 									.distinct()


### PR DESCRIPTION
Closes #598

I'm not sure if this is the best way. Maybe the filtering could happen earlier? The svm pom has this:

```
    <dependency>
      <groupId>org.graalvm.nativeimage</groupId>
      <artifactId>svm-hosted-native-linux-amd64</artifactId>
      <version>20.3.0</version>
      <type>tar.gz</type>
    </dependency>
```

Maybe Aether could be configured/instructed to skip `tar.gz` type dependencies?