### PR TITLE
fix: be able to launch editors with space in name

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -1,6 +1,7 @@
 package dev.jbang.cli;
 
 import static dev.jbang.Settings.CP_SEPARATOR;
+import static dev.jbang.cli.Run.escapeArguments;
 import static dev.jbang.util.Util.isWindows;
 import static dev.jbang.util.Util.verboseMsg;
 import static java.lang.System.out;
@@ -76,14 +77,15 @@ public class Edit extends BaseScriptDepsCommand {
 						+ System.getenv("GITPOD_WORKSPACE_URL") + "#" + project.getAbsolutePath() + "\n\n");
 			} else {
 				List<String> optionList = new ArrayList<>();
-				optionList.addAll(Arrays.asList(editor.get().split(" ")));
+				optionList.add(editor.get());
 				optionList.add(project.getAbsolutePath());
 
 				String[] cmd;
+				final String editorCommand = escapeArguments(optionList).stream().collect(Collectors.joining(" "));
 				if (isWindows()) {
-					cmd = new String[] { "cmd", "/c", optionList.stream().collect(Collectors.joining(" ")) };
+					cmd = new String[] { "cmd", "/c", editorCommand };
 				} else {
-					cmd = new String[] { "sh", "-c", optionList.stream().collect(Collectors.joining(" ")) };
+					cmd = new String[] { "sh", "-c", editorCommand };
 				}
 				info("Running `" + String.join(" ", cmd) + "`");
 				new ProcessBuilder(cmd).start();


### PR DESCRIPTION
Affects all Operating systems.
Now forcefully escape launched editor.

Fix #798



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->