### PR TITLE
fix: have app install use better derived name

### DIFF
--- a/itests/kubectl-example
+++ b/itests/kubectl-example
@@ -1,0 +1,297 @@
+//#!/usr/bin/env jbang
+// when editing comment out the line above to avoid errors in IDE's.
+// Necessity to have it as kubectl don't recognize it as a script otherwise.
+// See https://github.com/kubernetes/kubectl/issues/822
+
+// client-java for k8s
+//DEPS io.kubernetes:client-java:5.0.0
+// pico for cli
+//DEPS info.picocli:picocli:4.1.4
+// text output table
+//DEPS com.massisframework:j-text-utils:0.3.4
+// to quiet down log4j
+//DEPS org.slf4j:slf4j-nop:1.7.30
+
+
+import dnl.utils.text.table.TextTable;
+import io.kubernetes.client.ApiClient;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.Configuration;
+import io.kubernetes.client.ProtoClient;
+import io.kubernetes.client.apis.CoreV1Api;
+import io.kubernetes.client.models.*;
+import io.kubernetes.client.proto.V1;
+import io.kubernetes.client.util.Config;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static picocli.CommandLine.*;
+import static picocli.CommandLine.Model.*;
+
+@Command(
+        name = "example",
+        description = "An example kubectl plugin",
+        subcommands = {
+                PodCommand.class,
+                ResourcesCommand.class
+        },
+        mixinStandardHelpOptions=true
+)
+public class KubectlExample extends Base {
+
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new KubectlExample()).execute(args);
+        System.exit(exitCode);
+    }
+
+    @Override
+    public Integer call() {
+        cmd.commandLine().usage(cmd.commandLine().getOut());
+        return ExitCode.OK;
+    }
+}
+
+abstract class Base implements Callable<Integer> {
+
+    @Spec CommandSpec cmd;
+
+    java.io.PrintWriter out() {
+        return cmd.commandLine().getOut();
+    }
+    ApiClient client;
+
+    ApiClient getClient() {
+        if(client!=null) return client;
+
+        try {
+            client = Config.defaultClient();
+            Configuration.setDefaultApiClient(client);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to get cluster configuration", e);
+        }
+        return client;
+    }
+}
+
+@Command(
+        name = "pod",
+        description = "Programmatically accesses pods in a k8s with 'add', 'list' and 'list2'",
+        mixinStandardHelpOptions = true,
+        subcommands = {
+                PodAddCommand.class,
+                PodListCommand.class,
+                PodList2Command.class
+        }
+)
+class PodCommand extends Base {
+
+    @Override
+    public Integer call() {
+        cmd.commandLine().usage(cmd.commandLine().getOut());
+        return ExitCode.USAGE;
+    }
+}
+
+
+@Command(
+        name = "add",
+        description = "Adds a pod to a k8s cluster"
+)
+class PodAddCommand extends Base {
+
+    @Parameters(index = "0")
+    String name;
+
+    @Option(names = {"-i", "--image"}, description = "image to use for pod")
+    String image = "nginx";
+
+    @Option(names = {"-n", "--namespace"}, description = "namespace to use for pod")
+    String namespace = "default";
+
+    @Override
+    public Integer call() {
+        try {
+            CoreV1Api api = new CoreV1Api(getClient());
+            Map<String, String> labels = new HashMap<>();
+            labels.put("app", "demo");
+            V1Pod pod = new V1PodBuilder()
+                    .withNewMetadata()
+                    .withName(name)
+                    .withLabels(labels)
+                    .endMetadata()
+                    .withNewSpec()
+                    .addNewContainer()
+                    .withName(name)
+                    .withImage(image)
+                    .endContainer()
+                    .endSpec()
+                    .build();
+
+            api.createNamespacedPod(namespace, pod, null, null, null);
+            return ExitCode.OK;
+
+        } catch (ApiException e) {
+            throw new IllegalStateException("unable to get pod list", e);
+        }
+
+    }
+}
+
+@Command(
+        name = "list2",
+        description = "lists pods in the cluster using the protoclient approach"
+)
+class PodList2Command extends Base {
+
+    @Option(names = {"-n", "--namespace"}, description = "namespace to use for getting pods")
+    String namespace = "default";
+
+    @Override
+    public Integer call() {
+
+        ProtoClient pc =  new ProtoClient(getClient());
+
+        ProtoClient.ObjectOrStatus<V1.PodList> list;
+        try {
+            String path = String.format("/api/v1/namespaces/%s/pods", namespace);
+            list = pc.list(V1.PodList.newBuilder(), path);
+
+        } catch (ApiException | IOException e) {
+            throw new IllegalStateException("unable to get pod list", e);
+        }
+
+        if (list.object.getItemsList().size() < 1) {
+            out().println("No Pods found");
+        } else {
+            printTable(list.object);
+        }
+        return ExitCode.OK;
+    }
+
+    private void printTable(V1.PodList podList) {
+        Object[][] data = new Object[podList.getItemsList().size()][];
+        int i = 0;
+        for (V1.Pod item : podList.getItemsList()) {
+            ArrayList<Object> cols = new ArrayList<>();
+            cols.add(item.getMetadata().getName());
+            cols.add(item.getMetadata().getNamespace());
+            data[i++] = cols.toArray();
+        }
+
+        String[] columnNames = {"Pod Name", "namespace"};
+
+        TextTable tt = new TextTable(columnNames, data);
+        tt.printTable();
+    }
+}
+
+/**
+ * PodListCommand is a command for listing pods in a kubernetes cluster.  This class is an example and requires
+ * standard kubeconfig setup to work.
+ *
+ */
+@Command(
+        name = "list",
+        description = "lists pods in the cluster using a structured approach"
+)
+class PodListCommand extends Base {
+
+    @Override
+    public Integer call() {
+        ApiClient client;
+        try {
+            client = Config.defaultClient();
+            Configuration.setDefaultApiClient(client);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to get cluster configuration", e);
+        }
+
+        V1PodList list;
+        try {
+            CoreV1Api api = new CoreV1Api(client);
+            list = api.listPodForAllNamespaces(null, null, null, null, null, null, null, null, null);
+        } catch (ApiException e) {
+            throw new IllegalStateException("unable to get pod list", e);
+        }
+
+        if (list.getItems().size() < 1) {
+            out().println("No Pods found");
+        } else {
+            printTable(list);
+        }
+
+        return ExitCode.OK;
+    }
+
+    /**
+     * Prints the table of pods discovered
+     *
+     * @param list PodList of pods
+     */
+    private static void printTable(V1PodList list) {
+        Object[][] data = new Object[list.getItems().size()][];
+        int i = 0;
+        for (V1Pod item : list.getItems()) {
+            ArrayList<Object> cols = new ArrayList<>();
+            cols.add(item.getMetadata().getName());
+            cols.add(item.getMetadata().getNamespace());
+            data[i++] = cols.toArray();
+        }
+
+        String[] columnNames = {"Pod Name", "namespace"};
+
+        TextTable tt = new TextTable(columnNames, data);
+        tt.printTable();
+    }
+}
+
+@Command(
+        name = "resources",
+        description = "lists resources in the k8s cluster"
+)
+class ResourcesCommand extends Base {
+
+    @Override
+    public Integer call() {
+
+        V1APIResourceList list;
+        try {
+            CoreV1Api api = new CoreV1Api(getClient());
+            list = api.getAPIResources();
+
+        } catch (ApiException e) {
+            throw new IllegalStateException("unable to get resource list", e);
+        }
+
+        if (list.getResources().size() < 1) {
+            out().println("No resources found");
+        } else {
+            printTable(list.getResources());
+        }
+
+        return ExitCode.OK;
+    }
+
+    private void printTable(List<V1APIResource> resources) {
+        Object[][] data = new Object[resources.size()][];
+        int i = 0;
+        for (V1APIResource item : resources) {
+            ArrayList<Object> cols = new ArrayList<>();
+            cols.add(item.getName());
+            cols.add(item.isNamespaced());
+            cols.add(item.getKind());
+            data[i++] = cols.toArray();
+        }
+
+        String[] columnNames = {"Resource", "Namespaced", "Kind"};
+
+        TextTable tt = new TextTable(columnNames, data);
+        tt.printTable();
+    }
+}

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -43,6 +43,31 @@ public class TestApp extends BaseTest {
 	}
 
 	@Test
