### PR TITLE
feat: add //DESCRIPTION tag in scripts

### DIFF
--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -201,7 +201,7 @@ public class AliasUtil {
 			Map<String, String> props = a1.properties != null && !a1.properties.isEmpty() ? a1.properties
 					: a2.properties;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
-			return new Alias(a2.scriptRef, null, args, props, catalog);
+			return new Alias(a2.scriptRef, a2.description, args, props, catalog);
 		} else {
 			return a1;
 		}

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -29,6 +29,7 @@ public class Script {
 	private static final String DEPS_COMMENT_PREFIX = "//DEPS ";
 	private static final String FILES_COMMENT_PREFIX = "//FILES ";
 	private static final String SOURCES_COMMENT_PREFIX = "//SOURCES ";
+	private static final String DESCRIPTION_COMMENT_PREFIX = "//DESCRIPTION ";
 
 	private static final String DEPS_ANNOT_PREFIX = "@Grab(";
 	private static final Pattern DEPS_ANNOT_PAIRS = Pattern.compile("(?<key>\\w+)\\s*=\\s*\"(?<value>.*?)\"");
@@ -157,6 +158,13 @@ public class Script {
 										.collect(Collectors.toCollection(ArrayList::new));
 		}
 		return repositories;
+	}
+
+	public String getDescription() {
+		return getLines()	.stream()
+							.filter(Script::isDescriptionDeclare)
+							.map(s -> s.substring(DESCRIPTION_COMMENT_PREFIX.length()))
+							.collect(Collectors.joining(" "));
 	}
 
 	// https://stackoverflow.com/questions/366202/regex-for-splitting-a-string-using-space-when-not-surrounded-by-single-or-double
