### PR TITLE
fix: Make startup scripts a little more foolproof

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -97,7 +97,7 @@ if [ -f "$abs_jbang_dir/jbang.jar" ]; then
 elif [ -f "$abs_jbang_dir/.jbang/jbang.jar" ]; then
   jarPath=$abs_jbang_dir/.jbang/jbang.jar
 else
-  if [ ! -f "$JBDIR/bin/jbang.jar" ]; then
+  if [ ! -f "$JBDIR/bin/jbang.jar" || ! -f "$JBDIR/bin/jbang" ]; then
     echo "Downloading JBang..." 1>&2
     mkdir -p "$TDIR/urls"
     jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar"

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -54,9 +54,9 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
 } elseif (Test-Path "$PSScriptRoot\.jbang\jbang.jar") {
   $jarPath="$PSScriptRoot\.jbang\jbang.jar"
 } else {
-  if (Test-Path "$JBDIR\bin\jbang.jar.new") {
+  if (Test-Path "$JBDIR\bin\jbang.jar.new" -and Test-Path "$JBDIR\bin\jbang.ps1") {
     Move-Item -Path "$JBDIR\bin\jbang.jar.new" -Destination"$JBDIR\bin\jbang.jar" -Force
-  } elseif (-not (Test-Path "$JBDIR\bin\jbang.jar")) {
+  } elseif (-not (Test-Path "$JBDIR\bin\jbang.jar") -or -not (Test-Path "$JBDIR\bin\jbang.ps1")) {
     [Console]::Error.WriteLine("Downloading JBang...")
     New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
     $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"


### PR DESCRIPTION
The scripts will now detect if an install is missing
a required file and try to re-download.

