### PR TITLE
fix: move to use mavencentral instead of jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 repositories {
-	jcenter()
+	mavenCentral()
 	maven { url 'https://jitpack.io' }
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -593,8 +593,7 @@ In case you prefer `jbang` to just fail-fast when dependencies cannot be found l
 
 === Repositories
 
-By default `jbang` uses https://jcenter.bintray.com/[jcenter] as its repository as it is a superset of Maven Central
-and supposedly should be faster.
+By default `jbang` uses https://repo1.maven.org/maven2/[maven central]. In past it used `jcenter` but with its imminent shutdown deemed best to use central.
 
 And if you are using the above mentioned URL dependencies https://jitpack.io[jitpack] will be added automatically as well.
 
@@ -606,7 +605,7 @@ For ease of use there are also a few shorthands to use popular commonly availabl
 |===
 |Short name | Description
 |`mavencentral`
-|Maven Central
+|Maven Central (`https://repo1.maven.org/maven2/`)
 
 |`jcenter`
 |`https://jcenter.bintray.com/`
@@ -627,7 +626,7 @@ Following example enables use of Maven Central and add a custom `acme` repositor
 
 [WARNING]
 ====
-If you add any `//REPOS` lines `jbang` will no longer consult `jcenter` thus you need to explicitly add it if needed.
+If you add any `//REPOS` lines `jbang` will no longer consult `mavencentral` thus you need to explicitly add it if needed.
 ====
 
 [TIP]

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -259,7 +259,7 @@ public class Edit extends BaseScriptDepsCommand {
 		// resolveDependencies
 		List<MavenRepo> repositories = src.getAllRepositories();
 		if (repositories.isEmpty()) {
-			repositories.add(DependencyUtil.toMavenRepo("jcenter"));
+			repositories.add(DependencyUtil.toMavenRepo("mavencentral"));
 		}
 
 		// Turn any URL dependencies into regular GAV coordinates

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -39,6 +39,7 @@ public class DependencyUtil {
 
 	static {
 		aliasToRepos = new HashMap<>();
+		aliasToRepos.put("mavencentral", "https://repo1.maven.org/maven2/");
 		aliasToRepos.put("jbossorg", "https://repository.jboss.org/nexus/content/groups/public/");
 		aliasToRepos.put("redhat", "https://maven.repository.redhat.com/ga/");
 		aliasToRepos.put("jcenter", "https://jcenter.bintray.com/");
@@ -75,7 +76,7 @@ public class DependencyUtil {
 
 		if (repos.isEmpty()) {
 			repos = new ArrayList<>();
-			repos.add(toMavenRepo("jcenter"));
+			repos.add(toMavenRepo("mavencentral"));
 		}
 
 		// Turn any URL dependencies into regular GAV coordinates
@@ -283,13 +284,6 @@ public class DependencyUtil {
 		String repo = aliasToRepos.get(reporef.toLowerCase());
 		if (repo != null) {
 			return new MavenRepo(Optional.ofNullable(repoid).orElse(reporef.toLowerCase()), repo);
-		} else if ("mavenCentral".equalsIgnoreCase(reporef)) {
-			return new MavenRepo("", "") {
-				@Override
-				public void apply(ConfigurableMavenResolverSystem resolver) {
-					resolver.withMavenCentralRepo(true);
-				}
-			};
 		} else {
 			return new MavenRepo(repoid, reporef);
 		}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -525,22 +525,21 @@ public class Util {
 
 	public static String getDispositionFilename(String disposition) {
 		String fileName = "";
-		int index = disposition.indexOf("filename=");
-		if (index > 0) {
-			fileName = unquote(disposition.substring(index + 9));
-			// Seems not everybody properly quotes the filename
-			fileName = unquote(fileName);
-		} else {
-			index = disposition.indexOf("filename*=");
-			if (index > 0) {
-				String encodedName = unquote(disposition.substring(index + 10));
-				String[] parts = encodedName.split("'", 3);
-				if (parts.length == 3) {
-					try {
-						fileName = URLDecoder.decode(parts[2], parts[0]);
-					} catch (UnsupportedEncodingException e) {
-						Util.infoMsg("Content-Disposition contains unsupported encoding " + parts[0]);
-					}
+		int index1 = disposition.toLowerCase().lastIndexOf("filename=");
+		int index2 = disposition.toLowerCase().lastIndexOf("filename*=");
+		if (index1 > 0 && index1 > index2) {
+			fileName = unquote(disposition.substring(index1 + 9));
+		}
+		if (index2 > 0 && index2 > index1) {
+			String encodedName = disposition.substring(index2 + 10);
+			String[] parts = encodedName.split("'", 3);
+			if (parts.length == 3) {
+				String encoding = parts[0].isEmpty() ? "iso-8859-1" : parts[0];
+				String name = parts[2];
+				try {
+					fileName = URLDecoder.decode(name, encoding);
+				} catch (UnsupportedEncodingException e) {
+					Util.infoMsg("Content-Disposition contains unsupported encoding " + encoding);
 				}
 			}
 		}

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -124,7 +124,7 @@ public class TestEdit extends BaseTest {
 		assert (gradle.exists());
 		String buildGradle = Util.readString(gradle.toPath());
 		assertThat(buildGradle, not(containsString("github.com"))); // should be com.github
-		assertThat(buildGradle, containsString("jcenter")); // auto-added jcenter
+		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added jcenter
 		assertThat(buildGradle, containsString("jitpack.io")); // auto-added jitpack repo
 		assertThat(buildGradle, containsString("compile \"com.github.oldskoolsh:libvirt-schema:0.0.2\""));
 	}

--- a/src/test/java/dev/jbang/util/TestUtil.java
+++ b/src/test/java/dev/jbang/util/TestUtil.java
@@ -91,9 +91,19 @@ public class TestUtil extends BaseTest {
 	}
 
 	@Test
-	void testDispostionFilename() throws IOException {
+	void testDispostionFilename() {
+		assertThat(Util.getDispositionFilename("inline; filename=token"), equalTo("token"));
+		assertThat(Util.getDispositionFilename("inline; filename=\"quoted string\""), equalTo("quoted string"));
 		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates"), equalTo("£ rates"));
-		assertThat(Util.getDispositionFilename("inline; filename*=\"UTF-8''%c2%a3%20and%20%e2%82%ac%20rates\""),
+		assertThat(Util.getDispositionFilename("inline; filename*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates"),
 				equalTo("£ and € rates"));
+		assertThat(Util.getDispositionFilename("inline; filename=token; filename*=iso-8859-1'en'%A3%20rates"),
+				equalTo("£ rates"));
+		// The spec actually tells us to always use filename* but our implementation is
+		// too dumb for that
+		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates; filename=token"),
+				equalTo("token"));
+		// assertThat(Util.getDispositionFilename("inline;
+		// filename*=iso-fake-1''dummy"), equalTo(""));
 	}
 }


### PR DESCRIPTION
Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->