### PR TITLE
fix: make git urls work with jitpack again

### DIFF
--- a/src/main/java/dev/jbang/dependencies/JitPackUtil.java
+++ b/src/main/java/dev/jbang/dependencies/JitPackUtil.java
@@ -110,7 +110,7 @@ public class JitPackUtil {
 		String toGav() {
 			String v;
 			if (version == null) {
-				v = "HEAD-SNAPSHOT"; // using HEAD as no longer possible to know what default branch is called.
+				v = "-SNAPSHOT"; // using HEAD as no longer possible to know what default branch is called.
 			} else if (POSSIBLE_SHA1_PATTERN.matcher(version).matches()) {
 				v = version.substring(0, 10);
 			} else {

--- a/src/test/java/dev/jbang/dependencies/TestJitPack.java
+++ b/src/test/java/dev/jbang/dependencies/TestJitPack.java
@@ -11,7 +11,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGithubUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang"),
-				"com.github.jbangdev:jbang:HEAD-SNAPSHOT");
+				"com.github.jbangdev:jbang:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master"),
 				"com.github.jbangdev:jbang:master-SNAPSHOT");
@@ -32,7 +32,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGithubUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang#foo"),
-				"com.github.jbangdev.jbang:foo:HEAD-SNAPSHOT");
+				"com.github.jbangdev.jbang:foo:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo"),
 				"com.github.jbangdev.jbang:foo:master-SNAPSHOT");
@@ -71,7 +71,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGitlabUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab"),
-				"com.gitlab.gitlab-org:gitlab:HEAD-SNAPSHOT");
+				"com.gitlab.gitlab-org:gitlab:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master"),
 				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
@@ -92,7 +92,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractGitlabUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab#foo"),
-				"com.gitlab.gitlab-org.gitlab:foo:HEAD-SNAPSHOT");
+				"com.gitlab.gitlab-org.gitlab:foo:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master#foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
@@ -113,7 +113,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractBitbucketUrlDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler"),
-				"org.bitbucket.ceylon:ceylon-compiler:HEAD-SNAPSHOT");
+				"org.bitbucket.ceylon:ceylon-compiler:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/"),
 				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
@@ -133,7 +133,7 @@ public class TestJitPack extends BaseTest {
 	@Test
 	void testExtractBitbucketUrlWithHashDependencies() {
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler#foo"),
-				"org.bitbucket.ceylon.ceylon-compiler:foo:HEAD-SNAPSHOT");
+				"org.bitbucket.ceylon.ceylon-compiler:foo:-SNAPSHOT");
 
 		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/#foo"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");


### PR DESCRIPTION
HEAD-SNAPSHOT does not seem to work with jitpack thus moving to use -SNAPSHOT instead

Fixes #766



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->