### PR TITLE
feat: support for BOM POM's i.e. maven dependencyManagement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,12 @@ dependencies {
 	implementation 'org.codehaus.plexus:plexus-java:1.0.5'
 	implementation 'com.google.code.gson:gson:2.8.6'
 	implementation 'org.jsoup:jsoup:1.13.1'
-	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api:3.1.4'
-	implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.4'
+
+	implementation 'com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-api:3.1.5-allowpom'
+	implementation 'com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-impl-maven:3.1.5-allowpom'
+
+	//implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-api:3.1.4'
+	//implementation 'org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:3.1.4'
 	implementation "org.slf4j:slf4j-nop:1.7.30"
 	implementation "org.jboss:jandex:2.2.2.Final"
 	//implementation 'org.apache.maven:maven-aether-provider:3.0.5'
@@ -145,8 +149,11 @@ compileTestJava {
 
 shadowJar {
 	minimize()  {
-		exclude(dependency('org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:.*'))
-		exclude(dependency('org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:.*'))
+		//exclude(dependency('org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-spi:.*'))
+		//exclude(dependency('org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:.*'))
+		exclude(dependency('com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-spi:.*'))
+		exclude(dependency('com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-impl-maven:.*'))
+
 		//exclude(dependency('org.slf4j:slf4j-api:.*'))
 		exclude(dependency('org.slf4j:slf4j-nop:.*'))
 		exclude(dependency('org.jboss.logging:jboss-logging:.*'))

--- a/readme.adoc
+++ b/readme.adoc
@@ -530,6 +530,28 @@ $ ./classpath_example.java
 1 [main] INFO classpath_example  - Hello from Java!
 ----
 
+=== Managed dependencies ("BOM POM"'s) [Experimental]
+
+When using libraries and frameworks it can get tedious to mange and update multiple versions.
+For that jbang started since 0.62 to support so called "BOM POM"'s which are commonly used for managing versions.
+
+You use it by having as the very first dependency a `@pom` reference. This first reference will be used
+to define your managed dependences. Below is an example how that could look like when using Quarkus:
+
+```java
+//DEPS io.quarkus:quarkus-bom:1.11.0.Final@pom
+//DEPS io.quarkus:quarkus-resteasy
+//DEPS io.quarkus:quarkus-smallrye-openapi
+//DEPS io.quarkus:quarkus-swagger-ui
+```
+
+Notice the `@pom` at first line and then following dependencies are not required to use explicit versions.
+
+[NOTE]
+At the moment jbang support only one bom pom; in future it should be expanded to multiple.
+For now you can workaround this by reusing a published pom that includes all the dependency management
+sections you need.
+
 === Using links to Git sources
 
 Instead of gradle-style locators you can also use URLs to projects on GitHub, GitLab or BitBucket.

--- a/src/test/java/dev/jbang/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/DependencyResolverTest.java
@@ -213,18 +213,18 @@ class DependencyResolverTest extends BaseTest {
 
 	/*
 	 * @Ignore("BOM import not yet figured out with shrinkwrap")
-	 * 
-	 * @Test void testImportPOM() {
-	 * 
-	 * List<String> deps =
-	 * Arrays.asList("com.microsoft.azure:azure-bom:1.0.0.M1@pom",
-	 * "com.microsoft.azure:azure");
-	 * 
-	 * String classpath = new DependencyUtil().resolveDependencies(deps,
-	 * Collections.emptyList(), false, true);
-	 * 
-	 * assertEquals(46, classpath.split(Settings.CP_SEPARATOR).length);
-	 * 
-	 * }
 	 */
+	@Test
+	void testImportPOM() {
+
+		List<String> deps = Arrays.asList("com.microsoft.azure:azure-bom:1.0.0.M1@pom",
+				"com.microsoft.azure:azure");
+
+		ModularClassPath classpath = new DependencyUtil().resolveDependencies(deps,
+				Collections.emptyList(), false, true);
+
+		assertEquals(62, classpath.getArtifacts().size());
+
+	}
+
 }


### PR DESCRIPTION
jbang will now if and only if the very first dependency has a `@pom`
classifier, download it and load it as pom file in shrinkwrap.

Example:

```java
//DEPS io.quarkus:quarkus-bom:1.11.0.Final@pom
//DEPS io.quarkus:quarkus-resteasy
//DEPS io.quarkus:quarkus-smallrye-openapi
//DEPS io.quarkus:quarkus-swagger-ui
```

Then that pom file dependency management (and dependencies) gets listened to.

Fixes #63


Caveats:
 - I would prefer if could load arbitrary amount of bom/pom's but I haven't found
   a way to do that with shrinkwrap; we could potentially if more than one found generate
   a temporary one that has them all listed (TBD)
- This also means that we can't support the sequence being arbitrary; basically @pom's has to come first
  Should add check that for now is only *one* @pom and reject otherwise we risk breaking users in future when we have it.
- I had to create a fork of shrinkwrap resolver, to circumvent it so it would not filter out pom files. 
  Could probably find a way to call maven directly to get it but for now this is what we got :) 



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->