### PR TITLE
Add quarkus config property for swagger-ui in template

### DIFF
--- a/src/main/resources/init-qrest.java.qute
+++ b/src/main/resources/init-qrest.java.qute
@@ -5,6 +5,7 @@
 //DEPS io.quarkus:quarkus-resteasy
 // //DEPS io.quarkus:quarkus-smallrye-openapi
 // //DEPS io.quarkus:quarkus-swagger-ui
+// //Q:CONFIG quarkus.swagger-ui.always-include=true
 //JAVAC_OPTIONS -parameters
 
 import io.quarkus.runtime.Quarkus;


### PR DESCRIPTION
Without setting configuration property "quarkus.swagger-ui.always-include=true" feature swagger-ui is not installed and path /q/swagger-ui is not build.
This is taken from quarkus tutorial https://quarkus.io/guides/scripting