### PR TITLE
feat: Download and setup vscodium if no editor available.

### DIFF
--- a/itests/edit.feature
+++ b/itests/edit.feature
@@ -5,4 +5,3 @@ Scenario: edit a file should print to std out
   * command('jbang edit hello.java')
 * match err == ''
   * match out contains 'hello'
-

--- a/readme.adoc
+++ b/readme.adoc
@@ -65,8 +65,9 @@ toc::[]
 * `.jsh` via JShell from Java 9 and upwards
 * Works on icon:windows[] Windows, icon:apple[] OSX and icon:linux[] Linux
 * Install using curl, power shell, SDKMan (icon:apple[]/icon:linux[]), Homebrew (icon:apple[]), Chocolatey (icon:windows[]) or Scoop (icon:windows[])
+* If needed will automatically install Java and even a Java editor (vscodium) for editing
 * Installation of scripts to user `PATH`
-Include multiple files and sources
+* Include multiple files and sources
 * Dependency declarations using `//DEPS <gav>` for automatic dependency resolution
 * Control compile and runtime options with `//JAVAC_OPTIONS <flags>` and `//JAVA_OPTIONS <flags>`
 * Compiled jar and Dependency resolution caching
@@ -871,7 +872,7 @@ Instead of copying and pasting lines you could also redirect the output to a .ba
 
 == Editing
 
-You can edit your script in your IDE by using `jbang edit helloworld.java`. This will generate a project in a temporary location with symbolic links to your script
+You can edit your script in an IDE/editor by using `jbang edit helloworld.java`. This will generate a project in a temporary location with symbolic links to your script
 and output the generated folder name. The easiest way to use that is to use it in a call to your IDE:
 
 [source, bash]
@@ -891,9 +892,18 @@ jbang edit --open=[editor] helloworld.java
 The editor used will be what is specified as the argument to `--open` or value of `JBANG_EDITOR` environment variable.
 The editor command must be available on the PATH to be executed from jbang. If you are executing `jbang edit --open=code helloworld.java` a `code` executable (visual studio code) must be on the PATH. Next to this you can pass the full path to the `open` parameter like in `--open=/usr/bin/code`.
 
+
 NOTE: On Windows you might need elevated privileges to create symbolic links. If you don't have permissions then
 the `edit` option will result in an error. To use it https://stackoverflow.com/a/24353758[enable symbolic links]
 for your user or run your shell/terminal as administrator to have this feature working.
+
+=== Install of default vscodium editor [EXPERIMENTAL]
+
+If no editor available at all jbang will install https://vscodium.com[VSCodium] (free/libre version of Visual Studio code) with
+default java extensions enabled in so called https://code.visualstudio.com/docs/editor/portable["portable mode"].
+
+This automatic install and setup of editor is fully optional and if you have another IDE or editor already installed
+use it using `jbang edit --open=<editor>` or set JBANG_EDITOR environment variable to have jbang use it by default.
 
 === Live Editing
 

