### PR TITLE
fix: Make sure scripts are actually built before printing info

### DIFF
--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -19,7 +19,7 @@ import picocli.CommandLine;
 public class Info {
 }
 
-abstract class BaseInfoCommand extends BaseScriptCommand {
+abstract class BaseInfoCommand extends BaseBuildCommand {
 
 	class ScriptInfo {
 
@@ -54,7 +54,11 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		script = prepareScript(scriptOrFile);
+		script = prepareScript(scriptOrFile, null, properties, dependencies, classpaths);
+
+		if (script.needsJar()) {
+			build(script);
+		}
 
 		ScriptInfo info = new ScriptInfo(script);
 


### PR DESCRIPTION
If we don't do this the result might be incomplete. Running `info classpath`
before building doesn't include the actual script JAR while running it after
building does. That's obviously not consistent.
