### PR TITLE
fix: Now correctly handles out-of-date dependencies

### DIFF
--- a/src/main/java/dev/jbang/dependencies/ArtifactInfo.java
+++ b/src/main/java/dev/jbang/dependencies/ArtifactInfo.java
@@ -30,8 +30,12 @@ public class ArtifactInfo {
 		return coordinate;
 	}
 
-	public File asFile() {
+	public File getFile() {
 		return file;
+	}
+
+	public long getTimestamp() {
+		return timestamp;
 	}
 
 	public boolean isUpToDate() {
@@ -39,7 +43,7 @@ public class ArtifactInfo {
 	}
 
 	public String toString() {
-		String path = asFile().getAbsolutePath();
+		String path = getFile().getAbsolutePath();
 		return getCoordinate() == null ? "<null>" : getCoordinate().toCanonicalForm() + "=" + path;
 	}
 

--- a/src/main/java/dev/jbang/dependencies/DependencyCache.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyCache.java
@@ -71,8 +71,8 @@ public class DependencyCache {
 			JsonSerializer<ArtifactInfo> serializer = (src, typeOfSrc, context) -> {
 				JsonObject json = new JsonObject();
 				json.addProperty("gav", src.getCoordinate().toCanonicalForm());
-				json.addProperty("file", src.asFile().getPath());
-				json.addProperty("ts", src.asFile().lastModified());
+				json.addProperty("file", src.getFile().getPath());
+				json.addProperty("ts", src.getTimestamp());
 				return json;
 			};
 			Gson parser = new GsonBuilder()
@@ -107,7 +107,7 @@ public class DependencyCache {
 		Optional<ArtifactInfo> result = cache	.values()
 												.stream()
 												.flatMap(Collection::stream)
-												.filter(art -> art.asFile().equals(artifactPath))
+												.filter(art -> art.getFile().equals(artifactPath))
 												.findFirst();
 		return result.orElse(null);
 	}

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -55,8 +55,8 @@ public class DependencyUtil {
 			"^(?<groupid>[^:]*):(?<artifactid>[^:]*)(:(?<version>[^:@]*))?(:(?<classifier>[^@]*))?(@(?<type>.*))?$");
 
 	public ModularClassPath resolveDependencies(List<String> deps, List<MavenRepo> repos,
-			boolean offline, boolean loggingEnabled) {
-		return resolveDependencies(deps, repos, offline, loggingEnabled, true);
+			boolean offline, boolean updateCache, boolean loggingEnabled) {
+		return resolveDependencies(deps, repos, offline, updateCache, loggingEnabled, true);
 	}
 
 	/**
@@ -67,7 +67,7 @@ public class DependencyUtil {
 	 * @return string with resolved classpath
 	 */
 	public ModularClassPath resolveDependencies(List<String> deps, List<MavenRepo> repos,
-			boolean offline, boolean loggingEnabled, boolean transitivity) {
+			boolean offline, boolean updateCache, boolean loggingEnabled, boolean transitivity) {
 
 		// if no dependencies were provided we stop here
 		if (deps.isEmpty()) {
@@ -95,11 +95,12 @@ public class DependencyUtil {
 		}
 
 		List<ArtifactInfo> cachedDeps = null;
-
-		cachedDeps = DependencyCache.findDependenciesByHash(depsHash);
-
-		if (cachedDeps != null)
-			return new ModularClassPath(cachedDeps);
+		if (!updateCache) {
+			cachedDeps = DependencyCache.findDependenciesByHash(depsHash);
+			if (cachedDeps != null) {
+				return new ModularClassPath(cachedDeps);
+			}
+		}
 
 		if (loggingEnabled) {
 			infoMsg("Resolving dependencies...");

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -40,7 +40,7 @@ public class ModularClassPath {
 	public List<String> getClassPaths() {
 		if (classPaths == null) {
 			classPaths = artifacts	.stream()
-									.map(it -> it.asFile().getAbsolutePath())
+									.map(it -> it.getFile().getAbsolutePath())
 									.map(it -> it.contains(" ") ? '"' + it + '"' : it)
 									.distinct()
 									.collect(Collectors.toList());
@@ -60,7 +60,7 @@ public class ModularClassPath {
 	public String getManifestPath() {
 		if (manifestPath == null) {
 			manifestPath = artifacts.stream()
-									.map(it -> it.asFile().getAbsoluteFile().toURI())
+									.map(it -> it.getFile().getAbsoluteFile().toURI())
 									.map(URI::getPath)
 									.distinct()
 									.collect(Collectors.joining(" "));
@@ -82,7 +82,7 @@ public class ModularClassPath {
 			List<String> commandArguments = new ArrayList<>();
 
 			List<File> fileList = artifacts	.stream()
-											.map(ArtifactInfo::asFile)
+											.map(ArtifactInfo::getFile)
 											.collect(Collectors.toList());
 
 			ResolvePathsRequest<File> result = ResolvePathsRequest	.ofFiles(fileList)

--- a/src/main/java/dev/jbang/source/JarSource.java
+++ b/src/main/java/dev/jbang/source/JarSource.java
@@ -93,17 +93,17 @@ public class JarSource implements Source {
 			List<String> dependencies = new ArrayList<>(additionalDeps);
 			dependencies.add(resourceRef.getOriginalResource());
 			mcp = new DependencyUtil().resolveDependencies(dependencies,
-					Collections.emptyList(), Util.isOffline(), !Util.isQuiet());
+					Collections.emptyList(), Util.isOffline(), Util.isFresh(), !Util.isQuiet());
 		} else if (classPath != null) {
 			ModularClassPath mcp2 = new DependencyUtil().resolveDependencies(additionalDeps,
-					Collections.emptyList(), Util.isOffline(), !Util.isQuiet());
+					Collections.emptyList(), Util.isOffline(), Util.isFresh(), !Util.isQuiet());
 			ModularClassPath mcp3 = ModularClassPath.fromManifestClasspath(classPath);
 			List<ArtifactInfo> arts = Stream.concat(mcp2.getArtifacts().stream(), mcp3.getArtifacts().stream())
 											.collect(Collectors.toList());
 			mcp = new ModularClassPath(arts);
 		} else if (!additionalDeps.isEmpty()) {
 			mcp = new DependencyUtil().resolveDependencies(additionalDeps,
-					Collections.emptyList(), Util.isOffline(), !Util.isQuiet());
+					Collections.emptyList(), Util.isOffline(), Util.isFresh(), !Util.isQuiet());
 		} else {
 			mcp = new ModularClassPath(Collections.emptyList());
 		}

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -216,7 +216,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 			// todo honor offline
 			String gav = scriptResource;
 			String s = new DependencyUtil().resolveDependencies(Collections.singletonList(gav),
-					Collections.emptyList(), Util.isOffline(), !Util.isQuiet(), false).getClassPath();
+					Collections.emptyList(), Util.isOffline(), Util.isFresh(), !Util.isQuiet(), false).getClassPath();
 			result = forCachedResource(scriptResource, new File(s));
 		}
 

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -192,7 +192,7 @@ public class ScriptSource implements Source {
 		ModularClassPath classpath;
 		List<MavenRepo> repositories = getAllRepositories();
 		classpath = new DependencyUtil().resolveDependencies(dependencies, repositories, Util.isOffline(),
-				!Util.isQuiet());
+				Util.isFresh(), !Util.isQuiet());
 		return classpath;
 	}
 

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -62,7 +62,7 @@ public class IntegrationManager {
 			boolean nativeRequested) {
 		URL[] urls = artifacts.stream().map(s -> {
 			try {
-				return s.asFile().toURI().toURL();
+				return s.getFile().toURI().toURL();
 			} catch (MalformedURLException e) {
 				throw new RuntimeException(e);
 			}
@@ -76,7 +76,7 @@ public class IntegrationManager {
 															.collect(Collectors.toList());
 		List<Map.Entry<String, Path>> deps = artifacts	.stream()
 														.map(s -> new MapEntry(s.getCoordinate().toCanonicalForm(),
-																s.asFile().toPath()))
+																s.getFile().toPath()))
 														.collect(Collectors.toList());
 		Path nativeImage = null;
 		String mainClass = null;

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -145,7 +145,7 @@ class DependencyResolverTest extends BaseTest {
 
 		List<String> deps = Arrays.asList("com.offbytwo:docopt:0.6.0.20150202", "log4j:log4j:1.2+");
 
-		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
+		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, false, true);
 
 		// if returns 5 its because optional deps are included which they shouldn't
 		assertEquals(2, classpath.getClassPaths().size());
@@ -161,7 +161,7 @@ class DependencyResolverTest extends BaseTest {
 				"org.apache.commons:commons-configuration2:2.7",
 				"org.apache.commons:commons-text:1.8");
 
-		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
+		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, false, true);
 
 		// if returns with duplicates its because some dependencies are multiple times
 		// in the
@@ -186,7 +186,7 @@ class DependencyResolverTest extends BaseTest {
 		// using shrinkwrap resolves in ${os.detected.version} not being resolved
 		List<String> deps = Collections.singletonList("com.github.docker-java:docker-java:3.1.5");
 
-		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
+		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, false, true);
 
 		assertEquals(46, classpath.getClassPaths().size());
 
@@ -200,7 +200,7 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Arrays.asList("org.openjfx:javafx-graphics:11.0.2:mac", "com.offbytwo:docopt:0.6+");
 
 		ModularClassPath cp = new ModularClassPath(
-				dr.resolveDependencies(deps, Collections.emptyList(), false, true).getArtifacts()) {
+				dr.resolveDependencies(deps, Collections.emptyList(), false, false, true).getArtifacts()) {
 			@Override
 			protected boolean supportsModules(String requestedVersion) {
 				return true;
@@ -226,7 +226,7 @@ class DependencyResolverTest extends BaseTest {
 				"com.microsoft.azure:azure");
 
 		ModularClassPath classpath = new DependencyUtil().resolveDependencies(deps,
-				Collections.emptyList(), false, true);
+				Collections.emptyList(), false, false, true);
 
 		assertEquals(62, classpath.getArtifacts().size());
 

--- a/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
+++ b/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
@@ -26,7 +26,7 @@ public class TestArtifactInfo extends BaseTest {
 				"org.apache.commons:commons-text:1.8");
 
 		DependencyUtil dr = new DependencyUtil();
-		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
+		ModularClassPath classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, false, true);
 
 		DependencyCache.cache("wonka", classpath.getArtifacts());
 


### PR DESCRIPTION
Updating the dependency cache now correctly only writes out the
information that was actually retrieved and updated. Before the
code would always write out the latest timestamps, updating them
for *all* files in the cache, even the ones we weren't even
retrieving. Because resolving dependencies is a multi-step
process this basically ruined the information that was needed
for the following steps.

Fixes #757

