### PR TITLE
fix: `jdk home` output won't print "echo" anymore

### DIFF
--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -71,7 +71,7 @@ public class Jdk {
 	public Integer home(
 			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version of the JDK to select", arity = "0..1") Integer version) {
 		Path home = getJdkPath(version);
-		System.out.println("echo " + home);
+		System.out.println(home);
 		return EXIT_OK;
 	}
 


### PR DESCRIPTION
Minor but nasty fix.