### PR TITLE
Honor maven.repo.local system property to align with maven and gradle behavior. JBANG_REPO env variable will win if both present.

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -31,8 +31,10 @@ public class Settings {
 								.getOrDefault(JBANG_REPO,
 										(String) System	.getProperties()
 														.getOrDefault("maven.repo.local",
-																System.getProperty("user.home") + "/.m2/repository")))
-																														.getAbsoluteFile();
+																System.getProperty("user.home")
+																		+ File.separator + ".m2" + File.separator
+																		+ "repository")))
+																							.getAbsoluteFile();
 	}
 
 	public static Path getCacheDependencyFile() {

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -27,7 +27,11 @@ public class Settings {
 	final public static String CP_SEPARATOR = File.pathSeparator;
 
 	public static File getLocalMavenRepo() {
-		return new File(System.getenv().getOrDefault(JBANG_REPO, System.getProperty("user.home") + "/.m2/repository"))
+		return new File(System	.getenv()
+								.getOrDefault(JBANG_REPO,
+										(String) System	.getProperties()
+														.getOrDefault("maven.repo.local",
+																System.getProperty("user.home") + "/.m2/repository")))
 																														.getAbsoluteFile();
 	}
 

--- a/src/test/java/dev/jbang/cli/TestSettings.java
+++ b/src/test/java/dev/jbang/cli/TestSettings.java
@@ -27,6 +27,7 @@ public class TestSettings {
 
 		environmentVariables.set("JBANG_REPO", "/envrepo");
 		assertEquals(Settings.getLocalMavenRepo().toString(), "/envrepo");
+		environmentVariables.clear("JBANG_REPO");
 
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestSettings.java
+++ b/src/test/java/dev/jbang/cli/TestSettings.java
@@ -1,6 +1,8 @@
 package dev.jbang.cli;
 
+import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -18,15 +20,15 @@ public class TestSettings {
 
 		assertEquals(Settings.getLocalMavenRepo().toString(), System.getProperty("user.home") + "/.m2/repository");
 
-		System.setProperty("maven.repo.local", "/nowhere");
+		System.setProperty("maven.repo.local", "nowhere");
 		try {
-			assertEquals(Settings.getLocalMavenRepo().toString(), "/nowhere");
+			assertThat(Settings.getLocalMavenRepo().toString(), endsWith("nowhere"));
 		} finally {
 			System.clearProperty("maven.repo.local");
 		}
 
-		environmentVariables.set("JBANG_REPO", "/envrepo");
-		assertEquals(Settings.getLocalMavenRepo().toString(), "/envrepo");
+		environmentVariables.set("JBANG_REPO", "envrepo");
+		assertThat(Settings.getLocalMavenRepo().toString(), endsWith("envrepo"));
 		environmentVariables.clear("JBANG_REPO");
 
 	}

--- a/src/test/java/dev/jbang/cli/TestSettings.java
+++ b/src/test/java/dev/jbang/cli/TestSettings.java
@@ -1,0 +1,32 @@
+package dev.jbang.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Rule;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.Settings;
+
+public class TestSettings {
+
+	@Rule
+	public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+	@Test
+	void testRepo() {
+
+		assertEquals(Settings.getLocalMavenRepo().toString(), System.getProperty("user.home") + "/.m2/repository");
+
+		System.setProperty("maven.repo.local", "/nowhere");
+		try {
+			assertEquals(Settings.getLocalMavenRepo().toString(), "/nowhere");
+		} finally {
+			System.clearProperty("maven.repo.local");
+		}
+
+		environmentVariables.set("JBANG_REPO", "/envrepo");
+		assertEquals(Settings.getLocalMavenRepo().toString(), "/envrepo");
+
+	}
+}

--- a/src/test/java/dev/jbang/cli/TestSettings.java
+++ b/src/test/java/dev/jbang/cli/TestSettings.java
@@ -4,6 +4,8 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.jupiter.api.Test;
@@ -18,7 +20,9 @@ public class TestSettings {
 	@Test
 	void testRepo() {
 
-		assertEquals(Settings.getLocalMavenRepo().toString(), System.getProperty("user.home") + "/.m2/repository");
+		assertEquals(Settings.getLocalMavenRepo().toString(),
+				System.getProperty("user.home") + File.separator + ".m2" + File.separator
+						+ "repository");
 
 		System.setProperty("maven.repo.local", "nowhere");
 		try {


### PR DESCRIPTION
<!-
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->