### PR TITLE
feat: be able to refer to scriptref in init templates

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -37,7 +37,7 @@ public class Init extends BaseScriptCommand {
 	boolean force;
 
 	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
-	Map<String, Object> properties;
+	Map<String, Object> properties = new HashMap<>();
 
 	@Override
 	public Integer doCall() throws IOException {
@@ -50,6 +50,8 @@ public class Init extends BaseScriptCommand {
 		Path outFile = Util.getCwd().resolve(scriptOrFile);
 		Path outDir = outFile.getParent();
 		String outName = outFile.getFileName().toString();
+
+		properties.put("scriptref", scriptOrFile);
 
 		List<RefTarget> refTargets = tpl.fileRefs	.entrySet()
 													.stream()

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -143,8 +143,12 @@ public class TestInit extends BaseTest {
 		int result = Jbang.getCommandLine().execute("init", "-t=name", outFile.toString());
 		assertThat(result, is(0));
 		assertThat(outFile.resolveSibling(outName).toFile(), aReadableFile());
-		assertThat(outFile.resolveSibling("file2.java").toFile(), aReadableFile());
+		Path f2 = outFile.resolveSibling("file2.java");
+		assertThat(f2.toFile(), aReadableFile());
+		String assertInit = Util.base(outFile.toString());
+		assertThat(Util.readString(f2), Matchers.containsString("// file2 with " + outFile));
 		assertThat(outFile.resolveSibling("file3.md").toFile(), aReadableFile());
+
 	}
 
 	void testFailMultipleFiles(String targetName, String initName, String outName, boolean abs, int expectedResult)
@@ -159,6 +163,7 @@ public class TestInit extends BaseTest {
 		Path tplDir = Files.createDirectory(cwd.resolve("tpl"));
 		Path f1 = Files.createFile(tplDir.resolve("file1.java"));
 		Path f2 = Files.createFile(tplDir.resolve("file2.java.qute"));
+		Util.writeString(f2, "// {baseName} with {scriptref}");
 		Path f3 = Files.createFile(tplDir.resolve("file3.md"));
 		if (abs) {
 			int addResult = Jbang	.getCommandLine()


### PR DESCRIPTION
This allows you to have a scriptref in your init template
    so you can do things like:

```
before_install:
  -  curl -Ls https://sh.jbang.dev | bash -s - app setup
install:
  - ~/.jbang/bin/jbang export mavenrepo --force -O target -Dgroup=$GROUP -Dartifact=$ARTIFACT -Dversion=$VERSION {scriptref or 'main.java'}
  - mkdir -p ~/.m2/repository
  - cp -rv target/* ~/.m2/repository/
```

 and then `jbang init -t jitpack@jbangdev whatever.file`

  and then the templates know its `whatever.file` it should use as its target.




<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->