### PR TITLE
fix: Update should now work on Windows

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -194,7 +194,12 @@ class AppInstall extends BaseCommand {
 			files	.map(from::relativize)
 					.forEach(f -> {
 						try {
-							Files.copy(from.resolve(f), to.resolve(f), StandardCopyOption.REPLACE_EXISTING,
+							Path fromp = from.resolve(f);
+							Path top = to.resolve(f);
+							if (Util.isWindows() && f.endsWith("jbang.jar") && Files.isRegularFile(top)) {
+								top = Paths.get("jbang.jar.new");
+							}
+							Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
 									StandardCopyOption.COPY_ATTRIBUTES);
 						} catch (IOException e) {
 							throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -20,7 +20,11 @@ if exist "%~dp0jbang.jar" (
 ) else if exist "%~dp0.jbang\jbang.jar" (
   set jarPath=%~dp0.jbang\jbang.jar
 ) else (
-  if not exist "%JBDIR%\bin\jbang.jar" (
+  if exist "%JBDIR%\bin\jbang.jar.new" (
+    rem a new jbang version was found, we replace the old one with it
+    copy /y "%JBDIR%\bin\jbang.jar.new" "%JBDIR%\bin\jbang.jar" > nul 2>&1
+    del /f /q "%JBDIR%\bin\jbang.jar.new"
+  ) else if not exist "%JBDIR%\bin\jbang.jar" (
     echo Downloading JBang... 1>&2
     if not exist "%TDIR%\urls" ( mkdir "%TDIR%\urls" )
     powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest %jburl% -OutFile %TDIR%\urls\jbang.zip"

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -54,28 +54,30 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
 } elseif (Test-Path "$PSScriptRoot\.jbang\jbang.jar") {
   $jarPath="$PSScriptRoot\.jbang\jbang.jar"
 } else {
-  if (-not (Test-Path "$JBDIR\bin\jbang.jar")) {
+  if (Test-Path "$JBDIR\bin\jbang.jar.new") {
+    Move-Item -Path "$JBDIR\bin\jbang.jar.new" -Destination"$JBDIR\bin\jbang.jar" -Force
+  } elseif (-not (Test-Path "$JBDIR\bin\jbang.jar")) {
     [Console]::Error.WriteLine("Downloading JBang...")
     New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
     $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
     try { Invoke-WebRequest "$jburl" -OutFile "$TDIR\urls\jbang.zip"; $ok=$? } catch {
       $ok=$false
-      $error=$_
+      $err=$_
     }
     if (-not ($ok)) { 
       [Console]::Error.WriteLine("Error downloading JBang from $jburl to $TDIR\urls\jbang.zip")
-      [Console]::Error.WriteLine($error)
+      [Console]::Error.WriteLine($err)
       break 
     }
     [Console]::Error.WriteLine("Installing JBang...")
     Remove-Item -LiteralPath "$TDIR\urls\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
     try { Expand-Archive -Path "$TDIR\urls\jbang.zip" -DestinationPath "$TDIR\urls"; $ok=$? } catch {
       $ok=$false 
-      $error=$_
+      $err=$_
     }
     if (-not ($ok)) { 
       [Console]::Error.WriteLine("Error unzipping JBang from $TDIR\urls\jbang.zip to $TDIR\urls")
-      [Console]::Error.WriteLine($error)
+      [Console]::Error.WriteLine($err)
       break 
     }
     New-Item -ItemType Directory -Force -Path "$JBDIR\bin" >$null 2>&1


### PR DESCRIPTION
When a new update gets downloaded we won't try to overwrite
the jbang.jar on Windows because that would fail anyway.
Instead we copy the new jar next to the old jar as `jbang.jar.new`
and we overwrite the old version when the user runs jbang the
next time.

Fixes #823

