### PR TITLE
feat: `build` now has `--catalog` option too

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -75,6 +75,9 @@ public abstract class BaseBuildCommand extends BaseScriptDepsCommand {
 			"-n", "--native" }, description = "Build using native-image", defaultValue = "false")
 	boolean nativeImage;
 
+	@CommandLine.Option(names = { "--catalog" }, description = "path to catalog file")
+	File catalog;
+
 	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 
 	static Source buildIfNeeded(Source src, RunContext ctx) throws IOException {

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -23,6 +23,7 @@ public class Build extends BaseBuildCommand {
 				forcejsh);
 		ctx.setJavaVersion(javaVersion);
 		ctx.setNativeImage(nativeImage);
+		ctx.setCatalog(catalog);
 		Source src = Source.forResource(scriptOrFile, ctx);
 
 		buildIfNeeded(src, ctx);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -59,9 +59,6 @@ public class Run extends BaseBuildCommand {
 	@CommandLine.Option(names = { "--interactive" }, description = "activate interactive mode")
 	boolean interactive;
 
-	@CommandLine.Option(names = { "--catalog" }, description = "path to catalog file")
-	File catalog;
-
 	@CommandLine.Parameters(index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
 	List<String> userParams = new ArrayList<>();
 


### PR DESCRIPTION
Sorry Max, I forgot to move the `--catalog` option to the base class before creating the previous PR. The `build` command of course needs the same `--catalog` option (even if only for symmetry)