### PR TITLE
fix: use disco/foojay instead of adoptopenjdk to get api that works with old and new jdk versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,12 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 jobs:
   updatewebsite:
@@ -37,6 +43,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     name: build-and-testing
     steps:
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
       - uses: actions/checkout@v1
       - uses: actions/cache@v1
         with:

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -251,7 +251,21 @@ public class Util {
 	}
 
 	public enum Vendor {
-		adoptopenjdk, openjdk
+		adoptopenjdk {
+			public String foojayname() {
+				return "aoj";
+			}
+		},
+		openjdk {
+			public String foojayname() {
+				return "oracle_open_jdk";
+			}
+		},
+		termurin;
+
+		public String foojayname() {
+			return name();
+		}
 	}
 
 	static public void verboseMsg(String msg) {
@@ -561,7 +575,7 @@ public class Util {
 					url = new URL(url, location);
 					url = new URL(swizzleURL(url.toString()));
 					fileURL = url.toExternalForm();
-					// info("Redirecting to: " + url); // Should be debug info
+					Util.verboseMsg("Redirected to: " + url); // Should be debug info
 					urlConnection = url.openConnection();
 					continue;
 				}
@@ -592,7 +606,8 @@ public class Util {
 				 */
 
 			} else {
-				throw new FileNotFoundException("No file to download. Server replied HTTP code: " + responseCode);
+				throw new FileNotFoundException(
+						"No file to download at " + fileURL + ". Server replied HTTP code: " + responseCode);
 			}
 		} else {
 			fileName = fileURL.substring(fileURL.lastIndexOf("/") + 1);
@@ -870,9 +885,11 @@ public class Util {
 		return fileName.toString();
 	}
 
-	static String readStringFromURL(String requestURL, Map<String, String> headers) throws IOException {
+	public static String readStringFromURL(String requestURL, Map<String, String> headers) throws IOException {
 		URLConnection connection = new URL(requestURL).openConnection();
-		headers.forEach(connection::setRequestProperty);
+		if (headers != null) {
+			headers.forEach(connection::setRequestProperty);
+		}
 		try (Scanner scanner = new Scanner(connection.getInputStream(),
 				StandardCharsets.UTF_8.toString())) {
 			scanner.useDelimiter("\\A");

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -41,6 +41,9 @@ download() {
 
 abs_jbang_dir=$(dirname $(resolve_symlink $(absolute_path $0)))
 
+# todo might vary by os so can be overwritten below
+libc_type=glibc
+
 case "$(uname -s)" in
   Linux*)
     os=linux
@@ -50,9 +53,11 @@ case "$(uname -s)" in
     fi
     ;;
   Darwin*)
-    os=mac;;
+    os=mac
+    libc_type=libc;;
   CYGWIN*|MINGW*|MSYS*)
-    os=windows;;
+    os=windows
+    libc_type=c_std_lib;;
   AIX)
     os=aix;;
   *)
@@ -148,7 +153,7 @@ if [[ -z "$JAVA_EXEC" ]]; then
       fi
       mkdir -p "$TDIR/jdks"
       echo "Downloading JDK $javaVersion. Be patient, this can take several minutes..." 1>&2
-      jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
+      jdkurl="https://api.foojay.io/disco/v2.0/directuris?distro=aoj&libc_type=$libc_type&archive_type=zip&operating_system=$os&package_type=jdk&version=$javaVersion&release_status=ga&architecture=$arch&latest=available"
       download $jdkurl "$TDIR/bootstrap-jdk.tgz"
       if [ $retval -ne 0 ]; then echo "Error downloading JDK" 1>&2; exit $retval; fi
       echo "Installing JDK $javaVersion..." 1>&2

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -9,7 +9,7 @@ set os=windows
 set arch=x64
 
 set jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
-set jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/%javaVersion%/ga/%os%/%arch%/jdk/hotspot/normal/adoptopenjdk"
+set jdkurl="https://api.foojay.io/disco/v2.0/directuris?distro=aoj&libc_type=libc&archive_type=zip&operating_system=%os%&package_type=jdk&version=%javaVersion%&release_status=ga&architecture=%arch%&latest=available"
 
 if "%JBANG_DIR%"=="" (set JBDIR=%userprofile%\.jbang) else (set JBDIR=%JBANG_DIR%)
 if "%JBANG_CACHE_DIR%"=="" (set TDIR=%JBDIR%\cache) else (set TDIR=%JBANG_CACHE_DIR%)

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -44,6 +44,7 @@ if (-not (Test-Path env:JBANG_DEFAULT_JAVA_VERSION)) { $javaVersion='11' } else 
 
 $os='windows'
 $arch='x64'
+$libc_type='c_std_lib'
 
 if (-not (Test-Path env:JBANG_DIR)) { $JBDIR="$env:userprofile\.jbang" } else { $JBDIR=$env:JBANG_DIR }
 if (-not (Test-Path env:JBANG_CACHE_DIR)) { $TDIR="$JBDIR\cache" } else { $TDIR=$env:JBANG_CACHE_DIR }
@@ -115,7 +116,7 @@ if ($JAVA_EXEC -eq "") {
       # If not, download and install it
       New-Item -ItemType Directory -Force -Path "$TDIR\jdks" >$null 2>&1
       [Console]::Error.WriteLine("Downloading JDK $javaVersion. Be patient, this can take several minutes...")
-      $jdkurl="https://api.adoptopenjdk.net/v3/binary/latest/$javaVersion/ga/$os/$arch/jdk/hotspot/normal/adoptopenjdk"
+      $jdkurl="https://api.foojay.io/disco/v2.0/directuris?distro=aoj&libc_type=$libc_type&archive_type=zip&operating_system=$os&package_type=jdk&version=$javaVersion&release_status=ga&architecture=$arch&latest=available"
       try { Invoke-WebRequest "$jdkurl" -OutFile "$TDIR\bootstrap-jdk.zip"; $ok=$? } catch { $ok=$false }
       if (-not ($ok)) { [Console]::Error.WriteLine("Error downloading JDK"); break }
       [Console]::Error.WriteLine("Installing JDK $javaVersion...")


### PR DESCRIPTION
initial attempt on using foojay.io to fetch jdks so we can get both old and new java versions via 
the same API.

Opens up for in future doing nice things like `//JAVA 18-ea` to get earlyaccess versions or even `//JAVA 11+(zulu)` to get 11 or higher using zulu.

For now made default for jbang to use termurin for 8, 11 and 17+, rest is adoptopenjdk.
For bash and windows download of default jdk this still uses adoptopenjdk api as it gives 
a url that returns the right binary.

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->