### PR TITLE
docs: Update spotless pre-commit hook url

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -55,7 +55,7 @@ before `git push`:
 
 [source,shell]
 ----
-curl -o .git/hooks/pre-commit https://gist.githubusercontent.com/toefel18/23c8927e28b7e7cf600cb5cdd4d980e1/raw/163337f2ae596d4b3a55936c2652b1e8227db5b7/pre-commit && chmod +x ./.git/hooks/pre-commit
+curl -o .git/hooks/pre-commit https://gist.githubusercontent.com/toefel18/23c8927e28b7e7cf600cb5cdd4d980e1/raw/8636aa5dab09e1f34ba9b6b6544131f96a0112c0/pre-commit && chmod +x ./.git/hooks/pre-commit
 ----
 
 


### PR DESCRIPTION
Before this update, when making a change to `src/main/java/dev/jbang/net/JdkManager.java`, the script would re-add the file with the wrong path (`src/main/java/dev/jbang/ne-/JdkManager.java`) thus failing to properly commit.

```
❯ git commit -sam "fix: typo in temurin name"
Kotlin and/or Java found in staging, running:  ./gradlew -PdisableSpotlessCheck spotlessApply

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.9/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 721ms
6 actionable tasks: 6 up-to-date
re-adding src/main/java/dev/jbang/ne-/JdkManager.java after formatting
warning: could not open directory 'src/main/java/dev/jbang/ne-/': No such file or directory
fatal: pathspec 'src/main/java/dev/jbang/ne-/JdkManager.java' did not match any files
```

This PR updates the pre-commit hook to the latest version from https://gist.githubusercontent.com/toefel18/23c8927e28b7e7cf600cb5cdd4d980e1, which fixes the issue.
