### PR TITLE
feat: default editor --open without editor opens default editor feat: default key value, i.e. -Dkey interpreted as -Dkey=true

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
 	implementation 'org.apache.commons:commons-text:1.9'
 	implementation 'org.apache.commons:commons-compress:1.20'
-	implementation 'info.picocli:picocli:4.5.2'
+	implementation 'info.picocli:picocli:4.6.0'
 	implementation 'io.quarkus.qute:qute-core:1.10.5.Final'
 	implementation 'kr.motd.maven:os-maven-plugin:1.6.1'
 	implementation 'org.codehaus.plexus:plexus-java:1.0.5'

--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -12,7 +12,11 @@ Scenario: jshell arguments
 When command('jbang helloworld.jsh JSH!')
 Then match out == "Hello JSH!\n"
 
-Scenario: jsh system property
+Scenario: jsh default system property
+  When command('jbang -Dvalue hello.jsh')
+  Then match out == "true\n"
+
+  Scenario: jsh system property
 When command('jbang -Dvalue=hello hello.jsh')
 Then match out == "hello\n"
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -396,6 +396,11 @@ The script will have the output:
 
 Please note that `.jsh` files are source only, they are not compiled thus they are https://github.com/jbangdev/jbang/issues/506[not cached] nor can they be https://github.com/jbangdev/jbang/issues/510[built as native images].
 
+[TIP]
+====
+If you use `-Dkey` where no value is specified `jbang` will interpret this as `-Dkey=true` allowing you to easily have
+flags passed into, i.e. `jbang -DskipTests mytestrunner.java`. Now within your script `Boolean.getBoolean('skipTests') will return true.
+====
 
 ==== Running script from standard input
 
@@ -883,7 +888,7 @@ Above does require using a shell that allows for variable evaluation, if you are
 jbang edit --open=[editor] helloworld.java
 ----
 
-The editor used will be what is specified as the argument to `--open` or default to `$JBANG_EDITOR`, `$VISUAL` or `$EDITOR` in that order.
+The editor used will be what is specified as the argument to `--open` or value of `JBANG_EDITOR` environment variable.
 The editor command must be available on the PATH to be executed from jbang. If you are executing `jbang edit --open=code helloworld.java` a `code` executable (visual studio code) must be on the PATH. Next to this you can pass the full path to the `open` parameter like in `--open=/usr/bin/code`.
 
 NOTE: On Windows you might need elevated privileges to create symbolic links. If you don't have permissions then

--- a/src/main/java/dev/jbang/StrictParameterPreprocessor.java
+++ b/src/main/java/dev/jbang/StrictParameterPreprocessor.java
@@ -1,0 +1,27 @@
+package dev.jbang;
+
+import java.util.Map;
+import java.util.Stack;
+
+import picocli.CommandLine;
+
+/**
+ * preprocessor which strictly enforces you have to use a `=` to assign values.
+ * ie. only `--open=xyz` and `-o=xyz` will be accepted. Useful when you have
+ * option for which you like default value to be expressed without having it
+ * pick up adidtional values on the command line. i.e. `jbang edit --open
+ * myapp.java` should not treat `myapp.java` as editor to open but instead just
+ * open the default editor.
+ */
+public class StrictParameterPreprocessor implements CommandLine.IParameterPreprocessor {
+
+	@Override
+	public boolean preprocess(Stack<String> args, CommandLine.Model.CommandSpec commandSpec,
+			CommandLine.Model.ArgSpec argSpec, Map<String, Object> info) {
+		if (" ".equals(info.get("separator"))) { // parameter was not attached to option
+			// act as if the user specifed fallback value
+			args.push(((CommandLine.Model.OptionSpec) argSpec).fallbackValue());
+		}
+		return false;
+	}
+}

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -8,7 +8,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import dev.jbang.*;
+import dev.jbang.AliasUtil;
+import dev.jbang.ExitException;
+import dev.jbang.Script;
+import dev.jbang.Settings;
+import dev.jbang.Util;
 
 import picocli.CommandLine;
 
@@ -56,7 +60,7 @@ class AliasAdd extends BaseAliasCommand {
 			"-d" }, description = "A description for the alias")
 	String description;
 
-	@CommandLine.Option(names = { "-D" }, description = "set a system property")
+	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, String> properties;
 
 	@CommandLine.Option(names = { "--name" }, description = "A name for the command")

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -28,7 +28,17 @@ import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
-import dev.jbang.*;
+import dev.jbang.ExitException;
+import dev.jbang.FileRef;
+import dev.jbang.IntegrationManager;
+import dev.jbang.IntegrationResult;
+import dev.jbang.JarUtil;
+import dev.jbang.JavaUtil;
+import dev.jbang.JdkManager;
+import dev.jbang.KeyValue;
+import dev.jbang.Script;
+import dev.jbang.Settings;
+import dev.jbang.Util;
 
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
@@ -63,7 +73,7 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		return Optional.ofNullable(cds);
 	}
 
-	@CommandLine.Option(names = { "-D" }, description = "set a system property")
+	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, String> properties = new HashMap<>();
 
 	@CommandLine.Option(names = {


### PR DESCRIPTION
default editor and default key value for system properties made possible
with picocli 4.6.0 release.

Means `jbang edit --open my.java` will now actually honor JBANG_EDITOR value
as documented. Removed the EDITOR and VISUAL fallbacks as that would conflict with want
of supporting vscodium as a fallback.

And means that `jbang -DskipTests properties@jbangdev` will print out
`skipTests = true` which are useful for easy toggles.
"breaking" change here as before `-DskipTests` would have resulted in error
being printed; but now it actually does something useful instead.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