@@ -389,6 +397,10 @@ public class Script {
 
 	static boolean isDependDeclare(String line) {
 		return line.startsWith(DEPS_COMMENT_PREFIX) || line.contains(DEPS_ANNOT_PREFIX);
+	}
+
+	static boolean isDescriptionDeclare(String line) {
+		return line.startsWith(DESCRIPTION_COMMENT_PREFIX);
 	}
 
 	public Script setMainClass(String mainClass) {

--- a/src/main/java/dev/jbang/Script.java
+++ b/src/main/java/dev/jbang/Script.java
@@ -164,7 +164,7 @@ public class Script {
 		return getLines()	.stream()
 							.filter(Script::isDescriptionDeclare)
 							.map(s -> s.substring(DESCRIPTION_COMMENT_PREFIX.length()))
-							.collect(Collectors.joining(" "));
+							.collect(Collectors.joining("\n"));
 	}
 
 	// https://stackoverflow.com/questions/366202/regex-for-splitting-a-string-using-space-when-not-surrounded-by-single-or-double

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -83,6 +83,11 @@ class AliasAdd extends BaseAliasCommand {
 			if (name == null) {
 				name = AppInstall.chooseCommandName(script);
 			}
+
+			if (description == null) {
+				description = script.getDescription();
+			}
+
 			Path catFile = getCatalog(false);
 			if (catFile != null) {
 				AliasUtil.addAlias(null, catFile, name, scriptOrFile, description, userParams, properties);

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -84,7 +84,7 @@ class AliasAdd extends BaseAliasCommand {
 				name = AppInstall.chooseCommandName(script);
 			}
 
-			if (description == null) {
+			if (description == null && script.getDescription() != null && script.getDescription().length() > 0) {
 				description = script.getDescription();
 			}
 

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -96,6 +96,65 @@ public class TestAlias extends BaseTest {
 	}
 
 	@Test
+	void testAddWithDescriptionInScript() throws IOException {
+		TemporaryFolder tmp = new TemporaryFolder();
+		tmp.create();
+		Path tmpPath = tmp.getRoot().toPath();
+		Path testFile = tmpPath.resolve("test.java");
+		Files.write(testFile, ("// Test file \n" +
+				"//DESCRIPTION Description of the script inside the script").getBytes());
+		assertThat(Files.isRegularFile(Paths.get(tmpPath.toString(), AliasUtil.JBANG_CATALOG_JSON)), is(false));
+		Jbang jbang = new Jbang();
+		new CommandLine(jbang).execute("alias", "add", "-f", tmpPath.toString(), "--name=name", testFile.toString());
+		assertThat(Files.isRegularFile(Paths.get(tmp.getRoot().toPath().toString(), AliasUtil.JBANG_CATALOG_JSON)),
+				is(true));
+		AliasUtil.Alias name = AliasUtil.getAlias(tmpPath, "name");
+		assertThat(name.scriptRef, is(testFile.toString()));
+		assertThat(name.description, is("Description of the script inside the script"));
+	}
+
+	@Test
+	void testAddWithDescriptionInArgs() throws IOException {
+		TemporaryFolder tmp = new TemporaryFolder();
+		tmp.create();
+		Path tmpPath = tmp.getRoot().toPath();
+		Path testFile = tmpPath.resolve("test.java");
+		Files.write(testFile, ("// Test file \n" +
+				"//DESCRIPTION Description of the script inside the script").getBytes());
+		assertThat(Files.isRegularFile(Paths.get(tmpPath.toString(), AliasUtil.JBANG_CATALOG_JSON)), is(false));
+		Jbang jbang = new Jbang();
+		new CommandLine(jbang).execute("alias", "add", "-f", tmpPath.toString(), "--name=name",
+				"-d", "Description of the script in arguments", testFile.toString());
+		assertThat(Files.isRegularFile(Paths.get(tmp.getRoot().toPath().toString(), AliasUtil.JBANG_CATALOG_JSON)),
+				is(true));
+		AliasUtil.Alias name = AliasUtil.getAlias(tmpPath, "name");
+		assertThat(name.scriptRef, is(testFile.toString()));
+		// The argument has more precedance than the description tag in the script
+		assertThat(name.description, is("Description of the script in arguments"));
+	}
+
+	@Test
+	void testAddWithMultipleDescriptionTags() throws IOException {
+		TemporaryFolder tmp = new TemporaryFolder();
+		tmp.create();
+		Path tmpPath = tmp.getRoot().toPath();
+		Path testFile = tmpPath.resolve("test.java");
+		Files.write(testFile, ("// Test file \n" +
+				"//DESCRIPTION Description first tag\n" +
+				"//DESCRIPTION description second tag\n" +
+				"//DESCRIPTION description third tag").getBytes());
+		assertThat(Files.isRegularFile(Paths.get(tmpPath.toString(), AliasUtil.JBANG_CATALOG_JSON)), is(false));
+		Jbang jbang = new Jbang();
+		new CommandLine(jbang).execute("alias", "add", "-f", tmpPath.toString(), "--name=name", testFile.toString());
+		assertThat(Files.isRegularFile(Paths.get(tmp.getRoot().toPath().toString(), AliasUtil.JBANG_CATALOG_JSON)),
+				is(true));
+		AliasUtil.Alias name = AliasUtil.getAlias(tmpPath, "name");
+		assertThat(name.scriptRef, is(testFile.toString()));
+		assertThat(name.description,
+				is("Description first tag description second tag description third tag"));
+	}
+
+	@Test
 	void testAddWithHiddenJbangCatalog() throws IOException {
 		TemporaryFolder tmp = new TemporaryFolder();
 		tmp.create();

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -2,7 +2,15 @@ package dev.jbang.cli;
 
 import static dev.jbang.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -151,7 +159,25 @@ public class TestAlias extends BaseTest {
 		AliasUtil.Alias name = AliasUtil.getAlias(tmpPath, "name");
 		assertThat(name.scriptRef, is(testFile.toString()));
 		assertThat(name.description,
-				is("Description first tag description second tag description third tag"));
+				is("Description first tag\ndescription second tag\ndescription third tag"));
+	}
+
+	@Test
+	void testAddWithNoDescriptionTags() throws IOException {
+		TemporaryFolder tmp = new TemporaryFolder();
+		tmp.create();
+		Path tmpPath = tmp.getRoot().toPath();
+		Path testFile = tmpPath.resolve("test.java");
+		Files.write(testFile, ("// Test file \n").getBytes());
+		assertThat(Files.isRegularFile(Paths.get(tmpPath.toString(), AliasUtil.JBANG_CATALOG_JSON)), is(false));
+		Jbang jbang = new Jbang();
+		new CommandLine(jbang).execute("alias", "add", "-f", tmpPath.toString(), "--name=name", testFile.toString());
+		assertThat(Files.isRegularFile(Paths.get(tmp.getRoot().toPath().toString(), AliasUtil.JBANG_CATALOG_JSON)),
+				is(true));
+		AliasUtil.Alias name = AliasUtil.getAlias(tmpPath, "name");
+		assertThat(name.scriptRef, is(testFile.toString()));
+		assertThat(name.description,
+				nullValue());
 	}
 
 	@Test


### PR DESCRIPTION
A proposition that fixes #190.
Support of multiple tag DESCRIPTION that creates a merged description.
The description in argument has more precedence than the DESCRIPTION tag in the script.