### PR TITLE
Add quarkus config property for swagger-ui in template

### DIFF
--- a/src/main/resources/init-qrest.java.qute
+++ b/src/main/resources/init-qrest.java.qute
@@ -5,6 +5,7 @@
 //DEPS io.quarkus:quarkus-resteasy
 // //DEPS io.quarkus:quarkus-smallrye-openapi
 // //DEPS io.quarkus:quarkus-swagger-ui
+// //Q:CONFIG quarkus.swagger-ui.always-include=true
 //JAVAC_OPTIONS -parameters
 
 import io.quarkus.runtime.Quarkus;


### PR DESCRIPTION
Without setting configuration property "quarkus.swagger-ui.always-include=true" feature swagger-ui is not installed and path /q/swagger-ui is not build.
This is taken from quarkus tutorial https://quarkus.io/guides/scripting


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
