### PR TITLE
feat: Add `mavenLocal` to allow resolving dependencies from local repository

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -551,8 +551,11 @@ For ease of use there are also a few shorthands to use popular commonly availabl
 
 |===
 |Short name | Description
-|`mavencentral`
+|`mavenCentral`
 |Maven Central
+
+|`mavenLocal`
+|Local maven repository (only use if you know you need it)
 
 |`jcenter`
 |`https://jcenter.bintray.com/`

--- a/src/main/java/dev/jbang/DependencyUtil.java
+++ b/src/main/java/dev/jbang/DependencyUtil.java
@@ -31,6 +31,8 @@ public class DependencyUtil {
 	public static final String ALIAS_JCENTER = "jcenter";
 	public static final String ALIAS_GOOGLE = "google";
 	public static final String ALIAS_MAVEN_CENTRAL = "mavenCentral";
+	public static final String ALIAS_MAVEN_LOCAL = "mavenLocal";
+
 	public static final String ALIAS_JITPACK = "jitpack";
 
 	public static final String REPO_JCENTER = "https://jcenter.bintray.com/";
@@ -127,6 +129,8 @@ public class DependencyUtil {
 		customRepos.stream().forEach(mavenRepo -> {
 			mavenRepo.apply(resolver);
 		});
+
+		Util.verboseMsg("Local maven repo: " + Settings.getLocalMavenRepo().toPath().toAbsolutePath().toString());
 
 		System.setProperty("maven.repo.local", Settings.getLocalMavenRepo().toPath().toAbsolutePath().toString());
 
@@ -245,10 +249,17 @@ public class DependencyUtil {
 		} else if (ALIAS_JBOSS.equalsIgnoreCase(reporef)) {
 			return new MavenRepo(Optional.ofNullable(repoid).orElse(ALIAS_JBOSS), REPO_JBOSS);
 		} else if (ALIAS_MAVEN_CENTRAL.equalsIgnoreCase(reporef)) {
-			return new MavenRepo("", "") {
+			return new MavenRepo("mavenCentral", "") {
 				@Override
 				public void apply(ConfigurableMavenResolverSystem resolver) {
 					resolver.withMavenCentralRepo(true);
+				}
+			};
+		} else if (ALIAS_MAVEN_CENTRAL.equalsIgnoreCase(reporef)) {
+			return new MavenRepo("mavenLocal", "") {
+				@Override
+				public void apply(ConfigurableMavenResolverSystem resolver) {
+					resolver.useLegacyLocalRepo(true);
 				}
 			};
 		} else if (ALIAS_JITPACK.equalsIgnoreCase(reporef)) {


### PR DESCRIPTION
Fixes #431

Note, this is currently implemented by calling shrinkwrap method to uselegacylocal repo option.

This means the order of when `mavenLocal` shows up does not matter.

I wonder if we should instead add the local repo location as file url so it gets treated like any other repo 
and can be ordered ?

Interested in feedback before merging this. You can test this behavior against using file url by just manually specifying `//REPOS mylocal=file:/...path to m2`

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->