### PR TITLE
fix: Simplistic fix for encoded Content-Disposition

### DIFF
--- a/src/test/java/dev/jbang/TestUtil.java
+++ b/src/test/java/dev/jbang/TestUtil.java
@@ -2,6 +2,7 @@ package dev.jbang;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -87,5 +88,12 @@ public class TestUtil extends BaseTest {
 		assertThat(p, containsInAnyOrder("res/resource.java"));
 		assertThat(p, not(hasItem("test.java")));
 
+	}
+
+	@Test
+	void testDispostionFilename() throws IOException {
+		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates"), equalTo("£ rates"));
+		assertThat(Util.getDispositionFilename("inline; filename*=\"UTF-8''%c2%a3%20and%20%e2%82%ac%20rates\""),
+				equalTo("£ and € rates"));
 	}
 }


### PR DESCRIPTION
Fixes #693

This is not a true fix that will work in all situations. It for example still assumes that `filename` will be the last item in the `Content-Disposition` string, which although almost always true is not really something that the spec requires. A fool proof implementation would be much more complex however so we either we merge this until something better is needed or we just throw this away and add the code linked in the issue. It's up to you @maxandersen :-)