### PR TITLE
fix: jbang doesn't store additional deps in JAR Class-Path anymore

### DIFF
--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.resolver.api.maven.ConfigurableMavenResolverSystem;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -292,5 +293,13 @@ public class DependencyUtil {
 		} else {
 			return new MavenRepo(repoid, reporef);
 		}
+	}
+
+	@SafeVarargs
+	public static List<String> joinClasspaths(List<String>... classpaths) {
+		return Stream	.of(classpaths)
+						.flatMap(x -> x.stream())
+						.distinct()
+						.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -24,25 +24,34 @@ import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
 
 public class ModularClassPath {
-
 	static final String JAVAFX_PREFIX = "javafx";
 
+	private final List<ArtifactInfo> artifacts;
+
+	private List<String> classPaths;
 	private String classPath;
 	private String manifestPath;
-	private final List<ArtifactInfo> artifacts;
 	private Optional<Boolean> javafx = Optional.empty();
 
 	public ModularClassPath(List<ArtifactInfo> artifacts) {
 		this.artifacts = artifacts;
 	}
 
-	public String getClassPath() {
-		if (classPath == null) {
-			classPath = artifacts	.stream()
+	public List<String> getClassPaths() {
+		if (classPaths == null) {
+			classPaths = artifacts	.stream()
 									.map(it -> it.asFile().getAbsolutePath())
 									.map(it -> it.contains(" ") ? '"' + it + '"' : it)
 									.distinct()
-									.collect(Collectors.joining(CP_SEPARATOR));
+									.collect(Collectors.toList());
+		}
+
+		return classPaths;
+	}
+
+	public String getClassPath() {
+		if (classPath == null) {
+			classPath = String.join(CP_SEPARATOR, getClassPaths());
 		}
 
 		return classPath;

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -517,6 +517,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		ctx.setMainClass("wonkabear");
 
+		ctx.resolveClassPath(src, true);
 		BaseBuildCommand.createJarFile(src, ctx, dir, out);
 
 		try (JarFile jf = new JarFile(out)) {

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -148,7 +148,7 @@ class DependencyResolverTest extends BaseTest {
 		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
 
 		// if returns 5 its because optional deps are included which they shouldn't
-		assertEquals(2, classpath.getClassPath().split(Settings.CP_SEPARATOR).length);
+		assertEquals(2, classpath.getClassPaths().size());
 
 	}
 
@@ -166,7 +166,7 @@ class DependencyResolverTest extends BaseTest {
 		// if returns with duplicates its because some dependencies are multiple times
 		// in the
 		// classpath (commons-text-1.8, commons-lang3-3.9)
-		List<String> cps = Arrays.asList(classpath.getClassPath().split(Settings.CP_SEPARATOR));
+		List<String> cps = classpath.getClassPaths();
 
 		HashSet<String> othercps = new HashSet<>();
 		othercps.addAll(cps);
@@ -188,7 +188,7 @@ class DependencyResolverTest extends BaseTest {
 
 		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
 
-		assertEquals(46, classpath.getClassPath().split(Settings.CP_SEPARATOR).length);
+		assertEquals(46, classpath.getClassPaths().size());
 
 	}
 


### PR DESCRIPTION
Fixes #707

Dumb mistake. I should have double-checked.

If possible I'd do a quick-fix release @maxandersen . It's not _that_ bad , but I don't want people depending on this "feature" and then later complain it got broken :-)

To explain that better: right now you could do `jbang run --dep fu:bar:1.0 myfile.java`  and also `java -jar .../path/to/myfile.java.jar` and that would work.... but it shouldn't. The `--dep` is for adding dependencies at runtime, it shouldn't be "baked in".

But of course people might think it's very useful, you could have provided a whole bunch of deps at compile time but at runtime you don't have to anymore, yay! No! Not yay! :-)

It goes back to the idea of being able to use service loaders etc, it must be possible to specify deps at runtime for that.

Sorry for the long explanation for such a small PR, but I just wanted to make clear the "severity" of the issue.

