### PR TITLE
docs:Fix the fedora corp url

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -226,7 +226,7 @@ by doing the following:
 
 [source]
 ----
-dnf copr enable maxandersen/jbang
+dnf copr enable @jbangdev/jbang 
 dnf install jbang
 ----
 


### PR DESCRIPTION
The version in the old url is still 24