### PR TITLE
fix: Using correct backingResoure for JarSources

### DIFF
--- a/src/main/java/dev/jbang/source/JarSource.java
+++ b/src/main/java/dev/jbang/source/JarSource.java
@@ -30,16 +30,17 @@ import dev.jbang.util.Util;
  */
 public class JarSource implements Source {
 	private final ResourceRef resourceRef;
+	private final File jarFile;
 
 	private String classPath;
 	private String mainClass;
 	private List<String> javaRuntimeOptions;
 	private int buildJdk;
 
-	private JarSource(ResourceRef resourceRef) {
+	private JarSource(ResourceRef resourceRef, File jar) {
 		this.resourceRef = resourceRef;
+		this.jarFile = jar;
 		this.javaRuntimeOptions = Collections.emptyList();
-		File jar = getResourceRef().getFile();
 		if (jar.exists()) {
 			try (JarFile jf = new JarFile(jar)) {
 				Attributes attrs = jf.getManifest().getMainAttributes();
@@ -71,7 +72,7 @@ public class JarSource implements Source {
 
 	@Override
 	public File getJarFile() {
-		return getResourceRef().getFile();
+		return jarFile;
 	}
 
 	@Override
@@ -125,6 +126,10 @@ public class JarSource implements Source {
 	}
 
 	public static JarSource prepareJar(ResourceRef resourceRef) {
-		return new JarSource(resourceRef);
+		return new JarSource(resourceRef, resourceRef.getFile());
+	}
+
+	public static JarSource prepareJar(ResourceRef resourceRef, File jarFile) {
+		return new JarSource(resourceRef, jarFile);
 	}
 }

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -2,7 +2,6 @@ package dev.jbang.source;
 
 import static dev.jbang.dependencies.DependencyUtil.joinClasspaths;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -274,14 +273,10 @@ public class RunContext {
 	 * If the given source is a JarSource its metadata will be copied to this
 	 * RunContext and the JarSource will be returned. In any other case the given
 	 * source will be returned;
-	 * 
-	 * @return
 	 */
 	public Source importJarMetadataFor(Source src) {
-		File jarFile = src.getJarFile();
-		if (jarFile.exists()) {
-			JarSource jar = JarSource.prepareJar(
-					ResourceRef.forNamedFile(src.getResourceRef().getOriginalResource(), jarFile));
+		JarSource jar = src.asJarSource();
+		if (jar != null && jar.getJarFile().exists()) {
 			setMainClass(jar.getMainClass());
 			setPersistentJvmArgs(jar.getRuntimeOptions());
 			setBuildJdk(JavaUtil.javaVersion(jar.getJavaVersion()));

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -434,8 +434,7 @@ public class ScriptSource implements Source {
 		JarSource result = null;
 		File jarFile = getJarFile();
 		if (jarFile != null && jarFile.exists()) {
-			JarSource jarSrc = JarSource.prepareJar(
-					ResourceRef.forNamedFile(getResourceRef().getOriginalResource(), jarFile));
+			JarSource jarSrc = JarSource.prepareJar(getResourceRef(), jarFile);
 			if (jarSrc.resolveClassPath(Collections.emptyList()).isValid()) {
 				result = jarSrc;
 			}

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -52,9 +52,7 @@ public class TestInfo extends BaseTest {
 		assertThat(info.applicationJar, allOf(
 				containsString("quote.java."),
 				endsWith(".jar")));
-		assertThat(info.backingResource, allOf(
-				containsString("quote.java."),
-				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(Paths.get("itests/quote.java").toString()));
 		assertThat(Integer.parseInt(info.javaVersion), greaterThan(0));
 		assertThat(info.mainClass, equalTo("quote"));
 		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(


### PR DESCRIPTION
A JarSource that is created from a ScriptSource should have the
same backingResource as the original ScriptSource.

Fixes #734