### PR TITLE
feat: `info tools` now returns a lot more information

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -103,6 +103,7 @@ public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 			// We already have a Jar, check if we can still use it
 			JarSource jarSrc = src.asJarSource();
 			if (jarSrc == null
+					|| !jarSrc.isUpToDate()
 					|| JavaUtil.javaVersion(requestedJavaVersion) < JavaUtil.javaVersion(jarSrc.getJavaVersion())) {
 				buildRequired = true;
 			} else {

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -152,7 +152,7 @@ class Tools extends BaseInfoCommand {
 	@Override
 	public Integer doCall() throws IOException {
 
-		Gson parser = new GsonBuilder().setPrettyPrinting().create();
+		Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
 		parser.toJson(getInfo(), System.out);
 
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -7,11 +7,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import dev.jbang.dependencies.MavenRepo;
+import dev.jbang.net.JdkManager;
+import dev.jbang.source.RefTarget;
 import dev.jbang.source.RunContext;
+import dev.jbang.source.ScriptSource;
 import dev.jbang.source.Source;
 
 import picocli.CommandLine;
@@ -23,6 +29,28 @@ public class Info {
 
 abstract class BaseInfoCommand extends BaseScriptDepsCommand {
 
+	class ResourceFile {
+		String originalResource;
+		String backingResource;
+		String target;
+
+		ResourceFile(RefTarget ref) {
+			originalResource = ref.getSource().getOriginalResource();
+			backingResource = ref.getSource().getFile().toString();
+			target = Objects.toString(ref.getTarget(), null);
+		}
+	}
+
+	class Repo {
+		String id;
+		String url;
+
+		Repo(MavenRepo repo) {
+			id = repo.getId();
+			url = repo.getUrl();
+		}
+	}
+
 	class ScriptInfo {
 
 		String originalResource;
@@ -33,33 +61,77 @@ abstract class BaseInfoCommand extends BaseScriptDepsCommand {
 
 		String mainClass;
 
+		List<String> dependencies;
+
+		List<Repo> repositories;
+
 		List<String> resolvedDependencies;
 
 		String javaVersion;
 
+		String requestedJavaVersion;
+
+		String availableJdkPath;
+
+		List<String> compileOptions;
+
 		List<String> runtimeOptions;
 
-		public ScriptInfo(Source src, RunContext ctx) {
-			String cp = ctx.resolveClassPath(src);
+		List<ResourceFile> files;
 
+		List<ScriptInfo> sources;
+
+		public ScriptInfo(Source src, RunContext ctx) {
 			originalResource = src.getResourceRef().getOriginalResource();
 			backingResource = src.getResourceRef().getFile().toString();
 
-			applicationJar = src.getJarFile().getAbsolutePath();
-			mainClass = ctx.getMainClassOr(src);
-
-			if (cp.isEmpty()) {
-				resolvedDependencies = Collections.emptyList();
-			} else {
-				resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
+			ScriptSource ss = src.asScriptSource();
+			List<String> deps = ss.collectDependencies(System.getProperties());
+			if (!deps.isEmpty()) {
+				dependencies = deps;
+			}
+			if (!ss.collectRepositories().isEmpty()) {
+				repositories = ss	.collectRepositories()
+									.stream()
+									.map(repo -> new Repo(repo))
+									.collect(Collectors.toList());
+			}
+			List<RefTarget> refs = ss.collectFiles();
+			if (!refs.isEmpty()) {
+				files = refs.stream()
+							.map(ref -> new ResourceFile(ref))
+							.collect(Collectors.toList());
+			}
+			List<ScriptSource> srcs = ss.collectSources();
+			if (!srcs.isEmpty()) {
+				sources = srcs	.stream()
+								.map(s -> new ScriptInfo(s, null))
+								.collect(Collectors.toList());
+			}
+			if (!ss.getCompileOptions().isEmpty()) {
+				compileOptions = ss.getCompileOptions();
 			}
 
-			if (ctx.getBuildJdk() > 0) {
-				javaVersion = Integer.toString(ctx.getBuildJdk());
-			}
+			if (ctx != null) {
+				applicationJar = src.getJarFile().getAbsolutePath();
+				mainClass = ctx.getMainClassOr(src);
+				requestedJavaVersion = src.getJavaVersion();
+				availableJdkPath = Objects.toString(JdkManager.getCurrentJdk(requestedJavaVersion), null);
 
-			if (ctx.getRuntimeOptions() != null && !ctx.getRuntimeOptions().isEmpty()) {
-				runtimeOptions = ctx.getRuntimeOptions();
+				String cp = ctx.resolveClassPath(src);
+				if (cp.isEmpty()) {
+					resolvedDependencies = Collections.emptyList();
+				} else {
+					resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
+				}
+
+				if (ctx.getBuildJdk() > 0) {
+					javaVersion = Integer.toString(ctx.getBuildJdk());
+				}
+
+				if (ctx.getRuntimeOptions() != null && !ctx.getRuntimeOptions().isEmpty()) {
+					runtimeOptions = ctx.getRuntimeOptions();
+				}
 			}
 		}
 	}

--- a/src/main/java/dev/jbang/source/JarSource.java
+++ b/src/main/java/dev/jbang/source/JarSource.java
@@ -32,10 +32,12 @@ public class JarSource implements Source {
 	private final ResourceRef resourceRef;
 	private final File jarFile;
 
+	// Cached values
 	private String classPath;
 	private String mainClass;
 	private List<String> javaRuntimeOptions;
 	private int buildJdk;
+	private ScriptSource scriptSource;
 
 	private JarSource(ResourceRef resourceRef, File jar) {
 		this.resourceRef = resourceRef;
@@ -76,6 +78,22 @@ public class JarSource implements Source {
 	@Override
 	public JarSource asJarSource() {
 		return this;
+	}
+
+	@Override
+	public ScriptSource asScriptSource() {
+		if (scriptSource == null) {
+			scriptSource = ScriptSource.prepareScript(resourceRef);
+		}
+		return scriptSource;
+	}
+
+	/**
+	 * Determines if the associated jar is up-to-date, returns false if it needs to
+	 * be rebuilt
+	 */
+	public boolean isUpToDate() {
+		return jarFile != null && jarFile.exists() && resolveClassPath(Collections.emptyList()).isValid();
 	}
 
 	@Override
@@ -134,5 +152,11 @@ public class JarSource implements Source {
 
 	public static JarSource prepareJar(ResourceRef resourceRef, File jarFile) {
 		return new JarSource(resourceRef, jarFile);
+	}
+
+	public static JarSource prepareJar(ScriptSource ssrc) {
+		JarSource jsrc = new JarSource(ssrc.getResourceRef(), ssrc.getJarFile());
+		jsrc.scriptSource = ssrc;
+		return jsrc;
 	}
 }

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -285,7 +285,7 @@ public class RunContext {
 	 */
 	public Source importJarMetadataFor(Source src) {
 		JarSource jar = src.asJarSource();
-		if (jar != null && jar.getJarFile().exists()) {
+		if (jar != null && jar.isUpToDate()) {
 			setMainClass(jar.getMainClass());
 			setRuntimeOptions(jar.getRuntimeOptions());
 			setBuildJdk(JavaUtil.javaVersion(jar.getJavaVersion()));

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -128,11 +128,15 @@ public interface Source {
 	}
 
 	/**
-	 * Returns the JarSource associated with this Source or `null` if there is none
-	 * or if it's invalid (invalid could mean that the associated jar is out-of-date
-	 * and needs to be rebuilt).
+	 * Returns the JarSource associated with this Source or `null` if there is none.
 	 */
 	JarSource asJarSource();
+
+	/**
+	 * Returns the ScriptSource associated with this Source or `null` if there is
+	 * none.
+	 */
+	ScriptSource asScriptSource();
 
 	static Source forResource(String resource, RunContext ctx) {
 		ResourceRef resourceRef = ResourceRef.forScriptResource(resource);


### PR DESCRIPTION
Fixes #833

Eg:

```json
$ jbang info tools itests/resource.java
{
  "originalResource": "itests/resource.java",
  "backingResource": "/home/tschotan/projects/jbang/jbang/itests/resource.java",
  "applicationJar": "/home/tschotan/.jbang/cache/jars/resource.java.dd614e274e05a4b3e200963f43ba65e8ee416d7a0955957a1cc93f6f7c7cd224.jar",
  "resolvedDependencies": [],
  "availableJdkPath": "/home/tschotan/.sdkman/candidates/java/current",
  "files": [
    {
      "originalResource": "itests/resource.properties",
      "backingResource": "/home/tschotan/projects/jbang/jbang/itests/resource.properties"
    },
    {
      "originalResource": "itests/resource.properties",
      "backingResource": "/home/tschotan/projects/jbang/jbang/itests/resource.properties",
      "target": "renamed.properties"
    },
    {
      "originalResource": "itests/resource.properties",
      "backingResource": "/home/tschotan/projects/jbang/jbang/itests/resource.properties",
      "target": "META-INF/application.properties"
    }
  ]
}
```

```json
$ jbang info tools itests/one.java     
{
  "originalResource": "itests/one.java",
  "backingResource": "/home/tschotan/projects/jbang/jbang/itests/one.java",
  "applicationJar": "/home/tschotan/.jbang/cache/jars/one.java.a4c9946d3aa4a238c7c44b87c38817ab8aa6d5e48a65cd6ad8cf23b6cf5dade0.jar",
  "resolvedDependencies": [
    "/home/tschotan/.m2/repository/info/picocli/picocli/4.5.0/picocli-4.5.0.jar",
    "/home/tschotan/.m2/repository/org/kohsuke/github-api/1.116/github-api-1.116.jar",
    "/home/tschotan/.m2/repository/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar",
    "/home/tschotan/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.10.2/jackson-databind-2.10.2.jar",
    "/home/tschotan/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.10.2/jackson-annotations-2.10.2.jar",
    "/home/tschotan/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.10.2/jackson-core-2.10.2.jar",
    "/home/tschotan/.m2/repository/commons-io/commons-io/2.4/commons-io-2.4.jar"
  ],
  "availableJdkPath": "/home/tschotan/.sdkman/candidates/java/current",
  "sources": [
    {
      "originalResource": "itests/Two.java",
      "backingResource": "/home/tschotan/projects/jbang/jbang/itests/Two.java",
      "sources": [
        {
          "originalResource": "itests/gh_fetch_release_assets.java",
          "backingResource": "/home/tschotan/projects/jbang/jbang/itests/gh_fetch_release_assets.java",
          "dependencies": [
            "info.picocli:picocli:4.5.0",
            "org.kohsuke:github-api:1.116"
          ]
        },
        {
          "originalResource": "itests/gh_release_stats.java",
          "backingResource": "/home/tschotan/projects/jbang/jbang/itests/gh_release_stats.java",
          "dependencies": [
            "info.picocli:picocli:4.5.0",
            "org.kohsuke:github-api:1.116"
          ]
        }
      ]
    }
  ]
}
```
