### PR TITLE
fix: build and runtime not following same java version. fixes 806

### DIFF
--- a/itests/java4321.java
+++ b/itests/java4321.java
@@ -1,0 +1,12 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+// //DEPS <dependency1> <dependency2>
+//JAVA 4321
+
+import static java.lang.System.*;
+
+public class java4321 {
+
+    public static void main(String... args) {
+        out.println("java:" + System.getProperty("java.version"));
+    }
+}

--- a/itests/javaversion.feature
+++ b/itests/javaversion.feature
@@ -1,0 +1,12 @@
+Feature: java version control
+
+  Scenario: java run non existent //java
+    When command('jbang --verbose java4321.java')
+    Then match err contains "incompatible, using Jbang managed version 4321"
+    Then match err contains "Unable to download or install JDK version 4321"
+
+
+  Scenario: java run with explicit java 8
+    When command('jbang --verbose --java 8 java4321.java')
+    Then match err !contains "incompatible, using Jbang managed version 4321"
+    Then match err !contains "Unable to download or install JDK version 4321"

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -18,6 +18,8 @@ public class Build extends BaseBuildCommand {
 
 		RunContext ctx = RunContext.create(null, dependencyInfoMixin.getProperties(),
 				dependencyInfoMixin.getDependencies(), dependencyInfoMixin.getClasspaths(), forcejsh);
+		ctx.setJavaVersion(javaVersion);
+		ctx.setNativeImage(nativeImage);
 		Source src = Source.forResource(scriptOrFile, ctx);
 
 		buildIfNeeded(src, ctx);

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -42,6 +42,8 @@ public class Export {
 		RunContext ctx = RunContext.create(null, exportMixin.dependencyInfoMixin.getProperties(),
 				exportMixin.dependencyInfoMixin.getDependencies(), exportMixin.dependencyInfoMixin.getClasspaths(),
 				false);
+		ctx.setJavaVersion(exportMixin.javaVersion);
+		ctx.setNativeImage(exportMixin.nativeImage);
 		Source src = Source.forResource(exportMixin.scriptOrFile, ctx);
 
 		src = buildIfNeeded(src, ctx);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -71,6 +71,8 @@ public class Run extends BaseBuildCommand {
 
 		RunContext ctx = RunContext.create(userParams, dependencyInfoMixin.getProperties(),
 				dependencyInfoMixin.getDependencies(), dependencyInfoMixin.getClasspaths(), forcejsh);
+		ctx.setJavaVersion(javaVersion);
+		ctx.setNativeImage(nativeImage);
 		Source src = Source.forResource(scriptOrFile, ctx);
 		src = prepareArtifacts(src, ctx);
 
@@ -91,6 +93,8 @@ public class Run extends BaseBuildCommand {
 
 				RunContext actx = RunContext.create(userParams, dependencyInfoMixin.getProperties(),
 						dependencyInfoMixin.getDependencies(), dependencyInfoMixin.getClasspaths(), forcejsh);
+				actx.setJavaVersion(ctx.getJavaVersion());
+				actx.setNativeImage(ctx.isNativeImage());
 				Source asrc = Source.forResource(javaAgent, actx);
 				actx.setJavaAgentOption(javaAgentOptions.orElse(null));
 				if (needsJar(asrc, actx)) {

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -208,6 +208,14 @@ public class RunContext {
 		return nativeImage;
 	}
 
+	public void setNativeImage(boolean nativeImage) {
+		this.nativeImage = nativeImage;
+	}
+
+	public void setJavaVersion(String javaVersion) {
+		this.javaVersion = javaVersion;
+	}
+
 	public String getJavaVersion() {
 		return javaVersion;
 	}


### PR DESCRIPTION
<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->