### PR TITLE
fix: Docs don't explain several JBANG_ env vars #785

### DIFF
--- a/docs/modules/ROOT/pages/caching.adoc
+++ b/docs/modules/ROOT/pages/caching.adoc
@@ -16,4 +16,4 @@ In previous versions of `jbang`, Java 10+ direct launch of `.java` was used, but
 
 The caching goes to `~/.jbang/cache` by default, you can run `jbang cache clear` to remove all cache data from this folder.
 
-The default cache location can be overwritten by the environment variable `JBANG_CACHE_DIR`. If `$JBANG_DIR` environment variable is set, the `cache` folder will be placed there.
+The default cache location can be overwritten by the environment variable `JBANG_CACHE_DIR`. If `JBANG_DIR` environment variable is set, the `cache` folder will be placed there.

--- a/docs/modules/ROOT/pages/caching.adoc
+++ b/docs/modules/ROOT/pages/caching.adoc
@@ -15,3 +15,5 @@ endif::[]
 In previous versions of `jbang`, Java 10+ direct launch of `.java` was used, but since v0.6 `jbang` works with Java 8 and thus it needs to do a separate compile step. Besides now working with Java 8 this also allows to cache the compiled script and thus launch faster on consecutive runs.
 
 The caching goes to `~/.jbang/cache` by default, you can run `jbang cache clear` to remove all cache data from this folder.
+
+The default cache location can be overwritten by the environment variable `JBANG_CACHE_DIR`. If `$JBANG_DIR` environment variable is set, the `cache` folder will be placed there.

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -163,6 +163,7 @@ For secure authentication `jbang` will honor `~/.m2/settings-security.xml` for c
 username/passwords.
 ====
 
+By default, `jbang` uses `~/.m2` as local repository, but this can be overwritten by the environment variable `JBANG_REPO`.
 
 == Using `@Grab`
 

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -22,6 +22,11 @@ Once you hav installed from one of the below approaches it is recommended you ru
  your `PATH` to include jbang app scripts + it will on operating systems that supports
 it setup a `j!` alias you can use instead of `jbang`.
 
+[NOTE]
+====
+By default `jbang` uses `~/.jbang` for configurations and build cache. This can be changed using the environment variable `JBANG_DIR`.
+====
+
 == Using JBang
 
 The simplest way to install `jbang` is using JBang itself.


### PR DESCRIPTION
Fixes #785
Add short documentation of the 3 undocumented environment variables JBANG_DIR, JBANG_REPO and JBANG_CACHE_DIR listed in #785