### PR TITLE
feat: properties for init templates

### DIFF
--- a/docs/modules/ROOT/pages/templates.adoc
+++ b/docs/modules/ROOT/pages/templates.adoc
@@ -72,3 +72,11 @@ $ jbang template add showlogo.java img.jpg some.properties
 [jbang] No explicit target pattern was set, using first file: \{basename}.java=showlogo.java
 [jbang] Template 'showlogo' added to '.../jbang-catalog.json'
 ----
+
+== Properties
+
+Templates can refer to properties passed in using `-Dkey=value` on the `jbang init` command.
+
+Any key specified via `-Dkey=value` becomes available as `{key}` inside the templates.
+
+It is recommended you write templates where there is some kind of valid default or fallback on behavior as users might not be aware there is need for a key.

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -149,7 +149,7 @@ public class Init extends BaseScriptCommand {
 			if (properties == null) {
 				properties = new HashMap<>();
 			}
-			TemplateInstance templateWithData = template.data("properties", properties);
+			TemplateInstance templateWithData = template.instance();
 			properties.forEach((k, v) -> templateWithData.data(k, v));
 
 			templateWithData.data("baseName", basename);

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -9,7 +9,6 @@ import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -122,7 +121,8 @@ public class Init extends BaseScriptCommand {
 		return Paths.get(result);
 	}
 
-	private void renderQuteTemplate(Path outFile, ResourceRef templateRef, Map<String, Object> properties) throws IOException {
+	private void renderQuteTemplate(Path outFile, ResourceRef templateRef, Map<String, Object> properties)
+			throws IOException {
 		Util.verboseMsg("Rendering template " + templateRef.getOriginalResource() + " to " + outFile);
 		renderQuteTemplate(outFile, templateRef.getFile().getAbsolutePath(), properties);
 	}
@@ -146,15 +146,14 @@ public class Init extends BaseScriptCommand {
 
 		Files.createDirectories(outFile.getParent());
 		try (BufferedWriter writer = Files.newBufferedWriter(outFile)) {
-			if(properties==null) {
+			if (properties == null) {
 				properties = new HashMap<>();
 			}
 			TemplateInstance templateWithData = template.data("properties", properties);
-			properties.forEach((k,v) -> templateWithData.data(k,v));
+			properties.forEach((k, v) -> templateWithData.data(k, v));
 
 			templateWithData.data("baseName", basename);
 			String result = templateWithData.render();
-
 
 			writer.write(result);
 			outFile.toFile().setExecutable(true);

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -6,7 +6,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -18,6 +21,7 @@ import dev.jbang.util.TemplateEngine;
 import dev.jbang.util.Util;
 
 import io.quarkus.qute.Template;
+import io.quarkus.qute.TemplateInstance;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "init", description = "Initialize a script.")
@@ -32,6 +36,9 @@ public class Init extends BaseScriptCommand {
 	@CommandLine.Option(names = {
 			"--force" }, description = "Force overwrite of existing files")
 	boolean force;
+
+	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
+	Map<String, Object> properties;
 
 	@Override
 	public Integer doCall() throws IOException {
@@ -72,7 +79,7 @@ public class Init extends BaseScriptCommand {
 				if (refTarget.getSource().getOriginalResource().endsWith(".qute")) {
 					// TODO fix outFile path handling
 					Path out = refTarget.to(outDir);
-					renderQuteTemplate(out, refTarget.getSource());
+					renderQuteTemplate(out, refTarget.getSource(), properties);
 				} else {
 					refTarget.copy(outDir);
 				}
@@ -115,12 +122,16 @@ public class Init extends BaseScriptCommand {
 		return Paths.get(result);
 	}
 
-	private void renderQuteTemplate(Path outFile, ResourceRef templateRef) throws IOException {
+	private void renderQuteTemplate(Path outFile, ResourceRef templateRef, Map<String, Object> properties) throws IOException {
 		Util.verboseMsg("Rendering template " + templateRef.getOriginalResource() + " to " + outFile);
-		renderQuteTemplate(outFile, templateRef.getFile().getAbsolutePath());
+		renderQuteTemplate(outFile, templateRef.getFile().getAbsolutePath(), properties);
 	}
 
 	void renderQuteTemplate(Path outFile, String templatePath) throws IOException {
+		renderQuteTemplate(outFile, templatePath, null);
+	}
+
+	void renderQuteTemplate(Path outFile, String templatePath, Map<String, Object> properties) throws IOException {
 		Template template = TemplateEngine.instance().getTemplate(templatePath);
 		if (template == null) {
 			throw new ExitException(EXIT_INVALID_INPUT,
@@ -135,7 +146,16 @@ public class Init extends BaseScriptCommand {
 
 		Files.createDirectories(outFile.getParent());
 		try (BufferedWriter writer = Files.newBufferedWriter(outFile)) {
-			String result = template.data("baseName", basename).render();
+			if(properties==null) {
+				properties = new HashMap<>();
+			}
+			TemplateInstance templateWithData = template.data("properties", properties);
+			properties.forEach((k,v) -> templateWithData.data(k,v));
+
+			templateWithData.data("baseName", basename);
+			String result = templateWithData.render();
+
+
 			writer.write(result);
 			outFile.toFile().setExecutable(true);
 		}

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -1,7 +1,7 @@
 package dev.jbang.cli;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
@@ -13,8 +13,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,7 +32,7 @@ public class TestInit extends BaseTest {
 	void testInit(@TempDir Path outputDir) throws IOException {
 		Path out = outputDir.resolve("test.java");
 		new Init().renderQuteTemplate(out, "init-hello.java.qute");
-		assertThat(Util.readString(out), containsString("class test"));
+		assertThat(Util.readString(out), Matchers.containsString("class test"));
 	}
 
 	@ParameterizedTest
@@ -38,7 +41,7 @@ public class TestInit extends BaseTest {
 		Exception ex = assertThrows(ExitException.class, () -> {
 			new Init().renderQuteTemplate(Paths.get(filename), "init-hello.java.qute");
 		});
-		assertThat(ex.getMessage(), containsString("is not a valid class name in java."));
+		assertThat(ex.getMessage(), Matchers.containsString("is not a valid class name in java."));
 	}
 
 	@Test
@@ -48,7 +51,7 @@ public class TestInit extends BaseTest {
 		int result = Jbang.getCommandLine().execute("init", "--verbose", "--template=cli", s);
 		assertThat(result, is(0));
 		assertThat(new File(s).exists(), is(true));
-		MatcherAssert.assertThat(Util.readString(x), containsString("picocli"));
+		MatcherAssert.assertThat(Util.readString(x), Matchers.containsString("picocli"));
 	}
 
 	@Test
@@ -74,7 +77,7 @@ public class TestInit extends BaseTest {
 		int result = Jbang.getCommandLine().execute("init", s);
 		assertThat(result, is(0));
 		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), containsString("class edit"));
+		assertThat(Util.readString(x), Matchers.containsString("class edit"));
 	}
 
 	@Test
@@ -84,7 +87,7 @@ public class TestInit extends BaseTest {
 		int result = Jbang.getCommandLine().execute("init", s);
 		assertThat(result, is(0));
 		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), containsString("class XyzPlug"));
+		assertThat(Util.readString(x), Matchers.containsString("class XyzPlug"));
 	}
 
 	@Test
@@ -94,7 +97,7 @@ public class TestInit extends BaseTest {
 		int result = Jbang.getCommandLine().execute("init", s);
 		assertThat(result, is(0));
 		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), containsString("class xyzplug"));
+		assertThat(Util.readString(x), Matchers.containsString("class xyzplug"));
 	}
 
 	@Test
@@ -173,4 +176,42 @@ public class TestInit extends BaseTest {
 		return appDir.resolve(initName);
 	}
 
+	@Test
+	void testProperties() throws IOException {
+		Path cwd = Util.getCwd();
+		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{properties.prop1}{prop2}".getBytes());
+
+		Path out = cwd.resolve("result.java");
+		Map<String, Object> m = new HashMap<>();
+		m.put("prop1", "propvalue");
+		m.put("prop2", "rocks");
+
+		new Init().renderQuteTemplate(out, cwd.resolve("file1.java.qute").toFile().getAbsolutePath(), m);
+
+		String outcontent = Util.readString(out);
+
+		assertThat(outcontent, containsString("propvaluerocks"));
+	}
+
+	@Test
+	void testInitProperties() throws IOException {
+		Path cwd = Util.getCwd();
+		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{properties.prop1}{prop2}".getBytes());
+		Path out = cwd.resolve("result.java");
+
+		int addResult = Jbang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=name",
+						"{filename}" + "=" + f1.toAbsolutePath().toString());
+
+		assertThat(out.toFile().exists(), not(true));
+
+		int result = Jbang.getCommandLine().execute("init", "--verbose", "--template=name", "-Dprop1=propvalue", "-Dprop2=rocks", out.toAbsolutePath().toString());
+
+		assertThat(result, is(0));
+		assertThat(out.toFile().exists(), is(true));
+
+		String outcontent = Util.readString(out);
+
+		assertThat(outcontent, containsString("propvaluerocks"));
+	}
 }

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -200,12 +200,14 @@ public class TestInit extends BaseTest {
 		Path out = cwd.resolve("result.java");
 
 		int addResult = Jbang	.getCommandLine()
-				.execute("template", "add", "-f", cwd.toString(), "--name=name",
-						"{filename}" + "=" + f1.toAbsolutePath().toString());
+								.execute("template", "add", "-f", cwd.toString(), "--name=name",
+										"{filename}" + "=" + f1.toAbsolutePath().toString());
 
 		assertThat(out.toFile().exists(), not(true));
 
-		int result = Jbang.getCommandLine().execute("init", "--verbose", "--template=name", "-Dprop1=propvalue", "-Dprop2=rocks", out.toAbsolutePath().toString());
+		int result = Jbang	.getCommandLine()
+							.execute("init", "--verbose", "--template=name", "-Dprop1=propvalue", "-Dprop2=rocks",
+									out.toAbsolutePath().toString());
 
 		assertThat(result, is(0));
 		assertThat(out.toFile().exists(), is(true));

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -196,7 +196,7 @@ public class TestInit extends BaseTest {
 	@Test
 	void testInitProperties() throws IOException {
 		Path cwd = Util.getCwd();
-		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{properties.prop1}{prop2}".getBytes());
+		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{prop1}{prop2}".getBytes());
 		Path out = cwd.resolve("result.java");
 
 		int addResult = Jbang	.getCommandLine()

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -179,7 +179,7 @@ public class TestInit extends BaseTest {
 	@Test
 	void testProperties() throws IOException {
 		Path cwd = Util.getCwd();
-		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{properties.prop1}{prop2}".getBytes());
+		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{prop1}{prop2}".getBytes());
 
 		Path out = cwd.resolve("result.java");
 		Map<String, Object> m = new HashMap<>();


### PR DESCRIPTION
adds initial support for properties in `init`

makes -Dkey=value available as `{properties.key}` and `{key}` to avoid overshadow but also to prevent overwriting jbang defined values such as `{baseName}`.

not fully sold both are needed ....wdyt ?

fixes #960 