### PR TITLE
fix: migrate to adoptium

### DIFF
--- a/docs/modules/ROOT/pages/javaversions.adoc
+++ b/docs/modules/ROOT/pages/javaversions.adoc
@@ -45,7 +45,7 @@ It's easy to `install` additional JDKs by running:
   jbang jdk install 14
 
 which will download and install JDK version 14 into JBang's cache (`~/.jbang/cache/jdks` by default).
-The list of versions that are available for installation can be found here: https://adoptopenjdk.net/releases.html
+The list of versions that are available for installation can be found here: https://adoptium.net/releases.html
 
 The first JDK that gets installed by JBang will be set as the "default" JDK. This is from then on the JDK that will be
 used by JBang if no Java could be found on the system (meaning `javac` wasn't found on the `PATH` and no `JAVA_HOME` is set).

--- a/src/main/java/dev/jbang/net/JdkManager.java
+++ b/src/main/java/dev/jbang/net/JdkManager.java
@@ -21,7 +21,7 @@ import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
 
 public class JdkManager {
-	private static final String JDK_DOWNLOAD_URL = "https://api.adoptopenjdk.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/%s";
+	private static final String JDK_DOWNLOAD_URL = "https://api.adoptium.net/v3/binary/latest/%d/ga/%s/%s/jdk/hotspot/normal/%s";
 
 	public static Path getCurrentJdk(String requestedVersion) {
 		int currentVersion = JavaUtil.determineJavaVersion();

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -148,7 +148,7 @@ if [[ -z "$JAVA_EXEC" ]]; then
       fi
       mkdir -p "$TDIR/jdks"
       echo "Downloading JDK $javaVersion. Be patient, this can take several minutes..." 1>&2
-      jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
+      jdkurl="https://api.adoptium.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
       download $jdkurl "$TDIR/bootstrap-jdk.tgz"
       if [ $retval -ne 0 ]; then echo "Error downloading JDK" 1>&2; exit $retval; fi
       echo "Installing JDK $javaVersion..." 1>&2

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -9,7 +9,7 @@ set os=windows
 set arch=x64
 
 set jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
-set jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/%javaVersion%/ga/%os%/%arch%/jdk/hotspot/normal/adoptopenjdk"
+set jdkurl="https://api.adoptium.net/v3/binary/latest/%javaVersion%/ga/%os%/%arch%/jdk/hotspot/normal/adoptopenjdk"
 
 if "%JBANG_DIR%"=="" (set JBDIR=%userprofile%\.jbang) else (set JBDIR=%JBANG_DIR%)
 if "%JBANG_CACHE_DIR%"=="" (set TDIR=%JBDIR%\cache) else (set TDIR=%JBANG_CACHE_DIR%)

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -115,7 +115,7 @@ if ($JAVA_EXEC -eq "") {
       # If not, download and install it
       New-Item -ItemType Directory -Force -Path "$TDIR\jdks" >$null 2>&1
       [Console]::Error.WriteLine("Downloading JDK $javaVersion. Be patient, this can take several minutes...")
-      $jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
+      $jdkurl="https://api.adoptium.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
       try { Invoke-WebRequest "$jdkurl" -OutFile "$TDIR\bootstrap-jdk.zip"; $ok=$? } catch { $ok=$false }
       if (-not ($ok)) { [Console]::Error.WriteLine("Error downloading JDK"); break }
       [Console]::Error.WriteLine("Installing JDK $javaVersion...")


### PR DESCRIPTION
first attempt on migrating to use adoptium as requested at https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/ but it is not working.

opened https://github.com/adoptium/api.adoptium.net/issues/165 to understand better why.