### PR TITLE
chore: enable build and promotion of snapcraft

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -40,6 +40,12 @@ jobs:
           BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
           BREW_USER: ${{ secrets.BREW_USER }}
         run: ./misc/updatespec.sh
+      - name: snap
+        continue-on-error: true
+        env:
+          BREW_GITHUB_TOKEN: ${{ secrets.BREW_GITHUB_TOKEN }}
+          BREW_USER: ${{ secrets.BREW_USER }}
+        run: ./misc/updatesnap.sh
       - name: sdkman
         continue-on-error: true
         env:
@@ -83,4 +89,15 @@ jobs:
           powershell
           choco apikey -k ${{ secrets.CHOCO_API_KEY }} -source https://push.chocolatey.org/
           choco push $(ls *.nupkg | % {$_.FullName}) -s https://push.chocolatey.org/
-
+  snapcraft:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Snapcraft Action
+        uses: samuelmeuli/action-snapcraft@v1.1.3
+        with:
+          snapcraft_token: ${{ secrets.SNAPCRAFT_TOKEN }}
+      - name: Sleep
+        run: sleep 1200
+      - name: Promote
+        run: ./misc/promotesnap.sh

--- a/misc/promotesnap.sh
+++ b/misc/promotesnap.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+########################################################################
+### Release snap
+
+set -e
+
+jbang_version=`ls build/distributions/jbang-*.*.zip | sed -e 's/.*jbang-\(.*\).zip/\1/g'`
+echo "Promoting jbang snap with version $jbang_version from `pwd`"
+
+snapcraft list-revisions jbang | grep ${jbang_version} | awk '{print $1}' | tac | xargs -n1 -I {} snapcraft release jbang {} latest/stable
+
+## to test use `sudo snap install jbang`


### PR DESCRIPTION
This adds tag update of jbang-snap which will trigger
a build on snapcraft visible at https://snapcraft.io/jbang/builds

Then we wait ~20 minutes before we do a scripted promote
of every builds with the same version as we tagged with.

We do it this way as snapcraft for reasons I just don't grok
do not want to enable automated releases..so we have to work our
way around it.



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->