### PR TITLE
fix: Correct use of @-files

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -103,7 +103,8 @@ public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 			JarSource jarSrc = src.asJarSource();
 			if (jarSrc == null
 					|| !jarSrc.isUpToDate()
-					|| JavaUtil.javaVersion(requestedJavaVersion) < JavaUtil.javaVersion(jarSrc.getJavaVersion())) {
+					|| JavaUtil.javaVersion(requestedJavaVersion) < JavaUtil.minRequestedVersion(
+							jarSrc.getJavaVersion())) {
 				buildRequired = true;
 			} else {
 				result = ctx.importJarMetadataFor(jarSrc);

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -363,6 +363,14 @@ public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 		return arg;
 	}
 
+	static String escapeArgsFileArgument(String arg) {
+		if (!shellSafeChars.matcher(arg).matches()) {
+			arg = arg.replaceAll("([\"'\\\\])", "\\\\$1");
+			arg = "\"" + arg + "\"";
+		}
+		return arg;
+	}
+
 	static String escapeWindowsArgument(String arg) {
 		if (Util.isUsingPowerShell()) {
 			if (!pwrSafeChars.matcher(arg).matches()) {


### PR DESCRIPTION
We now correctly quote the first CLI argument as well as all the
arguments in the @-file. We also take into account now the values
of //JAVA and --java when determining which Java version we're
running.

Fixes #874

