### PR TITLE
fix: better trust url for maven central and default to parent url

### DIFF
--- a/src/test/java/dev/jbang/source/TestTrustedSources.java
+++ b/src/test/java/dev/jbang/source/TestTrustedSources.java
@@ -1,0 +1,36 @@
+package dev.jbang.source;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+
+/**
+ * Both class A and person.B have //SOURCES model/C.java
+ */
+public class TestTrustedSources extends BaseTest {
+
+	@Test
+	void testGoodUrlsToTrust() throws IOException {
+		assertEquals("https://github.com/maxandersen/myproject/",
+				ResourceRef.goodTrustURL("https://github.com/maxandersen/myproject/blob/master/file.java"));
+
+		assertEquals("https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/",
+				ResourceRef.goodTrustURL(
+						"https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.0.0.Final/quarkus-cli-2.0.0.Final-runner.jar"));
+
+		assertEquals("https://github.com/",
+				ResourceRef.goodTrustURL("https://github.com/t.java"));
+
+		assertEquals("https://github.com/",
+				ResourceRef.goodTrustURL("https://github.com/"));
+
+		assertEquals("https://acme.org",
+				ResourceRef.goodTrustURL("https://acme.org"));
+
+	}
+
+}


### PR DESCRIPTION
When running something like:

  jbang run https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.0.0.Final/quarkus-cli-2.0.0.Final-runner.jar

jbang would offer to trust https://repo1.maven.org which is too broad as
default.

Fixed this by adding pattern match for repo1.maven.org so it will suggest
closest Group and Artifact (i.e. https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/)
and have the fallback when url not recognized to just return the parent path.

i.e. https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.0.0.Final/
assuming repo1.maven.org was not covered.

Fixes #944


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
