### PR TITLE
Jar classpath + cleanup

### DIFF
--- a/src/main/java/dev/jbang/ScriptSource.java
+++ b/src/main/java/dev/jbang/ScriptSource.java
@@ -34,9 +34,6 @@ import dev.jbang.cli.BaseCommand;
  */
 public class ScriptSource implements Source {
 
-	public static final String BUILD_JDK = "Build-Jdk";
-	public static final String JBANG_JAVA_OPTIONS = "JBang-Java-Options";
-
 	private static final String DEPS_COMMENT_PREFIX = "//DEPS ";
 	private static final String FILES_COMMENT_PREFIX = "//FILES ";
 	private static final String SOURCES_COMMENT_PREFIX = "//SOURCES ";

--- a/src/main/java/dev/jbang/Source.java
+++ b/src/main/java/dev/jbang/Source.java
@@ -11,6 +11,11 @@ import java.util.Properties;
  * that can be used as or turned into executable code.
  */
 public interface Source {
+	String ATTR_BUILD_JDK = "Build-Jdk";
+	String ATTR_JBANG_JAVA_OPTIONS = "JBang-Java-Options";
+	String ATTR_BOOT_CLASS_PATH = "Boot-Class-Path";
+	String ATTR_PREMAIN_CLASS = "Premain-Class";
+	String ATTR_AGENT_CLASS = "Agent-Class";
 
 	/**
 	 * Returns the reference to resource to be executed. This contains both the


### PR DESCRIPTION
The first commit is simple:

The script's classpath was already stored in the JAR but we extracted it only in the specific place where it was needed. The `JarSource` now takes care of extracting that information.
This also cleans up the usage of MANIFEST attribute names a bit.

The second commit is a bit trickier:

The script's JAR is now used exclusively when it exists. Before Jbang would still parse the script file for information about dependencies and options, but those are also stored in the JAR itself so we should skip that and just use the JAR. Which is what this commit does. It also allows us the remove that "specific place" mentioned above.