### PR TITLE
chore: remove unsed code and warnings in eclipse and package setup

### DIFF
--- a/src/main/java/dev/jbang/DependencyUtil.java
+++ b/src/main/java/dev/jbang/DependencyUtil.java
@@ -21,12 +21,10 @@ import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenFormatStage;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenStrategyStage;
-import org.jboss.shrinkwrap.resolver.api.maven.MavenWorkingSession;
 import org.jboss.shrinkwrap.resolver.api.maven.PackagingType;
 import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinates;
-import org.jboss.shrinkwrap.resolver.impl.maven.MavenWorkingSessionContainer;
 
 public class DependencyUtil {
 
@@ -137,10 +135,7 @@ public class DependencyUtil {
 			mavenRepo.apply(resolver);
 		});
 
-		MavenWorkingSession xyz = ((MavenWorkingSessionContainer) resolver).getMavenWorkingSession();
 		System.setProperty("maven.repo.local", Settings.getLocalMavenRepo().toPath().toAbsolutePath().toString());
-
-		List<MavenCoordinate> deps = depIds.stream().map(this::depIdToArtifact).collect(Collectors.toList());
 
 		PomEquippedResolveStage pomResolve = null;
 

--- a/src/main/java/dev/jbang/JdkManager.java
+++ b/src/main/java/dev/jbang/JdkManager.java
@@ -13,6 +13,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import dev.jbang.util.UnpackUtil;
+
 public class JdkManager {
 	private static final String JDK_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/%s";
 

--- a/src/main/java/dev/jbang/ResourceRef.java
+++ b/src/main/java/dev/jbang/ResourceRef.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import dev.jbang.cli.BaseCommand;
+import dev.jbang.util.ConsoleInput;
 
 public class ResourceRef implements Comparable<ResourceRef> {
 	// original requested resource

--- a/src/main/java/dev/jbang/ScriptSource.java
+++ b/src/main/java/dev/jbang/ScriptSource.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import dev.jbang.cli.BaseCommand;
+import dev.jbang.util.PropertiesValueResolver;
 
 /**
  * A Script represents a Source (something runnable) in the form of a source
@@ -79,7 +80,7 @@ public class ScriptSource implements Source {
 		return resourceRef;
 	}
 
-	List<String> getLines() {
+	public List<String> getLines() {
 		if (lines == null && script != null) {
 			lines = Arrays.asList(script.split("\\r?\\n"));
 		}

--- a/src/main/java/dev/jbang/TemplateEngine.java
+++ b/src/main/java/dev/jbang/TemplateEngine.java
@@ -59,7 +59,6 @@ public class TemplateEngine {
 	static class ResourceTemplateLocation implements TemplateLocator.TemplateLocation {
 
 		private final URL resource;
-		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 		private Optional<Variant> variant = Optional.empty();
 
 		public ResourceTemplateLocation(URL resource) {

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -22,8 +22,8 @@ import dev.jbang.JdkManager;
 import dev.jbang.RunContext;
 import dev.jbang.Settings;
 import dev.jbang.Source;
-import dev.jbang.UnpackUtil;
 import dev.jbang.Util;
+import dev.jbang.util.UnpackUtil;
 
 import picocli.CommandLine;
 

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -29,10 +29,7 @@ import org.jboss.jandex.Type;
 
 import dev.jbang.ExitException;
 import dev.jbang.FileRef;
-import dev.jbang.IntegrationManager;
-import dev.jbang.IntegrationResult;
 import dev.jbang.JarSource;
-import dev.jbang.JarUtil;
 import dev.jbang.JavaUtil;
 import dev.jbang.JdkManager;
 import dev.jbang.KeyValue;
@@ -41,6 +38,9 @@ import dev.jbang.ScriptSource;
 import dev.jbang.Source;
 import dev.jbang.TemplateEngine;
 import dev.jbang.Util;
+import dev.jbang.spi.IntegrationManager;
+import dev.jbang.spi.IntegrationResult;
+import dev.jbang.util.JarUtil;
 
 import io.quarkus.qute.Template;
 import picocli.CommandLine;

--- a/src/main/java/dev/jbang/cli/DeprecatedMessageHandler.java
+++ b/src/main/java/dev/jbang/cli/DeprecatedMessageHandler.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.cli;
 
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import dev.jbang.Cache;
-import dev.jbang.ConsoleInput;
 import dev.jbang.DependencyUtil;
 import dev.jbang.EditorManager;
 import dev.jbang.ExitException;
@@ -33,9 +32,9 @@ import dev.jbang.RunContext;
 import dev.jbang.ScriptSource;
 import dev.jbang.Settings;
 import dev.jbang.Source;
-import dev.jbang.StrictParameterPreprocessor;
 import dev.jbang.TemplateEngine;
 import dev.jbang.Util;
+import dev.jbang.util.ConsoleInput;
 
 import io.quarkus.qute.Template;
 import picocli.CommandLine;

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -38,7 +38,6 @@ abstract class BaseInfoCommand extends BaseScriptDepsCommand {
 		String javaVersion;
 
 		public ScriptInfo(Source src, RunContext ctx) {
-			List<String> collectDependencies = ctx.collectAllDependenciesFor(src);
 			String cp = ctx.resolveClassPath(src, offline);
 
 			originalResource = src.getResourceRef().getOriginalResource();

--- a/src/main/java/dev/jbang/cli/Jbang.java
+++ b/src/main/java/dev/jbang/cli/Jbang.java
@@ -21,10 +21,8 @@ import java.util.Set;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 
-import dev.jbang.DeprecatedMessageHandler;
 import dev.jbang.ExitException;
 import dev.jbang.Util;
-import dev.jbang.VersionProvider;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Help.TextTable;

--- a/src/main/java/dev/jbang/cli/StrictParameterPreprocessor.java
+++ b/src/main/java/dev/jbang/cli/StrictParameterPreprocessor.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.cli;
 
 import java.util.Map;
 import java.util.Stack;

--- a/src/main/java/dev/jbang/cli/VersionProvider.java
+++ b/src/main/java/dev/jbang/cli/VersionProvider.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.cli;
 
 import picocli.CommandLine;
 

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.spi;
 
 import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
 
@@ -24,6 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import dev.jbang.ArtifactInfo;
+import dev.jbang.ExitException;
+import dev.jbang.MavenRepo;
+import dev.jbang.ScriptSource;
+import dev.jbang.Util;
 
 /**
  * JBang uses a 'convention based interface' for build time integration.

--- a/src/main/java/dev/jbang/spi/IntegrationResult.java
+++ b/src/main/java/dev/jbang/spi/IntegrationResult.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.spi;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/src/main/java/dev/jbang/util/ConsoleInput.java
+++ b/src/main/java/dev/jbang/util/ConsoleInput.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.util;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;

--- a/src/main/java/dev/jbang/util/ConsoleInputReadTask.java
+++ b/src/main/java/dev/jbang/util/ConsoleInputReadTask.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/dev/jbang/util/JarUtil.java
+++ b/src/main/java/dev/jbang/util/JarUtil.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.util;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/src/main/java/dev/jbang/util/PropertiesValueResolver.java
+++ b/src/main/java/dev/jbang/util/PropertiesValueResolver.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.util;
 
 import java.io.File;
 import java.util.Properties;

--- a/src/main/java/dev/jbang/util/UnpackUtil.java
+++ b/src/main/java/dev/jbang/util/UnpackUtil.java
@@ -1,4 +1,4 @@
-package dev.jbang;
+package dev.jbang.util;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,6 +18,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import dev.jbang.Util;
 
 public class UnpackUtil {
 

--- a/src/test/java/dev/jbang/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/DependencyResolverTest.java
@@ -20,6 +20,8 @@ import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import dev.jbang.util.PropertiesValueResolver;
+
 class DependencyResolverTest extends BaseTest {
 
 	@Test

--- a/src/test/java/dev/jbang/TestSourcesRecursivelyMultipleFiles.java
+++ b/src/test/java/dev/jbang/TestSourcesRecursivelyMultipleFiles.java
@@ -2,7 +2,6 @@ package dev.jbang;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
@@ -66,7 +65,6 @@ class TestSourcesRecursivelyMultipleFiles extends BaseTest {
 
 	@Test
 	void testFindSourcesInMultipleFilesRecursively() throws IOException {
-		File urlCache = null;
 		Path HiJBangPath = TestScript.createTmpFileWithContent("", "HiJbang.java", classHiJbang);
 		Path mainPath = TestScript.createTmpFile("somefolder", "A.java");
 		// Add absolute path in //SOURCES

--- a/src/test/java/dev/jbang/TestUtil.java
+++ b/src/test/java/dev/jbang/TestUtil.java
@@ -9,8 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -66,7 +64,6 @@ public class TestUtil extends BaseTest {
 
 	@Test
 	void testExplode() throws IOException {
-		FileSystem fs = FileSystems.getDefault();
 		Path baseDir = examplesTestFolder.toPath();
 
 		String source = ".";

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -220,7 +220,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallInvalidName() throws IOException {
 		try {
-			ExecutionResult result = checkedRun(null, "app", "install", "--name=invalid>name", "def/not/existing/file");
+			checkedRun(null, "app", "install", "--name=invalid>name", "def/not/existing/file");
 			Assert.fail();
 		} catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), containsString("Not a valid command name"));
@@ -230,7 +230,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallInvalidRef() throws IOException {
 		try {
-			ExecutionResult result = checkedRun(null, "app", "install", "def/not/existing/file");
+			checkedRun(null, "app", "install", "def/not/existing/file");
 			Assert.fail();
 		} catch (ExitException e) {
 			assertThat(e.getMessage(), containsString("Could not read script argument"));

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1281,8 +1281,6 @@ public class TestRun extends BaseTest {
 	@Test
 	void testNoDefaultApp(@TempDir File dir) throws IOException {
 
-		Run m = new Run();
-
 		ExitException e = assertThrows(ExitException.class,
 				() -> Source.forResource(dir.toPath().toString(), RunContext.empty()));
 
@@ -1327,8 +1325,6 @@ public class TestRun extends BaseTest {
 															"}")));
 
 		wms.start();
-		Run m = new Run();
-
 		assertThrows(ExitException.class,
 				() -> Source.forResource("http://localhost:" + wms.port() + "/sub/one/", RunContext.empty()));
 


### PR DESCRIPTION
eclipse cleanup + some intial basic package splits.

spi - service provider interface
util - classes that are truly util (some left named util but they are more things that porbably should be on the actual thing)
cli - old package but some classes was wrongly put in dev.jbang