### PR TITLE
feat: add interactive mode for non-jshell

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1090,6 +1090,16 @@ Java itself will add `JAVA_TOOL_OPTIONS` which will apply to `jbang` too.
 For finer and more explicit control the scripts, `jbang` will add `JBANG_JAVA_OPTIONS` to the call to `jbang` itself.
 Thus if you want to enable debug or other details for `jbang` set that environment variable.
 
+== Interactive REPL
+
+`jbang --interactive` enables use of `jshell` to explore and use your script and any dependencies in a REPL editor.
+
+When using `--interactive` for java/jar scripts/apps jbang sets up a jshell function named `userMain`. `userMain` delegates to
+the main function that would have been called if not running in interactive. You can call it with arguments as follows `userMain(args)`.
+
+NOTE: One caveat about jshell is that it cannt access classes in default package. Thus you will need to add a package statement
+to your script/class to see it.
+
 == Flight Recorder
 
 Flight recorder is a feature of the Java VM that lets you gather diagnostic and profiling data about your script.

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -369,6 +369,8 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
+
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -392,6 +394,8 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
+
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -402,6 +406,30 @@ public class TestRun extends BaseTest {
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("classpath"));
 		assertThat(result, containsString("log4j"));
+	}
+
+	@Test
+	void testDependenciesInteractive() throws IOException {
+
+		environmentVariables.clear("JAVA_HOME");
+		Jbang jbang = new Jbang();
+		String arg = examplesTestFolder.resolve("classpath_example.java").toAbsolutePath().toString();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--interactive", arg);
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		RunContext ctx = RunContext.create(run.userParams, run.properties,
+				run.dependencies, run.classpaths, run.forcejsh);
+		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+
+		String result = run.generateCommandLine(src, ctx);
+
+		assertThat(result, startsWith("jshell "));
+		assertThat(result, (containsString("classpath_example.java")));
+//		assertThat(result, containsString(" --source 11 "));
+		assertThat(result, not(containsString("  ")));
+		assertThat(result, containsString("classpath"));
+		assertThat(result, containsString("log4j"));
+		assertThat(result, not(endsWith(arg)));
 	}
 
 	@Test
@@ -421,6 +449,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -433,9 +462,9 @@ public class TestRun extends BaseTest {
 			assertThat(result, containsString("'-Dquoted=see this'"));
 		}
 		String[] split = result.split("example.java");
-		assertEquals(3, split.length);
+		assertEquals(2, split.length);
 		assertThat(split[0], not(containsString("after=wonka")));
-		assertThat(split[2], containsString("after=wonka"));
+		assertThat(split[1], containsString("after=wonka"));
 	}
 
 	@Test
@@ -457,6 +486,8 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
+
 		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
 
 		String s = run.generateCommandLine(src, ctx);
@@ -473,6 +504,8 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
+
 		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
 
 		String s = run.generateCommandLine(src, ctx);
@@ -1044,6 +1077,8 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(null, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
+
 		ScriptSource src = (ScriptSource) Source.forResource(f.getAbsolutePath(), ctx);
 
 		String line = run.generateCommandLine(src, ctx);
@@ -1056,7 +1091,8 @@ public class TestRun extends BaseTest {
 		Jbang jbang = new Jbang();
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--enablesystemassertions",
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--enablesystemassertions", "--main",
+				"fakemain",
 				f.getAbsolutePath());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -1343,6 +1379,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = RunContext.create(run.userParams, run.properties,
 				run.dependencies, run.classpaths, run.forcejsh);
+		ctx.setMainClass("fakemain");
 
 		assert (run.enableFlightRecording());
 		String line = run.generateCommandLine(Source.forResource(arg, ctx), ctx);


### PR DESCRIPTION
Implementing this revealed lots of our tests relied on 
jbang ignoring no main class found and just added the java
file as argument blindly.

Thats why there is alot of "fakemain" being added to tests so they 
dont fail now that --interactive means no arguments must be passed.

Fixes #112

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->