### PR TITLE
Fix quoting in jbang startup scripts

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -101,7 +101,8 @@ else
     rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
     cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
   fi
-  eval "exec $JBDIR/bin/jbang $*"
+  $JBDIR/bin/jbang "$@"
+  exit $?
 fi
 
 # Find/get a JDK

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -74,7 +74,7 @@ esac
 
 ## when mingw/git bash or cygwin fall out to just running the bat file.
 if [[ $os == windows && -f "$abs_jbang_dir/jbang.cmd" ]]; then
-  $abs_jbang_dir/jbang.cmd $*
+  $abs_jbang_dir/jbang.cmd "$@"
   exit $?
 fi
 

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -83,7 +83,7 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
     Remove-Item -Path "$JBDIR\bin\jbang.*" -Force -ErrorAction Ignore >$null 2>&1
     Copy-Item -Path "$TDIR\urls\jbang\bin\*" -Destination "$JBDIR\bin" -Force >$null 2>&1
   }
-  Invoke-Expression ". '$JBDIR\bin\jbang.ps1' $args"
+  . "$JBDIR\bin\jbang.ps1" @args
   break
 }
 


### PR DESCRIPTION
Today while using Jbang on Windows I found out that the hand-off from the bash script (running in Git Bash) to the .cmd file wasn't taking into account quoted arguments.

So something like `jbang hello@jbangdev one "two three"` would display:

```
Hello one
Hello two
Hello three
```

After fixing that I went on to check if other hand-offs had similar problems and indeed, running `curl -Ls https://sh.jbang.dev | bash -s - hello@jbangdev one "two three"` gave the same problem (both on Linux as on Windows).

So the second commit fixes that.