--- a/src/main/java/dev/jbang/EditorManager.java
+++ b/src/main/java/dev/jbang/EditorManager.java
@@ -1,0 +1,125 @@
+package dev.jbang;
+
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EditorManager {
+	private static final String CODIUM_DOWNLOAD_URL = "https://github.com/VSCodium/vscodium/releases/download/%s/VSCodium-%s-%s-%s.%s";
+
+	public static Path getVSCodiumPath() {
+		if (Util.isMac()) {
+			return Settings.getConfigEditorDir().resolve("vscodium.app");
+		} else if (Util.isWindows()) {
+			return Settings.getConfigEditorDir().resolve("vscodium");
+		} else {
+			return Settings.getConfigEditorDir().resolve("vscodium");
+		}
+	}
+
+	public static Path downloadAndInstallEditor() {
+		// https://github.com/VSCodium/vscodium/releases/download/1.52.1/VSCodium-darwin-x64-1.52.1.zip
+
+		String version = getLatestVSCodiumVersion();
+
+		Util.infoMsg("Downloading VSCodium " + version
+				+ ". Be patient, this can take several minutes...(Ctrl+C if you want to cancel)");
+		String url = getVSCodiumDownloadURL(version);
+		Util.verboseMsg("Downloading " + url);
+		Path editorDir = getVSCodiumPath();
+		Path editorTmpDir = editorDir.getParent().resolve(editorDir.getFileName().toString() + ".tmp");
+		Path editorOldDir = editorDir.getParent().resolve(editorDir.getFileName().toString() + ".old");
+		Util.deletePath(editorTmpDir, false);
+		Util.deletePath(editorOldDir, false);
+		try {
+			Path jdkPkg = Util.downloadAndCacheFile(url, false);
+			Util.infoMsg("Installing VSCodium " + version + "...");
+			Util.verboseMsg("Unpacking to " + editorDir.toString());
+			UnpackUtil.unpackEditor(jdkPkg, editorTmpDir);
+			if (Files.isDirectory(editorDir)) {
+				Files.move(editorDir, editorOldDir);
+			}
+			Files.move(editorTmpDir, editorDir);
+			Util.deletePath(editorOldDir, false);
+			return editorDir;
+		} catch (Exception e) {
+			Util.deletePath(editorTmpDir, true);
+			if (!Files.isDirectory(editorDir) && Files.isDirectory(editorOldDir)) {
+				try {
+					Files.move(editorOldDir, editorDir);
+				} catch (IOException ex) {
+					// Ignore
+				}
+			}
+			Util.errorMsg("VSCode editor not possible to download or install.");
+			throw new ExitException(EXIT_UNEXPECTED_STATE,
+					"Unable to download or install VSCodium version " + version, e);
+		}
+
+	}
+
+	private static String getVSCodiumDownloadURL(String version) {
+		String os = Util.getOS().name();
+
+		if (os.equals("mac")) {
+			os = "darwin";
+		} else if (os.equals("windows")) {
+			os = "win32";
+		}
+
+		String suffix = "tar.gz";
+		if (Util.isWindows() || Util.isMac()) {
+			suffix = "zip";
+		}
+		String url = String.format(CODIUM_DOWNLOAD_URL, version, os, Util.getArch().name(), version, suffix);
+		return url;
+	}
+
+	private static String getLatestVSCodiumVersion() {
+		String version = "1.52.1";
+		try {
+			Util.verboseMsg("Lookup vscodium latest version...");
+			String out = new Scanner(
+					new URL("https://api.github.com/repos/vscodium/vscodium/releases/latest").openStream(),
+					"UTF-8").useDelimiter("\\A").next();
+			Matcher matcher = Pattern.compile("\"tag_name\":.*?\"(.*?)\"").matcher(out);
+			if (matcher.find()) {
+				version = matcher.group(1);
+			} else {
+				Util.verboseMsg("Could not find latest version - falling back to " + version);
+			}
+		} catch (IOException e) {
+			// ignore e.printStackTrace();
+		}
+		return version;
+	}
+
+	public static Path getVSCodiumDataPath() {
+		if (Util.isMac()) {
+			return getVSCodiumPath().getParent().resolve("codium-portable-data");
+		} else {
+			return getVSCodiumPath().resolve("data");
+		}
+	}
+
+	public static Path getVSCodiumBinPath() {
+		if (Util.isMac()) {
+			return getVSCodiumPath().resolve("Contents/Resources/app/bin/code");
+		} else if (Util.isWindows()) {
+			return getVSCodiumPath().resolve("bin/codium.cmd");
+		} else {
+			return getVSCodiumPath().resolve("bin/codium");
+		}
+	}
+
+	/*
+	 * private static Path getJdksPath() { return
+	 * Settings.getCacheDir(Settings.CacheClass.jdks); }
+	 */
+}

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -39,6 +39,7 @@ public class Settings {
 	public static final String DEPENDENCY_CACHE_JSON = "dependency_cache.json";
 	public static final String CURRENT_JDK = "currentjdk";
 	public static final String BIN_DIR = "bin";
+	public static final String EDITOR_DIR = "editor";
 
 	public static final String ENV_DEFAULT_JAVA_VERSION = "JBANG_DEFAULT_JAVA_VERSION";
 
@@ -84,6 +85,10 @@ public class Settings {
 
 	public static Path getConfigBinDir() {
 		return getConfigDir(true).resolve(BIN_DIR);
+	}
+
+	public static Path getConfigEditorDir() {
+		return getConfigDir(true).resolve(EDITOR_DIR);
 	}
 
 	public static void setupJbangDir(Path dir) {


### PR DESCRIPTION
WIP: Just POC for now. should support linux, windows and osx atm

Depends on #639 for notion of default editor.

Now when no editor is specified it:

1) downloads vscodium
2) create portable dir data
3) setup redhat.java and java.debug extensions

uses the just installed vscodium as editor.

Fixes #632



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->