### PR TITLE
feat: `--deps` and `--cp` now available on `info` and `edit`

### DIFF
--- a/src/main/java/dev/jbang/DecoratedSource.java
+++ b/src/main/java/dev/jbang/DecoratedSource.java
@@ -275,6 +275,17 @@ public class DecoratedSource implements Source {
 		return classpath.getAutoDectectedModuleArguments(requestedVersion);
 	}
 
+	public void importJarMetadata() {
+		File outjar = getJar();
+		if (outjar.exists()) {
+			JarSource jar = JarSource.prepareJar(
+					ResourceRef.forNamedFile(getResourceRef().getOriginalResource(), outjar));
+			setMainClass(jar.getMainClass());
+			setPersistentJvmArgs(jar.getRuntimeOptions());
+			setBuildJdk(jar.getBuildJdk());
+		}
+	}
+
 	public static DecoratedSource forResource(String resource) {
 		return forResource(resource, null, null, null, null, false, false);
 	}

--- a/src/main/java/dev/jbang/DecoratedSource.java
+++ b/src/main/java/dev/jbang/DecoratedSource.java
@@ -260,7 +260,10 @@ public class DecoratedSource implements Source {
 		}
 		StringBuilder cp = new StringBuilder(classpath.getClassPath());
 		for (String addcp : additionalClasspaths) {
-			cp.append(Settings.CP_SEPARATOR).append(addcp);
+			if (cp.length() > 0) {
+				cp.append(Settings.CP_SEPARATOR);
+			}
+			cp.append(addcp);
 		}
 		return cp.toString();
 	}

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -45,7 +45,7 @@ import dev.jbang.Util;
 import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
-public abstract class BaseBuildCommand extends BaseScriptCommand {
+public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 	public static final Type STRINGARRAYTYPE = Type.create(DotName.createSimple("[Ljava.lang.String;"),
 			Type.Kind.ARRAY);
 	public static final Type STRINGTYPE = Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS);
@@ -81,12 +81,6 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	@CommandLine.Option(names = {
 			"-n", "--native" }, description = "Build using native-image", defaultValue = "false")
 	boolean nativeImage;
