### PR TITLE
fix: ignore dead symbolic links and fail on explicit missing //SOURCE (#744)f

### DIFF
--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -58,7 +58,11 @@ public class ResourceRef implements Comparable<ResourceRef> {
 			} else {
 				sr = Paths.get(originalResource).resolveSibling(siblingResource).toString();
 			}
-			return forTrustedResource(sr);
+			ResourceRef result = forTrustedResource(sr);
+			if (result == null) {
+				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not find " + siblingResource);
+			}
+			return result;
 		} catch (URISyntaxException e) {
 			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR, e);
 		}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -166,7 +166,7 @@ public class Util {
 		} else if (Util.isURL(filepattern)) {
 			results.add(filepattern);
 		} else if (!filepattern.contains("?") && !filepattern.contains("*")) {
-			// no a pattern thus just as well return path directly
+			// not a pattern thus just as well return path directly
 			results.add(filepattern);
 		} else {
 			// it is a non-url letls try locate it
@@ -178,7 +178,11 @@ public class Util {
 					Path relpath = baseDir.relativize(file);
 					if (matcher.matches(relpath)) {
 						// to avoid windows fail.
-						results.add(relpath.toString().replace("\\", "/"));
+						if (file.toFile().exists()) {
+							results.add(relpath.toString().replace("\\", "/"));
+						} else {
+							Util.verboseMsg("Warning: " + relpath.toString() + " matches but does not exist!");
+						}
 					}
 					return FileVisitResult.CONTINUE;
 				}

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -1,0 +1,137 @@
+package dev.jbang.source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.TreeSet;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+import dev.jbang.cli.ExitException;
+
+class TestSourcesMultipleSomeMissingFiles extends BaseTest {
+
+	String classA = "//SOURCES **/*.java\n"
+			+ "\n"
+			+ "import person.B;\n"
+			+ "\n"
+			+ "public class A {\n"
+			+ "    \n"
+			+ "    public static void main(String args[]) {\n"
+			+ "        new B();\n"
+			+ "		   new HiJbang();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String classB = "package person;\n"
+			+ "\n"
+			+ "//SOURCES model/C.java\n"
+			+ "\n"
+			+ "import person.model.C;\n"
+			+ "\n"
+			+ "public class B {\n"
+			+ "    \n"
+			+ "	public B() {\n"
+			+ "		System.out.println(\"B constructor\");\n"
+			+ "		new C();\n"
+			+ "    }\n"
+			+ "}\n";
+
+	String classC = "package person.model;\n"
+			+ "\n"
+			+ "public class C {\n"
+			+ "    \n"
+			+ "	public C() {\n"
+			+ "		System.out.println(\"C constructor\");\n"
+			+ "        }\n"
+			+ "}\n";
+
+	String classHiJbang = "//SOURCES inner/HelloInner.java\n"
+			+ "\n"
+			+ "public class HiJbang {\n"
+			+ "    \n"
+			+ "	public HiJbang() {\n"
+			+ "		System.out.println(\"HiJbang constructor.\");\n"
+			+ "		new HelloInner();\n"
+			+ "	}\n"
+			+ "}\n";
+
+	String classHelloInner = "public class HelloInner {\n"
+			+ "    \n"
+			+ "	public HelloInner() {\n"
+			+ "		System.out.println(\"HelloInner constructor.\");\n"
+			+ "	}\n"
+			+ "}\n";
+
+	/**
+	 * Tests if a //SOURCES <pattern with *> matches a symbolic link file which
+	 * targets does not exist the file is just ignored
+	 * 
+	 * @throws IOException
+	 */
+	@Test
+	void testFindSourcesInMultipleFilesSymbolicLinkMissing() throws IOException {
+		Path HiJBangPath = TestScript.createTmpFileWithContent("", "HiJbang.java", classHiJbang);
+		Path mainPath = TestScript.createTmpFile("somefolder", "A.java");
+		// Add absolute path in //SOURCES
+		final String mainClass = "//SOURCES " + HiJBangPath.toString() + "\n" + classA;
+		TestScript.writeContentToFile(mainPath, mainClass);
+		Path BPath = TestScript.createTmpFileWithContent(mainPath.getParent(), "person", "B.java", classB);
+		Path target = TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classC);
+		Path t = target.getParent().resolve("C2.java");
+		t.toFile().delete();
+
+		target = Files.copy(target, target.getParent().resolve("C3.java"), StandardCopyOption.REPLACE_EXISTING);
+		Files.createSymbolicLink(t, target);
+		Files.delete(target);
+
+		TestScript.createTmpFileWithContent(HiJBangPath.getParent(), "inner", "HelloInner.java",
+				classHelloInner);
+		String scriptURL = mainPath.toString();
+		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath.toFile());
+		ScriptSource script = ScriptSource.prepareScript(resourceRef);
+		List<ScriptSource> sources = script.getAllSources();
+		assertEquals(sources.size(), 4);
+		TreeSet<String> fileNames = new TreeSet<>();
+		for (ScriptSource source : sources) {
+			fileNames.add(source.getResourceRef().getFile().getName());
+		}
+		assertEquals(fileNames.pollFirst(), "B.java");
+		assertEquals(fileNames.pollFirst(), "C.java");
+		assertEquals(fileNames.pollFirst(), "HelloInner.java");
+		assertEquals(fileNames.pollFirst(), "HiJbang.java");
+	}
+
+	/**
+	 * tests if //SOURCE <specific path> points to file that does not exist then we
+	 * fail.
+	 * 
+	 * @throws IOException
+	 */
+	@Test
+	void testFindSourcesInMultipleFilesSimpleFileMissing() throws IOException {
+		Path HiJBangPath = TestScript.createTmpFileWithContent("", "HiJbang.java", classHiJbang);
+		Path mainPath = TestScript.createTmpFile("somefolder", "A.java");
+		// Add absolute path in //SOURCES
+		final String mainClass = "//SOURCES " + HiJBangPath.toString() + "\n" + classA;
+		TestScript.writeContentToFile(mainPath, mainClass);
+		Path BPath = TestScript.createTmpFileWithContent(mainPath.getParent(), "person", "B.java", classB);
+		Path target = TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classC);
+		Files.delete(target);
+
+		TestScript.createTmpFileWithContent(HiJBangPath.getParent(), "inner", "HelloInner.java",
+				classHelloInner);
+		String scriptURL = mainPath.toString();
+		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath.toFile());
+		ScriptSource script = ScriptSource.prepareScript(resourceRef);
+		Assertions.assertThrows(ExitException.class, () -> script.getAllSources());
+
+	}
+
+}


### PR DESCRIPTION
//SOURCE missingfile.java will now error.
//SOURCE **/*.java and it matches symoblic link which point to dead file will be ignored

@quintesse should we maybe ignore both cases and just print warn during --verbose ? WDYT? 

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->