### PR TITLE
feat: --jsh to allow forcing .jsh

### DIFF
--- a/itests/hellojsh
+++ b/itests/hellojsh
@@ -1,0 +1,3 @@
+// example of jsh without suffix.
+// use jbang --jsh to force it.
+System.out.println(args[0]);

--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -24,7 +24,11 @@ Scenario: jsh quoted system property
 When command('jbang -Dvalue="a quoted" hello.jsh')
 Then match out == "a quoted\n"
 
-
 Scenario: jsh fail on --native
   When command('jbang --native hello.jsh')
   Then match err contains ".jsh cannot be used with --native"
+
+Scenario: force jsh
+  When command('jbang --jsh hellojsh hello')
+  Then match err == ""
+  Then match out == "hello\n"

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -72,6 +72,11 @@ public class Script {
 	 **/
 	private String javaAgentOption;
 
+	/**
+	 * if true, interpret any input as for jshell
+	 */
+	private boolean forcejsh = false;
+
 	public Script(ScriptResource resource, List<String> arguments, Map<String, String> properties)
 			throws FileNotFoundException {
 		this(resource, getBackingFileContent(resource.getFile()), arguments, properties);
@@ -437,7 +442,7 @@ public class Script {
 	}
 
 	public boolean forJShell() {
-		return getBackingFile().getName().endsWith(".jsh");
+		return forcejsh || getBackingFile().getName().endsWith(".jsh");
 	}
 
 	public void setOriginal(String ref) {
@@ -656,6 +661,10 @@ public class Script {
 
 	public List<KeyValue> getAgentOptions() {
 		return agentOptions;
+	}
+
+	public void setForcejsh(boolean forcejsh) {
+		this.forcejsh = forcejsh;
 	}
 
 }

--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -400,7 +400,8 @@ public class Util {
 		// to handle if kubectl-style name (i.e. extension less)
 		File f = path.toFile();
 		String nonkebabname = f.getName();
-		if (!f.getName().endsWith(".jar")) { // avoid directly downloaded jar files getting renamed to .java
+		if (!f.getName().endsWith(".jar") && !f.getName().endsWith(".jsh")) { // avoid directly downloaded jar files
+																				// getting renamed to .java
 			nonkebabname = unkebabify(f.getName());
 		}
 		if (nonkebabname.equals(f.getName())) {

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -56,6 +56,9 @@ public abstract class BaseScriptCommand extends BaseCommand {
 			"--insecure" }, description = "Enable insecure trust of all SSL certificates.", defaultValue = "false")
 	boolean insecure;
 
+	@CommandLine.Option(names = { "--jsh" }, description = "Force input to be interpreted with jsh/jshell")
+	boolean forcejsh = false;
+
 	@CommandLine.Parameters(index = "0", arity = "1", description = "A file with java code or if named .jsh will be run with jshell")
 	String scriptOrFile;
 
@@ -106,11 +109,11 @@ public abstract class BaseScriptCommand extends BaseCommand {
 
 	public static Script prepareScript(String scriptResource, List<String> arguments, Map<String, String> properties,
 			List<String> dependencies, List<String> classpaths) throws IOException {
-		return prepareScript(scriptResource, arguments, properties, dependencies, classpaths, false);
+		return prepareScript(scriptResource, arguments, properties, dependencies, classpaths, false, false);
 	}
 
 	public static Script prepareScript(String scriptResource, List<String> arguments, Map<String, String> properties,
-			List<String> dependencies, List<String> classpaths, boolean fresh)
+			List<String> dependencies, List<String> classpaths, boolean fresh, boolean forcejsh)
 			throws IOException {
 		ScriptResource scriptFile = getScriptFile(scriptResource);
 
@@ -156,6 +159,7 @@ public abstract class BaseScriptCommand extends BaseCommand {
 		Script s = null;
 		try {
 			s = new Script(scriptFile, arguments, properties);
+			s.setForcejsh(forcejsh);
 			s.setOriginal(scriptResource);
 			s.setAlias(alias);
 			s.setAdditionalDependencies(dependencies);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -68,7 +68,8 @@ public class Run extends BaseBuildCommand {
 			enableInsecure();
 		}
 
-		script = prepareArtifacts(prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths, fresh));
+		script = prepareArtifacts(
+				prepareScript(scriptOrFile, userParams, properties, dependencies, classpaths, fresh, forcejsh));
 
 		String cmdline = generateCommandLine(script);
 		debug("run: " + cmdline);
@@ -125,7 +126,7 @@ public class Run extends BaseBuildCommand {
 
 			String requestedJavaVersion = javaVersion != null ? javaVersion : script.javaVersion();
 			String javacmd = resolveInJavaHome("java", requestedJavaVersion);
-			if (script.getBackingFile().getName().endsWith(".jsh")) {
+			if (script.forJShell()) {
 
 				javacmd = resolveInJavaHome("jshell", requestedJavaVersion);
 				if (!classpath.trim().isEmpty()) {


### PR DESCRIPTION
Main usecase is that tools like bach uses suffix less files.

for example to allow building https://github.com/jbee/purejin
using `jbang --jsh --java 16 https://bit.ly/bach-main-build`



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->