-
-	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
-	List<String> dependencies;
-
-	@CommandLine.Option(names = { "--cp", "--class-path" }, description = "Add class path entries.")
-	List<String> classpaths;
 
 	@CommandLine.Option(names = {
 			"-f",

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -32,12 +32,10 @@ import dev.jbang.ExitException;
 import dev.jbang.FileRef;
 import dev.jbang.IntegrationManager;
 import dev.jbang.IntegrationResult;
-import dev.jbang.JarSource;
 import dev.jbang.JarUtil;
 import dev.jbang.JavaUtil;
 import dev.jbang.JdkManager;
 import dev.jbang.KeyValue;
-import dev.jbang.ResourceRef;
 import dev.jbang.Settings;
 import dev.jbang.Source;
 import dev.jbang.Util;
@@ -96,15 +94,10 @@ public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 		for (Map.Entry<String, String> entry : properties.entrySet()) {
 			System.setProperty(entry.getKey(), entry.getValue());
 		}
-		File outjar = xrunit.getJar();
-		if (outjar.exists()) {
-			JarSource jar = JarSource.prepareJar(
-					ResourceRef.forNamedFile(xrunit.getResourceRef().getOriginalResource(), outjar));
-			xrunit.setMainClass(jar.getMainClass());
-			xrunit.setPersistentJvmArgs(jar.getRuntimeOptions());
-			xrunit.setBuildJdk(jar.getBuildJdk());
-		}
 
+		xrunit.importJarMetadata();
+
+		File outjar = xrunit.getJar();
 		boolean nativeBuildRequired = nativeImage && !getImageName(outjar).exists();
 		IntegrationResult integrationResult = new IntegrationResult(null, null, null);
 		String requestedJavaVersion = javaVersion != null ? javaVersion : xrunit.javaVersion();

--- a/src/main/java/dev/jbang/cli/BaseScriptDepsCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptDepsCommand.java
@@ -1,0 +1,15 @@
+package dev.jbang.cli;
+
+import java.util.List;
+
+import picocli.CommandLine;
+
+public abstract class BaseScriptDepsCommand extends BaseScriptCommand {
+
+	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	List<String> dependencies;
+
+	@CommandLine.Option(names = { "--cp", "--class-path" }, description = "Add class path entries.")
+	List<String> classpaths;
+
+}

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -39,7 +39,7 @@ import io.quarkus.qute.Template;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "edit", description = "Setup a temporary project to edit script in an IDE.")
-public class Edit extends BaseScriptCommand {
+public class Edit extends BaseScriptDepsCommand {
 
 	@CommandLine.Option(names = {
 			"--live" }, description = "Setup temporary project, regenerate project on dependency changes.")
@@ -56,7 +56,7 @@ public class Edit extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		xrunit = DecoratedSource.forResource(scriptOrFile);
+		xrunit = DecoratedSource.forResource(scriptOrFile, null, null, dependencies, classpaths, false, forcejsh);
 		File project = createProjectForEdit(xrunit, false);
 		// err.println(project.getAbsolutePath());
 

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 public class Info {
 }
 
-abstract class BaseInfoCommand extends BaseScriptCommand {
+abstract class BaseInfoCommand extends BaseScriptDepsCommand {
 
 	class ScriptInfo {
 
@@ -62,7 +62,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 			enableInsecure();
 		}
 
-		xrunit = DecoratedSource.forResource(scriptOrFile);
+		xrunit = DecoratedSource.forResource(scriptOrFile, null, null, dependencies, classpaths, false, forcejsh);
 
 		ScriptInfo info = new ScriptInfo(xrunit);
 

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -52,17 +52,19 @@ abstract class BaseInfoCommand extends BaseScriptDepsCommand {
 				resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
 			}
 
-			javaVersion = xrunit.javaVersion();
-
+			if (xrunit.getBuildJdk() > 0) {
+				javaVersion = Integer.toString(xrunit.getBuildJdk());
+			}
 		}
 	}
 
-	protected ScriptInfo getInfo() throws IOException {
+	ScriptInfo getInfo() {
 		if (insecure) {
 			enableInsecure();
 		}
 
 		xrunit = DecoratedSource.forResource(scriptOrFile, null, null, dependencies, classpaths, false, forcejsh);
+		xrunit.importJarMetadata();
 
 		ScriptInfo info = new ScriptInfo(xrunit);
 

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -1,0 +1,98 @@
+package dev.jbang.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+
+import java.nio.file.Paths;
+import java.util.Collection;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+
+import picocli.CommandLine;
+
+public class TestInfo extends BaseTest {
+
+	@Test
+	void testInfoToolsSimple() {
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "itests/quote.java");
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo("itests/quote.java"));
+		assertThat(info.applicationJar, allOf(
+				containsString("quote.java."),
+				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(Paths.get("itests/quote.java").toString()));
+//		assertThat(info.javaVersion, is(nullValue()));
+//		assertThat(info.mainClass, is(nullValue()));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("picocli"))));
+	}
+
+	@Test
+	void testInfoToolsBuilt() {
+		Jbang jbang = new Jbang();
+		new CommandLine(jbang).execute("build", "itests/quote.java");
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "itests/quote.java");
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo("itests/quote.java"));
+		assertThat(info.applicationJar, allOf(
+				containsString("quote.java."),
+				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(Paths.get("itests/quote.java").toString()));
+		assertThat(Integer.parseInt(info.javaVersion), greaterThan(0));
+		assertThat(info.mainClass, equalTo("quote"));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("picocli"))));
+	}
+
+	@Test
+	void testInfoToolsWithDeps() {
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "--deps",
+				"info.picocli:picocli:4.5.0", "itests/helloworld.java");
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo("itests/helloworld.java"));
+		assertThat(info.applicationJar, allOf(
+				containsString("helloworld.java."),
+				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(Paths.get("itests/helloworld.java").toString()));
+//		assertThat(info.javaVersion, is(nullValue()));
+//		assertThat(info.mainClass, is(nullValue()));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("picocli"))));
+	}
+
+	@Test
+	void testInfoToolsWithClasspath() {
+		Jbang jbang = new Jbang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "--cp", "itests/hellojar.jar",
+				"itests/helloworld.java");
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo("itests/helloworld.java"));
+		assertThat(info.applicationJar, allOf(
+				containsString("helloworld.java."),
+				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(Paths.get("itests/helloworld.java").toString()));
+//		assertThat(info.javaVersion, is(nullValue()));
+//		assertThat(info.mainClass, is(nullValue()));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("itests/hellojar.jar"))));
+	}
+}


### PR DESCRIPTION
It's a minor change which adds the flags `--deps` and `--cp` to the `info` and `edit` commands.
It's especially useful for `info` where we can add extra dependencies using `--deps`. The `--cp` is perhaps less useful but it's just to be complete.
The same for `edit`, not sure if these options are very useful for it, but it uses the same kind of code that `info` does, so just to be complete I've added the options there too.