### PR TITLE
chore: Alias list again shows @ catalog where appropriate

### DIFF
--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -297,6 +297,23 @@ public class Catalog {
 		return catalog;
 	}
 
+	// Returns the implicit name for a Catalog if that Catalog was found in
+	// the list of implicit catalogs
+	public static String findImplicitName(Catalog catalog) {
+		Path file = Settings.getUserImplicitCatalogFile();
+		if (Files.isRegularFile(file) && Files.isReadable(file)) {
+			Catalog implicit = get(file);
+			return implicit.catalogs.entrySet()
+									.stream()
+									.filter(e -> catalog.catalogRef	.getOriginalResource()
+																	.equals(e.getValue().catalogRef))
+									.map(e -> e.getKey())
+									.findAny()
+									.orElse(null);
+		}
+		return null;
+	}
+
 	// This returns the built-in Catalog that can be found in the resources
 	public static Catalog getBuiltin() {
 		Catalog catalog = new Catalog(null, null, null);

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -152,7 +152,8 @@ class AliasList extends BaseAliasCommand {
 	private static void printAlias(PrintStream out, String catalogName, Catalog catalog, String name,
 			int indent) {
 		dev.jbang.catalog.Alias alias = catalog.aliases.get(name);
-		String fullName = catalogName != null ? name + "@" + catalogName : name;
+		String catName = catalogName != null ? catalogName : Catalog.findImplicitName(alias.catalog);
+		String fullName = catName != null ? name + "@" + catName : name;
 		String scriptRef = alias.scriptRef;
 		if (!catalog.aliases.containsKey(scriptRef)
 				&& !Catalog.isValidCatalogReference(scriptRef)) {

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -313,9 +313,9 @@ public class ResourceRef implements Comparable<ResourceRef> {
 
 	private static ResourceRef fetchFromURL(String scriptURL) {
 		try {
-			scriptURL = swizzleURL(scriptURL);
-			Path path = Util.downloadAndCacheFile(scriptURL);
-			return forCachedResource(scriptURL, path.toFile());
+			String url = swizzleURL(scriptURL);
+			Path path = Util.downloadAndCacheFile(url);
+			return forCachedResource(url, path.toFile());
 		} catch (IOException e) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
 		}


### PR DESCRIPTION
The `alias list` command wasn't showing the `@catalogname` in the appropriate circumstances giving the impression that you could run the alias simply by using it's name (which in case of the implicit catalogs isn't the case).