### PR TITLE
feat: added `java` and `main` options to aliases

### DIFF
--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -21,12 +21,18 @@ public class Alias extends CatalogItem {
 	@SerializedName(value = "java-options")
 	public final List<String> javaOptions;
 	public final Map<String, String> properties;
+	@SerializedName(value = "java")
+	public final String javaVersion;
+	@SerializedName(value = "main")
+	public final String mainClass;
 
 	public Alias(String scriptRef,
 			String description,
 			List<String> arguments,
 			List<String> javaOptions,
 			Map<String, String> properties,
+			String javaVersion,
+			String mainClass,
 			Catalog catalog) {
 		super(catalog);
 		this.scriptRef = scriptRef;
@@ -34,6 +40,8 @@ public class Alias extends CatalogItem {
 		this.arguments = arguments;
 		this.javaOptions = javaOptions;
 		this.properties = properties;
+		this.javaVersion = javaVersion;
+		this.mainClass = mainClass;
 	}
 
 	/**
@@ -51,7 +59,7 @@ public class Alias extends CatalogItem {
 	 * @return An Alias object or null if no alias was found
 	 */
 	public static Alias get(String aliasName) {
-		return get(aliasName, null, null, null);
+		return get(aliasName, null, null, null, null, null);
 	}
 
 	/**
@@ -63,12 +71,14 @@ public class Alias extends CatalogItem {
 	 * @param arguments   Optional arguments to apply to the Alias
 	 * @param javaOptions Optional java runtime options to apply to the Alias
 	 * @param properties  Optional properties to apply to the Alias
+	 * @param javaVersion Optional java version to apply to the Alias
+	 * @param mainClass   Optional main class name to apply to the Alias
 	 * @return An Alias object or null if no alias was found
 	 */
 	public static Alias get(String aliasName, List<String> arguments, List<String> javaOptions,
-			Map<String, String> properties) {
+			Map<String, String> properties, String javaVersion, String mainClass) {
 		HashSet<String> names = new HashSet<>();
-		Alias alias = new Alias(null, null, arguments, javaOptions, properties, null);
+		Alias alias = new Alias(null, null, arguments, javaOptions, properties, javaVersion, mainClass, null);
 		Alias result = merge(alias, aliasName, Alias::getLocal, names);
 		return result.scriptRef != null ? result : null;
 	}
@@ -83,12 +93,14 @@ public class Alias extends CatalogItem {
 	 * @param arguments      Optional arguments to apply to the Alias
 	 * @param runtimeOptions Optional java runtime options to apply to the Alias
 	 * @param properties     Optional properties to apply to the Alias
+	 * @param javaVersion    Optional java version to apply to the Alias
+	 * @param mainClass      Optional main class name to apply to the Alias
 	 * @return An Alias object or null if no alias was found
 	 */
 	public static Alias get(Catalog catalog, String aliasName, List<String> arguments, List<String> runtimeOptions,
-			Map<String, String> properties) {
+			Map<String, String> properties, String javaVersion, String mainClass) {
 		HashSet<String> names = new HashSet<>();
-		Alias alias = new Alias(null, null, arguments, runtimeOptions, properties, null);
+		Alias alias = new Alias(null, null, arguments, runtimeOptions, properties, javaVersion, mainClass, null);
 		Alias result = merge(alias, aliasName, catalog.aliases::get, names);
 		return result.scriptRef != null ? result : null;
 	}
@@ -119,8 +131,10 @@ public class Alias extends CatalogItem {
 					: a2.javaOptions;
 			Map<String, String> props = a1.properties != null && !a1.properties.isEmpty() ? a1.properties
 					: a2.properties;
+			String javaVersion = a1.javaVersion != null ? a1.javaVersion : a2.javaVersion;
+			String mainClass = a1.mainClass != null ? a1.mainClass : a2.mainClass;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
-			return new Alias(a2.scriptRef, a2.description, args, opts, props, catalog);
+			return new Alias(a2.scriptRef, a2.description, args, opts, props, javaVersion, mainClass, catalog);
 		} else {
 			return a1;
 		}

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -56,7 +56,8 @@ public class Catalog {
 		catalogs.forEach((key, c) -> this.catalogs.put(key,
 				new CatalogRef(c.catalogRef, c.description, this)));
 		aliases.forEach((key, a) -> this.aliases.put(key,
-				new Alias(a.scriptRef, a.description, a.arguments, a.javaOptions, a.properties, this)));
+				new Alias(a.scriptRef, a.description, a.arguments, a.javaOptions, a.properties, a.javaVersion,
+						a.mainClass, this)));
 		templates.forEach((key, t) -> this.templates.put(key,
 				new Template(t.fileRefs, t.description, this)));
 	}
@@ -244,6 +245,8 @@ public class Catalog {
 	}
 
 	private static void merge(Catalog catalog, Catalog result) {
+		// Merge the aliases and templates of the catalog refs
+		// into the current catalog
 		for (CatalogRef ref : catalog.catalogs.values()) {
 			Catalog cat = getByRef(ref.catalogRef);
 			result.aliases.putAll(cat.aliases);

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -39,9 +39,12 @@ public class CatalogUtil {
 			String description,
 			List<String> arguments,
 			List<String> javaRuntimeOptions,
-			Map<String, String> properties) {
+			Map<String, String> properties,
+			String javaVersion,
+			String mainClass) {
 		Path catalogFile = Catalog.getCatalogFile(null);
-		addAlias(catalogFile, name, scriptRef, description, arguments, javaRuntimeOptions, properties);
+		addAlias(catalogFile, name, scriptRef, description, arguments, javaRuntimeOptions, properties, javaVersion,
+				mainClass);
 		return catalogFile;
 	}
 
@@ -57,12 +60,15 @@ public class CatalogUtil {
 			String description,
 			List<String> arguments,
 			List<String> javaRuntimeOptions,
-			Map<String, String> properties) {
+			Map<String, String> properties,
+			String javaVersion,
+			String mainClass) {
 		Path cwd = Util.getCwd();
 		catalogFile = cwd.resolve(catalogFile);
 		Catalog catalog = Catalog.get(catalogFile);
 		scriptRef = catalog.relativize(scriptRef);
-		Alias alias = new Alias(scriptRef, description, arguments, javaRuntimeOptions, properties, catalog);
+		Alias alias = new Alias(scriptRef, description, arguments, javaRuntimeOptions, properties, javaVersion,
+				mainClass, catalog);
 		catalog.aliases.put(name, alias);
 		try {
 			catalog.write();

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -65,6 +65,14 @@ class AliasAdd extends BaseAliasCommand {
 	@CommandLine.Option(names = { "--runopt" }, description = "A Java runtime option")
 	List<String> javaRuntimeOptions;
 
+	@CommandLine.Option(names = { "-m",
+			"--main" }, description = "Main class to use when running. Used primarily for running jar's.")
+	String mainClass;
+
+	@CommandLine.Option(names = { "-j",
+			"--java" }, description = "JDK version to use for running the alias.")
+	String javaVersion;
+
 	@CommandLine.Option(names = { "-D" }, description = "Set a system property", mapFallbackValue = "true")
 	Map<String, String> properties;
 
@@ -94,9 +102,11 @@ class AliasAdd extends BaseAliasCommand {
 
 		Path catFile = getCatalog(false);
 		if (catFile != null) {
-			CatalogUtil.addAlias(catFile, name, scriptOrFile, desc, userParams, javaRuntimeOptions, properties);
+			CatalogUtil.addAlias(catFile, name, scriptOrFile, desc, userParams, javaRuntimeOptions, properties,
+					javaVersion, mainClass);
 		} else {
-			catFile = CatalogUtil.addNearestAlias(name, scriptOrFile, desc, userParams, javaRuntimeOptions, properties);
+			catFile = CatalogUtil.addNearestAlias(name, scriptOrFile, desc, userParams, javaRuntimeOptions, properties,
+					javaVersion, mainClass);
 		}
 		info(String.format("Alias '%s' added to '%s'", name, catFile));
 		return EXIT_OK;
@@ -176,6 +186,16 @@ class AliasList extends BaseAliasCommand {
 			out.println(
 					Util.repeat(" ", fullName.length() + indent) + ConsoleOutput.cyan("   Arguments: ")
 							+ String.join(" ", alias.arguments));
+		}
+		if (alias.javaVersion != null) {
+			out.println(
+					Util.repeat(" ", fullName.length() + indent) + ConsoleOutput.cyan("   Java Version: ")
+							+ alias.javaVersion);
+		}
+		if (alias.mainClass != null) {
+			out.println(
+					Util.repeat(" ", fullName.length() + indent) + ConsoleOutput.cyan("   Main Class: ")
+							+ alias.mainClass);
 		}
 		if (alias.javaOptions != null) {
 			out.println(

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -16,18 +16,24 @@ public class Build extends BaseBuildCommand {
 			enableInsecure();
 		}
 
+		RunContext ctx = getRunContext();
+		Source src = Source.forResource(scriptOrFile, ctx);
+
+		buildIfNeeded(src, ctx);
+
+		return EXIT_OK;
+	}
+
+	RunContext getRunContext() {
 		RunContext ctx = RunContext.create(null, null,
 				dependencyInfoMixin.getProperties(),
 				dependencyInfoMixin.getDependencies(),
 				dependencyInfoMixin.getClasspaths(),
 				forcejsh);
 		ctx.setJavaVersion(javaVersion);
+		ctx.setMainClass(main);
 		ctx.setNativeImage(nativeImage);
 		ctx.setCatalog(catalog);
-		Source src = Source.forResource(scriptOrFile, ctx);
-
-		buildIfNeeded(src, ctx);
-
-		return EXIT_OK;
+		return ctx;
 	}
 }

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -146,14 +146,18 @@ public interface Source {
 		if (resourceRef == null) {
 			// Not found as such, so let's check the aliases
 			if (ctx.getCatalog() == null) {
-				alias = Alias.get(resource, ctx.getArguments(), ctx.getJavaOptions(), ctx.getProperties());
+				alias = Alias.get(resource, ctx.getArguments(), ctx.getJavaOptions(), ctx.getProperties(),
+						ctx.getJavaVersion(), ctx.getMainClass());
 			} else {
 				Catalog cat = Catalog.get(ctx.getCatalog().toPath());
-				alias = Alias.get(cat, resource, ctx.getArguments(), ctx.getJavaOptions(), ctx.getProperties());
+				alias = Alias.get(cat, resource, ctx.getArguments(), ctx.getJavaOptions(), ctx.getProperties(),
+						ctx.getJavaVersion(), ctx.getMainClass());
 			}
 			if (alias != null) {
 				resourceRef = ResourceRef.forResource(alias.resolve());
 				ctx.setArguments(alias.arguments);
+				ctx.setJavaVersion(alias.javaVersion);
+				ctx.setMainClass(alias.mainClass);
 				ctx.setJavaOptions(alias.javaOptions);
 				ctx.setProperties(alias.properties);
 				ctx.setAlias(alias);

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -215,13 +215,13 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasNone() throws IOException {
-		Alias alias = Alias.get("dummy-alias!", null, null, null);
+		Alias alias = Alias.get("dummy-alias!");
 		assertThat(alias, nullValue());
 	}
 
 	@Test
 	void testGetAliasOne() throws IOException {
-		Alias alias = Alias.get("one", null, null, null);
+		Alias alias = Alias.get("one");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -234,7 +234,7 @@ public class TestAlias extends BaseTest {
 	void testGetAliasOneWithArgs() throws IOException {
 		Alias alias = Alias.get("one", Collections.singletonList("X"),
 				Collections.singletonList("--foo"),
-				Collections.singletonMap("foo", "bar"));
+				Collections.singletonMap("foo", "bar"), null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -248,7 +248,7 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasTwo() throws IOException {
-		Alias alias = Alias.get("two", null, null, null);
+		Alias alias = Alias.get("two");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -262,7 +262,8 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasTwoAlt() throws IOException {
-		Alias alias = Alias.get("two", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap());
+		Alias alias = Alias.get("two", Collections.emptyList(), Collections.emptyList(), Collections.emptyMap(), null,
+				null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -278,7 +279,7 @@ public class TestAlias extends BaseTest {
 	void testGetAliasTwoWithArgs() throws IOException {
 		Alias alias = Alias.get("two", Collections.singletonList("X"),
 				Collections.singletonList("--foo"),
-				Collections.singletonMap("foo", "bar"));
+				Collections.singletonMap("foo", "bar"), null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -292,7 +293,7 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasFour() throws IOException {
-		Alias alias = Alias.get("four", null, null, null);
+		Alias alias = Alias.get("four");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -308,7 +309,7 @@ public class TestAlias extends BaseTest {
 	void testGetAliasFourWithArgs() throws IOException {
 		Alias alias = Alias.get("four", Collections.singletonList("X"),
 				Collections.singletonList("--foo"),
-				Collections.singletonMap("foo", "bar"));
+				Collections.singletonMap("foo", "bar"), null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -322,7 +323,7 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasFive() throws IOException {
-		Alias alias = Alias.get("five", null, null, null);
+		Alias alias = Alias.get("five");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -338,7 +339,7 @@ public class TestAlias extends BaseTest {
 	void testGetAliasFiveWithArgs() throws IOException {
 		Alias alias = Alias.get("five", Collections.singletonList("X"),
 				Collections.singletonList("--foo"),
-				Collections.singletonMap("foo", "bar"));
+				Collections.singletonMap("foo", "bar"), null, null);
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 		assertThat(alias.resolve(), equalTo("http://dummy"));
@@ -352,7 +353,7 @@ public class TestAlias extends BaseTest {
 
 	@Test
 	void testGetAliasGav() throws IOException {
-		Alias alias = Alias.get("gav", null, null, null);
+		Alias alias = Alias.get("gav");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("org.example:artifact:version"));
 		assertThat(alias.resolve(), equalTo("org.example:artifact:version"));
@@ -364,7 +365,7 @@ public class TestAlias extends BaseTest {
 	@Test
 	void testGetAliasLoop() throws IOException {
 		try {
-			Alias.get("eight", null, null, null);
+			Alias.get("eight");
 			Assert.fail();
 		} catch (RuntimeException ex) {
 			assertThat(ex.getMessage(), containsString("seven"));

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -150,7 +150,7 @@ public class TestAliasNearest extends BaseTest {
 	void testAddLocal(String ref, String result) throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -161,7 +161,8 @@ public class TestAliasNearest extends BaseTest {
 	void testAddLocalExplicit() throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addAlias(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", "dummy.java", null, null, null, null);
+		CatalogUtil.addAlias(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", "dummy.java", null, null, null, null, null,
+				null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -183,7 +184,7 @@ public class TestAliasNearest extends BaseTest {
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		Path dotLocalCatalog = cwd.resolve(CatalogUtil.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
@@ -208,7 +209,7 @@ public class TestAliasNearest extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(CatalogUtil.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
@@ -237,7 +238,7 @@ public class TestAliasNearest extends BaseTest {
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
 		Files.delete(parentCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));

--- a/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
@@ -63,7 +63,7 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 	void testAddLocal() throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -76,7 +76,7 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		Path dotLocalCatalog = cwd.resolve(CatalogUtil.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
@@ -92,7 +92,7 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(CatalogUtil.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
@@ -109,7 +109,7 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(CatalogUtil.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestAlias("new", "../scripts/parent.java", null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "../scripts/parent.java", null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();

--- a/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
@@ -44,7 +44,7 @@ public class TestAliasWithBaseRef extends BaseTest {
 	@Test
 	void testGetAliasOne() throws IOException {
 		Path cwd = Util.getCwd();
-		Alias alias = Alias.get("one", null, null, null);
+		Alias alias = Alias.get("one");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("foo"));
 		assertThat(alias.resolve(), equalTo("http://dummy/foo"));
@@ -53,7 +53,7 @@ public class TestAliasWithBaseRef extends BaseTest {
 	@Test
 	void testGetAliasTwo() throws IOException {
 		Path cwd = Util.getCwd();
-		Alias alias = Alias.get("two", null, null, null);
+		Alias alias = Alias.get("two");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("foo/bar.java"));
 		assertThat(alias.resolve(), equalTo("http://dummy/foo/bar.java"));
@@ -62,7 +62,7 @@ public class TestAliasWithBaseRef extends BaseTest {
 	@Test
 	void testGetAliasThree() throws IOException {
 		Path cwd = Util.getCwd();
-		Alias alias = Alias.get("three", null, null, null);
+		Alias alias = Alias.get("three");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy/baz.java"));
 		assertThat(alias.resolve(), equalTo("http://dummy/baz.java"));
@@ -71,7 +71,7 @@ public class TestAliasWithBaseRef extends BaseTest {
 	@Test
 	void testGetAliasGav() throws IOException {
 		Path cwd = Util.getCwd();
-		Alias alias = Alias.get("gav", null, null, null);
+		Alias alias = Alias.get("gav");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("org.example:artifact:version"));
 		assertThat(alias.resolve(), equalTo("org.example:artifact:version"));

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -65,7 +65,7 @@ public class TestCatalog extends BaseTest {
 
 	@Test
 	void testGetAlias() throws IOException {
-		Alias alias = Alias.get("one@test", null, null, null);
+		Alias alias = Alias.get("one@test");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
 	}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -90,8 +90,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(arg, ctx);
 
 		src = run.prepareArtifacts(src, ctx);
@@ -127,8 +126,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--catalog", cat.toString(), "helloworld");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setCatalog(cat.toFile());
 		Source src = Source.forResource("helloworld", ctx);
 
@@ -161,8 +159,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -188,8 +185,7 @@ public class TestRun extends BaseTest {
 		File empty = new File(dir, "empty.jsh");
 		empty.createNewFile();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(empty.toString(), ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -211,8 +207,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--jsh", arg, "helloworld");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -237,8 +232,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(jar, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -267,8 +261,7 @@ public class TestRun extends BaseTest {
 			CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 			Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-			RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-					run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+			RunContext ctx = run.getRunContext();
 			Source src = Source.forResource(jar, ctx);
 
 			String cmdline = run.generateCommandLine(src, ctx);
@@ -293,8 +286,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(jar, ctx);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*codegen-4.5.0.jar"));
@@ -328,8 +320,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(jar, ctx);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*.jar"));
@@ -353,8 +344,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(jar, ctx);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*eclipse.jgit.pgm.*.jar"));
@@ -377,8 +367,7 @@ public class TestRun extends BaseTest {
 				"picocli.codegen.aot.graalvm.ReflectionConfigGenerator", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(jar, ctx);
 
 		String cmd = run.generateCommandLine(src, ctx);
@@ -402,8 +391,7 @@ public class TestRun extends BaseTest {
 				"blah");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -427,8 +415,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--debug", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
@@ -451,8 +438,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
@@ -476,8 +462,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--interactive", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -506,8 +491,7 @@ public class TestRun extends BaseTest {
 
 		assertThat(run.dependencyInfoMixin.getProperties().size(), is(2));
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
 
@@ -543,8 +527,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
 		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
@@ -561,8 +544,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url, " ~!@#$%^&*()-+\\:;'`<>?/,.{}[]\"");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
 		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
@@ -762,8 +744,7 @@ public class TestRun extends BaseTest {
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(arg, ctx);
 
 		src = run.build((ScriptSource) src, ctx);
@@ -1012,8 +993,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(null, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
 
 		run.build(src, ctx);
@@ -1042,8 +1022,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(null, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
 
 		run.build(src, ctx);
@@ -1146,8 +1125,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--ea", f.getAbsolutePath());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(null, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
 		ScriptSource src = (ScriptSource) Source.forResource(f.getAbsolutePath(), ctx);
@@ -1167,8 +1145,7 @@ public class TestRun extends BaseTest {
 				f.getAbsolutePath());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(null, null, run.dependencyInfoMixin.getProperties(),
-				run.dependencyInfoMixin.getDependencies(), run.dependencyInfoMixin.getClasspaths(), run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(f.getAbsolutePath(), ctx);
 
 		String line = run.generateCommandLine(src, ctx);
@@ -1448,8 +1425,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--jfr", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.properties,
-				run.dependencyInfoMixin.dependencies, run.dependencyInfoMixin.classpaths, run.forcejsh);
+		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
 		assert (run.enableFlightRecording());


### PR DESCRIPTION
Added the `java` (alt `java-version`) option we need for the MSFT support and also added `main` (alt `main-class`) because that was the only other option that might prevent code from running if not available (even if we most likely don't need it in this particular case).