### PR TITLE
fix: No longer showing ugly error after `app setup`

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -423,12 +423,15 @@ class AppSetup extends BaseCommand {
 					System.err.println("Please open a new CMD window for changes to take effect");
 				}
 			}
-			System.out.println(cmd);
-			return EXIT_EXECUTE;
 		} else {
 			if (changed) {
 				System.out.println("Please start a new Shell for changes to take effect");
 			}
+		}
+		if (!cmd.isEmpty()) {
+			System.out.println(cmd);
+			return EXIT_EXECUTE;
+		} else {
 			return EXIT_OK;
 		}
 	}


### PR DESCRIPTION
This would happen when there was nothing to be done but we still
returned with the exit code instructing the startup script to
execute jbang's output.

