### PR TITLE
feat: Allow adding repositories from cli using `--repos`

### DIFF
--- a/src/main/java/dev/jbang/AliasUtil.java
+++ b/src/main/java/dev/jbang/AliasUtil.java
@@ -26,6 +26,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
 
 public class AliasUtil {
+
 	public static final String JBANG_CATALOG_JSON = "jbang-catalog.json";
 	public static final String JBANG_IMPLICIT_CATALOG_JSON = "implicit-catalog.json";
 	public static final String JBANG_DOT_DIR = ".jbang";

--- a/src/main/java/dev/jbang/DependencyContext.java
+++ b/src/main/java/dev/jbang/DependencyContext.java
@@ -1,0 +1,72 @@
+package dev.jbang;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class to capture context for dependencies, i.e. optional repositories,
+ * dependencies and classpath that should be considered.
+ * 
+ */
+public class DependencyContext {
+
+	private List<String> repositories;
+	private List<String> dependencies;
+	private List<String> classpaths;
+
+	public DependencyContext(List<String> repositories, List<String> dependencies, List<String> classpaths) {
+		this.setRepositories(repositories);
+		this.setDependencies(dependencies);
+		this.setClasspaths(classpaths);
+	}
+
+	public DependencyContext() {
+		this.repositories = Collections.emptyList();
+		this.dependencies = Collections.emptyList();
+		this.classpaths = Collections.emptyList();
+	}
+
+	List<String> safeList(List<String> list) {
+		if (list == null) {
+			return Collections.emptyList();
+		} else {
+			return Collections.unmodifiableList(list);
+		}
+	}
+
+	public List<String> getRepositories() {
+		return repositories;
+	}
+
+	// TODO: should have properties inherited rather than gobal system
+	public List<MavenRepo> getRepositoriesAsMavenRepo() {
+		return repositories	.stream()
+							.map(PropertiesValueResolver::replaceProperties)
+							.map(DependencyUtil::toMavenRepo)
+							.collect(Collectors.toList());
+	}
+
+	public DependencyContext setRepositories(List<String> repositories) {
+		this.repositories = safeList(repositories);
+		return this;
+	}
+
+	public List<String> getDependencies() {
+		return dependencies;
+	}
+
+	public DependencyContext setDependencies(List<String> dependencies) {
+		this.dependencies = safeList(dependencies);
+		return this;
+	}
+
+	public List<String> getClasspaths() {
+		return classpaths;
+	}
+
+	public DependencyContext setClasspaths(List<String> classpaths) {
+		this.classpaths = safeList(classpaths);
+		return this;
+	}
+}

--- a/src/main/java/dev/jbang/DependencyUtil.java
+++ b/src/main/java/dev/jbang/DependencyUtil.java
@@ -130,6 +130,7 @@ public class DependencyUtil {
 			boolean offline, boolean loggingEnabled, boolean transitively) {
 
 		ConfigurableMavenResolverSystem resolver = Maven.configureResolver()
+														.withClassPathResolution(false)
 														.withMavenCentralRepo(false)
 														.workOffline(offline);
 

--- a/src/main/java/dev/jbang/JarSource.java
+++ b/src/main/java/dev/jbang/JarSource.java
@@ -68,16 +68,17 @@ public class JarSource implements Source {
 	}
 
 	@Override
-	public ModularClassPath resolveClassPath(List<String> additionalDeps, boolean offline) {
+	public ModularClassPath resolveClassPath(DependencyContext additionalDependencyContext, boolean offline) {
 		ModularClassPath classpath;
 		if (DependencyUtil.looksLikeAGav(resourceRef.getOriginalResource())) {
-			List<String> dependencies = new ArrayList<>(additionalDeps);
+			List<String> dependencies = new ArrayList<>(additionalDependencyContext.getDependencies());
 			dependencies.add(resourceRef.getOriginalResource());
 			classpath = new DependencyUtil().resolveDependencies(dependencies,
-					Collections.emptyList(), offline, !Util.isQuiet());
-		} else if (!additionalDeps.isEmpty()) {
-			classpath = new DependencyUtil().resolveDependencies(additionalDeps,
-					Collections.emptyList(), offline, !Util.isQuiet());
+					additionalDependencyContext.getRepositoriesAsMavenRepo(),
+					offline, !Util.isQuiet());
+		} else if (!additionalDependencyContext.getDependencies().isEmpty()) {
+			classpath = new DependencyUtil().resolveDependencies(additionalDependencyContext.getDependencies(),
+					additionalDependencyContext.getRepositoriesAsMavenRepo(), offline, !Util.isQuiet());
 		} else {
 			classpath = new ModularClassPath(
 					Collections.singletonList(new ArtifactInfo(null, getResourceRef().getFile())));

--- a/src/main/java/dev/jbang/ResourceRef.java
+++ b/src/main/java/dev/jbang/ResourceRef.java
@@ -202,7 +202,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 			// support url's as script files
 			result = fetchFromURL(scriptResource, knownTrusted);
 		} else if (DependencyUtil.looksLikeAGav(scriptResource)) {
-			// todo honor offline
+			// todo honor offline and honor repos!
 			String gav = scriptResource;
 			String s = new DependencyUtil().resolveDependencies(Collections.singletonList(gav),
 					Collections.emptyList(), false, !Util.isQuiet(), false).getClassPath();

--- a/src/main/java/dev/jbang/ScriptSource.java
+++ b/src/main/java/dev/jbang/ScriptSource.java
@@ -173,10 +173,13 @@ public class ScriptSource implements Source {
 	}
 
 	@Override
-	public ModularClassPath resolveClassPath(List<String> dependencies, boolean offline) {
+	public ModularClassPath resolveClassPath(DependencyContext dependencies, boolean offline) {
 		ModularClassPath classpath;
 		List<MavenRepo> repositories = getAllRepositories();
-		classpath = new DependencyUtil().resolveDependencies(dependencies, repositories, offline,
+		repositories = Stream	.concat(dependencies.getRepositoriesAsMavenRepo().stream(), repositories.stream())
+								.collect(Collectors.toList());
+
+		classpath = new DependencyUtil().resolveDependencies(dependencies.getDependencies(), repositories, offline,
 				!Util.isQuiet());
 		return classpath;
 	}

--- a/src/main/java/dev/jbang/Source.java
+++ b/src/main/java/dev/jbang/Source.java
@@ -74,10 +74,10 @@ public interface Source {
 	/**
 	 * Resolves the given list of dependencies
 	 *
-	 * @param dependencies List of dependencies
-	 * @param offline      Determines if we can access the network or not
+	 * @param additional Additional dependencies, classpath, repositories etc.
+	 * @param offline    Determines if we can access the network or not
 	 */
-	ModularClassPath resolveClassPath(List<String> dependencies, boolean offline);
+	ModularClassPath resolveClassPath(DependencyContext additional, boolean offline);
 
 	static boolean forJar(File backingFile) {
 		return backingFile != null && backingFile.toString().endsWith(".jar");

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -30,6 +30,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
 import dev.jbang.DecoratedSource;
+import dev.jbang.DependencyContext;
 import dev.jbang.ExitException;
 import dev.jbang.FileRef;
 import dev.jbang.IntegrationManager;
@@ -81,6 +82,9 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	@CommandLine.Option(names = {
 			"-n", "--native" }, description = "Build using native-image", defaultValue = "false")
 	boolean nativeImage;
+
+	@CommandLine.Option(names = { "--repos" }, description = "Add additional repositories.")
+	List<String> repositories;
 
 	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
 	List<String> dependencies;
@@ -330,6 +334,10 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 		if (process.exitValue() != 0) {
 			throw new ExitException(1, "Error during native-image");
 		}
+	}
+
+	protected DependencyContext getDependencyContext() {
+		return new DependencyContext(repositories, dependencies, classpaths);
 	}
 
 	static void createJarFile(DecoratedSource xrunit, File path, File output) throws IOException {

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -15,8 +15,7 @@ public class Build extends BaseBuildCommand {
 			enableInsecure();
 		}
 
-		xrunit = DecoratedSource.forResource(scriptOrFile, null, properties, dependencies, classpaths, fresh,
-				forcejsh);
+		xrunit = DecoratedSource.forResource(scriptOrFile, null, properties, getDependencyContext(), fresh, forcejsh);
 
 		if (xrunit.needsJar()) {
 			build(xrunit);

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -142,8 +142,7 @@ public class Export extends BaseBuildCommand {
 			enableInsecure();
 		}
 
-		xrunit = DecoratedSource.forResource(scriptOrFile, null, properties, dependencies, classpaths, fresh,
-				forcejsh);
+		xrunit = DecoratedSource.forResource(scriptOrFile, null, properties, getDependencyContext(), fresh, forcejsh);
 
 		if (xrunit.needsJar()) {
 			build(xrunit);

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -37,7 +37,6 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 		String javaVersion;
 
 		public ScriptInfo(DecoratedSource xrunit) {
-			List<String> collectDependencies = xrunit.collectAllDependencies();
 			String cp = xrunit.resolveClassPath(offline);
 
 			originalResource = xrunit.getResourceRef().getOriginalResource();

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -70,7 +70,7 @@ public class Run extends BaseBuildCommand {
 		}
 
 		xrunit = prepareArtifacts(
-				DecoratedSource.forResource(scriptOrFile, userParams, properties, dependencies, classpaths, fresh,
+				DecoratedSource.forResource(scriptOrFile, userParams, properties, getDependencyContext(), fresh,
 						forcejsh));
 
 		String cmdline = generateCommandLine(xrunit);
@@ -91,7 +91,7 @@ public class Run extends BaseBuildCommand {
 				Optional<String> javaAgentOptions = agentOption.getValue();
 
 				DecoratedSource agentXrunit = DecoratedSource.forResource(javaAgent, userParams, properties,
-						dependencies, classpaths, fresh, forcejsh);
+						getDependencyContext(), fresh, forcejsh);
 				agentXrunit.setJavaAgentOption(javaAgentOptions.orElse(null));
 				if (agentXrunit.needsJar()) {
 					info("Building javaagent...");

--- a/src/test/java/dev/jbang/BaseTest.java
+++ b/src/test/java/dev/jbang/BaseTest.java
@@ -97,7 +97,7 @@ public abstract class BaseTest {
 		return new ExecutionResult(result, outStr, errStr);
 	}
 
-	protected static class ExecutionResult {
+	public static class ExecutionResult {
 		public final Integer exitCode;
 		public final String out;
 		public final String err;

--- a/src/test/java/dev/jbang/cli/TestExternalDeps.java
+++ b/src/test/java/dev/jbang/cli/TestExternalDeps.java
@@ -1,0 +1,86 @@
+package dev.jbang.cli;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.jbang.BaseTest;
+import dev.jbang.DecoratedSource;
+import dev.jbang.Util;
+
+import picocli.CommandLine;
+
+class TestExternalDeps extends BaseTest {
+
+	String checkdeps = "public class test {"
+			+ "public static void main(String... args) {"
+			+ ""
+			+ " \n"
+			+ "    ClassLoader classLoader = test.class.getClassLoader();\n"
+			+ "\n"
+			+ "    try {\n"
+			+ "        Class aClass = classLoader.loadClass(\"picocli.Commandline\");\n"
+			+ "        System.out.println(aClass.getName());\n"
+			+ "    } catch (ClassNotFoundException e) {\n"
+			+ "        System.out.println(\"ERROR\");\n"
+			+ "    } "
+			+ "}"
+			+ ""
+			+ ""
+			+ "}";
+
+	@Test
+	void testDepsWork(@TempDir File dir) throws IOException {
+
+		File f = new File(dir, "test.java");
+
+		Util.writeString(f.toPath(), checkdeps);
+
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--deps", "info.picocli:picocli:4.6.1",
+				f.getPath());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		DecoratedSource xrunit = DecoratedSource.forResource(f.getPath(), run.userParams, run.properties,
+				run.getDependencyContext(), run.fresh,
+				run.forcejsh);
+
+		run.prepareArtifacts(xrunit);
+
+		String result = run.generateCommandLine(xrunit);
+
+		assertThat(result, containsString("pico"));
+
+	}
+
+	@Test
+	void testReposWork(@TempDir File dir) throws IOException {
+
+		File f = new File(dir, "test.java");
+
+		Util.writeString(f.toPath(), checkdeps);
+
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--repos", "mavencentral", "--repos",
+				"https://jitpack.io",
+				"--deps", "com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-api:3.1.5-allowpom", f.getPath());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		DecoratedSource xrunit = DecoratedSource.forResource(f.getPath(), run.userParams, run.properties,
+				run.getDependencyContext(), run.fresh,
+				run.forcejsh);
+
+		run.prepareArtifacts(xrunit);
+
+		String result = run.generateCommandLine(xrunit);
+
+		assertThat(result, containsString("com.github.jbangdev.jbang"));
+
+	}
+
+}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -58,6 +58,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import dev.jbang.AliasUtil;
 import dev.jbang.BaseTest;
 import dev.jbang.DecoratedSource;
+import dev.jbang.DependencyContext;
 import dev.jbang.ExitException;
 import dev.jbang.ResourceRef;
 import dev.jbang.Settings;
@@ -77,8 +78,8 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
-				run.dependencies, run.classpaths,
-				run.fresh, run.forcejsh);
+				run.getDependencyContext(), run.fresh,
+				run.forcejsh);
 
 		run.prepareArtifacts(xrunit);
 
@@ -101,8 +102,8 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
-				run.dependencies, run.classpaths,
-				run.fresh, run.forcejsh);
+				run.getDependencyContext(), run.fresh,
+				run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -128,8 +129,8 @@ public class TestRun extends BaseTest {
 		empty.createNewFile();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(empty.toString(), run.userParams, run.properties,
-				run.dependencies, run.classpaths,
-				run.fresh, run.forcejsh);
+				run.getDependencyContext(), run.fresh,
+				run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -152,9 +153,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 		assertThat(result, matchesPattern("^.*java(.exe)?.*"));
@@ -182,9 +183,10 @@ public class TestRun extends BaseTest {
 			CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 			Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-			DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-					run.classpaths,
-					run.fresh, run.forcejsh);
+			DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+					run.getDependencyContext(),
+					run.fresh,
+					run.forcejsh);
 
 			String cmdline = run.generateCommandLine(xrunit);
 
@@ -208,9 +210,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		assertThat(xrunit.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*codegen-4.5.0.jar"));
 
@@ -243,9 +245,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		assertThat(xrunit.getResourceRef().getFile().toString(), matchesPattern(".*.jar"));
 
@@ -268,9 +270,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		assertThat(xrunit.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*eclipse.jgit.pgm.*.jar"));
 
@@ -292,9 +294,9 @@ public class TestRun extends BaseTest {
 				"picocli.codegen.aot.graalvm.ReflectionConfigGenerator", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(jar, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String cmd = run.generateCommandLine(xrunit);
 
@@ -317,9 +319,9 @@ public class TestRun extends BaseTest {
 				"blah");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -342,9 +344,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--debug", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -365,9 +367,9 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -394,9 +396,9 @@ public class TestRun extends BaseTest {
 
 		assertThat(run.properties.size(), is(2));
 
-		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String result = run.generateCommandLine(xrunit);
 
@@ -430,8 +432,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		String s = run.generateCommandLine(
-				DecoratedSource.forResource(url, run.userParams, run.properties, run.dependencies, run.classpaths,
-						run.fresh,
+				DecoratedSource.forResource(url, run.userParams, run.properties, run.getDependencyContext(), run.fresh,
 						run.forcejsh));
 
 		assertThat(s, not(containsString("file:")));
@@ -445,8 +446,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		String s = run.generateCommandLine(
-				DecoratedSource.forResource(url, run.userParams, run.properties, run.dependencies, run.classpaths,
-						run.fresh,
+				DecoratedSource.forResource(url, run.userParams, run.properties, run.getDependencyContext(), run.fresh,
 						run.forcejsh));
 		if (Util.isWindows()) {
 			assertThat(s, containsString("^\"^ ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
@@ -636,9 +636,9 @@ public class TestRun extends BaseTest {
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties, run.dependencies,
-				run.classpaths, run.fresh,
-				run.forcejsh);
+		DecoratedSource xrunit = DecoratedSource.forResource(arg, run.userParams, run.properties,
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		run.build(xrunit);
 
@@ -876,11 +876,11 @@ public class TestRun extends BaseTest {
 		writeString(p, agent);
 
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
-		Build run = (Build) pr.subcommand().commandSpec().userObject();
+		BaseBuildCommand run = (BaseBuildCommand) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(p.toFile().getAbsolutePath(), null, run.properties,
-				run.dependencies,
-				run.classpaths, run.fresh, run.forcejsh);
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		run.build(xrunit);
 
@@ -906,11 +906,11 @@ public class TestRun extends BaseTest {
 		writeString(p, preagent);
 
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
-		Build run = (Build) pr.subcommand().commandSpec().userObject();
+		BaseBuildCommand run = (BaseBuildCommand) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(p.toFile().getAbsolutePath(), null, run.properties,
-				run.dependencies,
-				run.classpaths, run.fresh, run.forcejsh);
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		run.build(xrunit);
 
@@ -1014,8 +1014,8 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), run.userParams, run.properties,
-				run.dependencies,
-				run.classpaths, run.fresh, run.forcejsh);
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String line = run.generateCommandLine(xrunit);
 
@@ -1032,8 +1032,8 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), run.userParams, run.properties,
-				run.dependencies,
-				run.classpaths, run.fresh, run.forcejsh);
+				run.getDependencyContext(),
+				run.fresh, run.forcejsh);
 
 		String line = run.generateCommandLine(xrunit);
 
@@ -1046,7 +1046,8 @@ public class TestRun extends BaseTest {
 
 		Run m = new Run();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), null, null, null, null, false, false);
+		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), null, null, new DependencyContext(),
+				false, false);
 
 		m.build(xrunit);
 
@@ -1079,7 +1080,8 @@ public class TestRun extends BaseTest {
 
 		Run m = new Run();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), null, null, null, null, false, false);
+		DecoratedSource xrunit = DecoratedSource.forResource(f.getAbsolutePath(), null, null, new DependencyContext(),
+				false, false);
 
 		m.build(xrunit);
 
@@ -1139,8 +1141,7 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		DecoratedSource xrunit = DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one.java", null,
-				null, null, null, false,
-				false);
+				null, new DependencyContext(), false, false);
 
 		m.build(xrunit);
 
@@ -1180,8 +1181,7 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		DecoratedSource xrunit = DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one.java", null,
-				null, null, null, false,
-				false);
+				null, new DependencyContext(), false, false);
 
 		m.build(xrunit);
 
@@ -1219,8 +1219,7 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		DecoratedSource xrunit = DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one", null, null,
-				null, null, false,
-				false);
+				new DependencyContext(), false, false);
 
 		m.build(xrunit);
 	}
@@ -1244,8 +1243,8 @@ public class TestRun extends BaseTest {
 
 		Run m = new Run();
 
-		DecoratedSource xrunit = DecoratedSource.forResource(dir.toPath().toString(), null, null, null, null, false,
-				false);
+		DecoratedSource xrunit = DecoratedSource.forResource(dir.toPath().toString(), null, null,
+				new DependencyContext(), false, false);
 
 		m.build(xrunit);
 
@@ -1257,7 +1256,8 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		ExitException e = assertThrows(ExitException.class,
-				() -> DecoratedSource.forResource(dir.toPath().toString(), null, null, null, null, false, false));
+				() -> DecoratedSource.forResource(dir.toPath().toString(), null, null, new DependencyContext(), false,
+						false));
 
 		assertThat(e.getMessage(), containsString("is a directory and no default application"));
 
@@ -1280,8 +1280,7 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		DecoratedSource xrunit = DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one/", null, null,
-				null, null, false,
-				false);
+				new DependencyContext(), false, false);
 
 		m.build(xrunit);
 	}
@@ -1303,9 +1302,9 @@ public class TestRun extends BaseTest {
 		Run m = new Run();
 
 		assertThrows(ExitException.class,
-				() -> DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one/", null, null, null,
-						null, false,
-						false));
+				() -> DecoratedSource.forResource("http://localhost:" + wms.port() + "/sub/one/", null, null,
+						new DependencyContext(),
+						false, false));
 
 	}
 


### PR DESCRIPTION
Add `--repo` to cli including a refactoring of how dependency context is
setup.

Now DependencyContext is created and pass through rather than having
individual deps, repos and classpath entries.

Fixes #611

WIP as turns out we have no tests for --deps nor --classpath and thus 
adding test for repos needs more work. Submitting PR just to check 
haven't broken something thus far.

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->