### PR TITLE
bug: Fix gist regex to handle usernames with hyphens

### DIFF
--- a/src/main/java/dev/jbang/Util.java
+++ b/src/main/java/dev/jbang/Util.java
@@ -674,7 +674,7 @@ public class Util {
 		String[] pathPlusAnchor = url.split("#");
 		String fileName = getFileNameFromGistURL(url);
 		String gistapi = pathPlusAnchor[0].replaceFirst(
-				"^https://gist.github.com/(([a-zA-Z0-9]*)/)?(?<gistid>[a-zA-Z0-9]*)$",
+				"^https://gist.github.com/(([a-zA-Z0-9\-]*)/)?(?<gistid>[a-zA-Z0-9]*)$",
 				"https://api.github.com/gists/${gistid}");
 
 		Util.verboseMsg("Gist url api: " + gistapi);


### PR DESCRIPTION
This adds the `-` to the Gist regex as Github user names - such as mine - can contain dashes.