+	void testAppInstallExtensionLessFile() throws IOException {
+		ExecutionResult result = checkedRun(null, "app", "install", "itests/kubectl-example");
+		assertThat(result.err, containsString("Command installed: kubectl-example"));
+		if (Util.isWindows()) {
+			assertThat(result.exitCode, equalTo(BaseCommand.EXIT_EXECUTE));
+		} else {
+			assertThat(result.exitCode, equalTo(BaseCommand.EXIT_OK));
+		}
+
+	}
+
+	@Test
+	void testAppInstallURL() throws IOException {
+		ExecutionResult result = checkedRun(null, "app", "install",
+				"https://github.com/jbangdev/k8s-cli-java/blob/jbang/kubectl-example");
+		assertThat(result.err, containsString("Command installed: kubectl-example"));
+		if (Util.isWindows()) {
+			assertThat(result.exitCode, equalTo(BaseCommand.EXIT_EXECUTE));
+		} else {
+			assertThat(result.exitCode, equalTo(BaseCommand.EXIT_OK));
+		}
+
+	}
+
+	@Test
 	void testAppInstallFileExists() throws IOException {
 		ExecutionResult result = checkedRun(null, "app", "install", "itests/helloworld.java");
 		assertThat(result.err, containsString("Command installed: helloworld"));


### PR DESCRIPTION
i.e. `kubectl-example` stays `kubectl-example` not kebabified `KubectlExample`

Fixes #653

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->