### PR TITLE
Add support for running jbang on AIX (also removes GNU tar dependency)

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -213,11 +213,11 @@ public class Util {
 	}
 
 	public enum OS {
-		linux, mac, windows, unknown
+		linux, mac, windows, aix, unknown
 	}
 
 	public enum Arch {
-		x32, x64, aarch64, unknown
+		x32, x64, aarch64, ppc64, unknown
 	}
 
 	public enum Vendor {
@@ -320,6 +320,8 @@ public class Util {
 			return OS.linux;
 		} else if (os.startsWith("win")) {
 			return OS.windows;
+		} else if (os.startsWith("aix")) {
+			return OS.aix;
 		} else {
 			Util.verboseMsg("Unknown OS: " + os);
 			return OS.unknown;
@@ -334,6 +336,8 @@ public class Util {
 			return Arch.x32;
 		} else if (arch.matches("^(aarch64)$")) {
 			return Arch.aarch64;
+		} else if (arch.matches("^(ppc64)$")) {
+			return Arch.ppc64;
 		} else {
 			Util.verboseMsg("Unknown Arch: " + arch);
 			return Arch.unknown;

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -48,6 +48,8 @@ case "$(uname -s)" in
     os=mac;;
   CYGWIN*|MINGW*|MSYS*)
     os=windows;;
+  AIX)
+    os=aix;;
   *)
     os=
 esac
@@ -62,7 +64,12 @@ case "$(uname -m)" in
   armv7l)
     arch=arm;;
   *)
-    arch=
+    ## AIX gives a machine ID for `uname -m` but it only supports ppc64
+    if [ "$os" = "aix" ]; then
+      arch=ppc64
+    else
+      arch=
+    fi;;
 esac
 
 ## when mingw/git bash or cygwin fall out to just running the bat file.
@@ -136,11 +143,13 @@ if [[ -z "$JAVA_EXEC" ]]; then
       echo "Installing JDK $javaVersion..." 1>&2
       rm -rf "$TDIR/jdks/$javaVersion.tmp/"
       mkdir -p "$TDIR/jdks/$javaVersion.tmp"
-      tar xf "$TDIR/bootstrap-jdk.tgz" -C "$TDIR/jdks/$javaVersion.tmp" --strip-components=1
+      gzip -cd "$TDIR/bootstrap-jdk.tgz" | tar xf - -C "$TDIR/jdks/$javaVersion.tmp"
       retval=$?
       if [[ $os == mac && $retval -eq 0 ]]; then
-        mv "$TDIR/jdks/$javaVersion.tmp/Contents/Home/"* "$TDIR/jdks/$javaVersion.tmp/"
+        mv "$TDIR/jdks/$javaVersion.tmp/Contents/Home/"*/* "$TDIR/jdks/$javaVersion.tmp/"
         retval=$?
+      else
+        mv "$TDIR/jdks/$javaVersion.tmp/"*/* "$TDIR/jdks/$javaVersion.tmp/"
       fi
       if [ $retval -ne 0 ]; then
         # Check if the JDK was installed properly


### PR DESCRIPTION
This PR (Only about two months after I told @maxandersen I'd do it!) adds support for IBM's AIX:
- Detection of `os` and `arch` variables
- Removal of dependency on GNU tar for `--strip-components` parameter (Similar logic to macos is now used everywhere

Alternatives considered:
- Detect whether GNU tar is present and use the `--strip-components` parameter if it is, otherwise use the alternate mechanism
- Using a weird regex to see if `uname -m` is a hex string and if so assume AIX
- Use uname -p on AIX to set `arch`

Also worth noting that this does still rely on `readline` which isn't standard on AIX but can be obtained from e.g. the `coreutils` package on the AIX toolbox