### PR TITLE
docs: Fixed "Using Jbang" installation instructions

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -104,14 +104,14 @@ Linux/OSX/Windows Bash:
 
 [source, bash]
 ----
-curl -Ls https://sh.jbang.dev | bash -s - app install jbang
+curl -Ls https://sh.jbang.dev | bash -s - app setup
 ----
 
 Windows Powershell:
 
 [source, powershell]
 ----
-iex "& { $(iwr -useb https://ps.jbang.dev) } app install jbang"
+iex "& { $(iwr -useb https://ps.jbang.dev) } app setup"
 ----
 
 === SDKMan icon:linux[] / icon:apple[]


### PR DESCRIPTION
The current instructions actually resulted in a warning message saying jbang was already installed.
This is because the zero-install procedure already copies the jbang scripts+jar to the same place that `app install` does.
The only thing that's needed is the `app setup` which will make the required changes to the user's PATH.

