### PR TITLE
chore: remove gradle 7 deprecations to allow testing using gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,7 +146,9 @@ jar {
 				'Main-Class': 'dev.jbang.Main',
 		)
 	}
-	}
+	duplicatesStrategy = DuplicatesStrategy.INCLUDE // allow duplicates to work with gradle 7
+
+}
 
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,7 @@ dependencies {
 	//implementation 'org.apache.maven:maven-aether-provider:3.0.5'
 	//implementation 'com.google.guava:guava:28.2-jre'
 
-
-	testCompile "com.github.tomakehurst:wiremock-jre8:2.32.0"
+	testImplemetnation "com.github.tomakehurst:wiremock-jre8:2.32.0"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.7.1"
 	testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.1')
@@ -133,12 +132,12 @@ distributions {
 }
 
 latestDistZip {
-	archiveName = "${project.name}.zip"
+	archiveFileName = "${project.name}.zip"
 }
 
 
 latestDistTar {
-	archiveName = "${project.name}.tar"
+	archiveFileName = "${project.name}.tar"
 }
 
 jar {
@@ -178,7 +177,7 @@ shadowJar {
 		attributes 'Main-Class': 'dev.jbang.Main'
 	}
 	// warning is printed about deprecation in 7.0 but if I fix this shadowjar turns into a bogus file
-	archiveName = "${baseName}.${extension}"
+	archiveFileName = "${archiveBaseName}.${archiveExtension}"
 }
 
 test {
@@ -228,7 +227,7 @@ processTestResources.dependsOn copyTestResources
 task createChecksum(type: Checksum) {
 	dependsOn(assembleDist)
 	files = files([distZip, latestDistZip, distTar, latestDistTar].outputs.files.flatten())
-	outputDir = distZip.destinationDir
+	outputDir = distZip.destinationDirectory.get().getAsFile()
 	algorithm = Checksum.Algorithm.SHA256
 }
 
@@ -287,6 +286,23 @@ task tag(type: Exec) {
 	doFirst {
 		println 'Tagging with v' + project.version
 		commandLine 'git', 'tag', '-a', 'v' + project.version, '-F', 'CHANGELOG.md'
+	}
+}
+
+githubRelease {
+	// currently does not work as project.version not set.
+	// FilenameFilter filter = { dir, filename -> filename.contains(project.version) } // ensure nothing extra gets included.
+	//releaseAssets = distZip.destinationDir.listFiles filter
+	releaseAssets = files(distZip.destinationDirectory.get().getAsFile().listFiles(), new File(project.getBuildDir(), "tmp/version.txt"))
+	//println(getReleaseAssets().getFiles())
+	// set ORG_GRADLE_PROJECT_github_token
+	token = project.hasProperty('github_token') ? getProperty('github_token') : "unknown_github_token"
+	owner = "jbangdev"
+	draft = true
+	try {
+		body = grgit.resolve.toTag(project.version).fullMessage
+	} catch (Exception e) {
+		body = "No tag description found for " + project.version
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	//implementation 'org.apache.maven:maven-aether-provider:3.0.5'
 	//implementation 'com.google.guava:guava:28.2-jre'
 
-	testImplemetnation "com.github.tomakehurst:wiremock-jre8:2.32.0"
+	testImplementation "com.github.tomakehurst:wiremock-jre8:2.32.0"
 
 	testImplementation "org.junit.jupiter:junit-jupiter:5.7.1"
 	testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.7.1')
@@ -288,23 +288,6 @@ task tag(type: Exec) {
 	doFirst {
 		println 'Tagging with v' + project.version
 		commandLine 'git', 'tag', '-a', 'v' + project.version, '-F', 'CHANGELOG.md'
-	}
-}
-
-githubRelease {
-	// currently does not work as project.version not set.
-	// FilenameFilter filter = { dir, filename -> filename.contains(project.version) } // ensure nothing extra gets included.
-	//releaseAssets = distZip.destinationDir.listFiles filter
-	releaseAssets = files(distZip.destinationDirectory.get().getAsFile().listFiles(), new File(project.getBuildDir(), "tmp/version.txt"))
-	//println(getReleaseAssets().getFiles())
-	// set ORG_GRADLE_PROJECT_github_token
-	token = project.hasProperty('github_token') ? getProperty('github_token') : "unknown_github_token"
-	owner = "jbangdev"
-	draft = true
-	try {
-		body = grgit.resolve.toTag(project.version).fullMessage
-	} catch (Exception e) {
-		body = "No tag description found for " + project.version
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->