### PR TITLE
docs: Jbang install option

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -96,7 +96,7 @@ it setup a `j!` alias you can use instead of `jbang`.
 
 === Using Jbang
 
-Perhaps the coolest way to install Jbang is using Jbang itself.
+The simplest way to install `jbang` is using Jbang itself.
 This method has no other requirements (besides `curl` on Linux/OSX).
 
 Linux/OSX/Windows Bash:

--- a/readme.adoc
+++ b/readme.adoc
@@ -94,9 +94,29 @@ Once you have installed from one of the below approaches it is recommended you r
 to have it setup your `PATH` to include jbang app scripts + it will on operating systems that supports
 it setup a `j!` alias you can use instead of `jbang`.
 
+=== Using Jbang
+
+Perhaps the coolest way to install Jbang is using Jbang itself.
+This method has no other requirements (besides `curl` on Linux/OSX).
+
+Linux/OSX/Windows Bash:
+
+[source, bash]
+----
+curl -Ls https://sh.jbang.dev | bash -s - app install jbang
+----
+
+Windows Powershell:
+
+[source, powershell]
+----
+iex "& { $(iwr -useb https://ps.jbang.dev) } app install jbang"
+----
+
 === SDKMan icon:linux[] / icon:apple[]
 
-To install both java and `jbang` we recommend https://sdkman.io[sdkman] on Linux and OSX.
+Although if you want to have easy updates or install multiple Jbang versions we recommend
+https://sdkman.io[sdkman] to install both java and `jbang` on Linux and OSX.
 
 [source, bash]
 ----


### PR DESCRIPTION
Added explanation how to install Jbang using Jbang is the first option, thereby promoting the option that has no additional dependencies on package managers that are not available by default on the user's system.
