### PR TITLE
chore: eliminate warnings from code base

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -88,10 +88,8 @@ public class Init extends BaseScriptCommand {
 			}
 		} catch (IOException e) {
 			// Clean up any files we already created
-			boolean first = true;
 			for (RefTarget refTarget : refTargets) {
 				Util.deletePath(refTarget.to(outDir), true);
-				first = false;
 			}
 		}
 

--- a/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +42,6 @@ public class TestAliasWithBaseRef extends BaseTest {
 
 	@Test
 	void testGetAliasOne() throws IOException {
-		Path cwd = Util.getCwd();
 		Alias alias = Alias.get("one");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("foo"));
@@ -52,7 +50,6 @@ public class TestAliasWithBaseRef extends BaseTest {
 
 	@Test
 	void testGetAliasTwo() throws IOException {
-		Path cwd = Util.getCwd();
 		Alias alias = Alias.get("two");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("foo/bar.java"));
@@ -61,7 +58,6 @@ public class TestAliasWithBaseRef extends BaseTest {
 
 	@Test
 	void testGetAliasThree() throws IOException {
-		Path cwd = Util.getCwd();
 		Alias alias = Alias.get("three");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy/baz.java"));
@@ -70,7 +66,6 @@ public class TestAliasWithBaseRef extends BaseTest {
 
 	@Test
 	void testGetAliasGav() throws IOException {
-		Path cwd = Util.getCwd();
 		Alias alias = Alias.get("gav");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("org.example:artifact:version"));

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -45,13 +45,6 @@ public class TestApp extends BaseTest {
 	private static final List<String> h2ps1Contents = Collections.singletonList(
 			"jbang run com.h2database:h2:1.4.200 $args");
 
-	private static final List<String> h2nativeShContents = Arrays.asList("#!/bin/sh",
-			"exec jbang run --native com.h2database:h2:1.4.200 \"$@\"");
-	private static final List<String> h2nativeCmdContents = Arrays.asList("@echo off",
-			"jbang run --native com.h2database:h2:1.4.200 %*");
-	private static final List<String> h2nativePs1Contents = Collections.singletonList(
-			"jbang run --native com.h2database:h2:1.4.200 $args");
-
 	@Test
 	void testAppInstallFile() throws IOException {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -128,6 +128,7 @@ public class TestExport extends BaseTest {
 		File outFile = Settings.getLocalMavenRepo();
 		ExecutionResult result = checkedRun(null, "export", "mavenrepo", "--force",
 				examplesTestFolder.resolve("classpath_log.java").toString());
+		assertThat(result.exitCode, equalTo(BaseCommand.EXIT_OK));
 		assertThat(outFile.toPath().resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
 		assertThat(outFile.toPath().resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.pom").toFile(),

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -186,7 +186,7 @@ public class TestInit extends BaseTest {
 	@Test
 	void testProperties() throws IOException {
 		Path cwd = Util.getCwd();
-		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{prop1}{prop2}".getBytes());
+		Files.write(cwd.resolve("file1.java.qute"), "{prop1}{prop2}".getBytes());
 
 		Path out = cwd.resolve("result.java");
 		Map<String, Object> m = new HashMap<>();
@@ -206,9 +206,9 @@ public class TestInit extends BaseTest {
 		Path f1 = Files.write(cwd.resolve("file1.java.qute"), "{prop1}{prop2}".getBytes());
 		Path out = cwd.resolve("result.java");
 
-		int addResult = JBang	.getCommandLine()
-								.execute("template", "add", "-f", cwd.toString(), "--name=name",
-										"{filename}" + "=" + f1.toAbsolutePath().toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=name",
+						"{filename}" + "=" + f1.toAbsolutePath().toString());
 
 		assertThat(out.toFile().exists(), not(true));
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -654,11 +654,9 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		Run m = new Run();
-
 		Source src = Source.forFile(f);
 		RunContext ctx = RunContext.empty();
-		src = m.build((ScriptSource) src, ctx);
+		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("aclass"));
 
@@ -705,12 +703,10 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		Run m = new Run();
-
 		Source src = Source.forFile(f);
 		RunContext ctx = RunContext.empty();
 
-		src = m.build((ScriptSource) src, ctx);
+		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("dualclass"));
 
@@ -747,7 +743,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		Source src = Source.forResource(arg, ctx);
 
-		src = run.build((ScriptSource) src, ctx);
+		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("dualclass"));
 
@@ -996,7 +992,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
 
-		run.build(src, ctx);
+		BaseBuildCommand.build(src, ctx);
 
 		assertThat(src.isAgent(), is(true));
 
@@ -1025,7 +1021,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
 
-		run.build(src, ctx);
+		BaseBuildCommand.build(src, ctx);
 
 		assertThat(src.isAgent(), is(true));
 
@@ -1157,12 +1153,10 @@ public class TestRun extends BaseTest {
 	void testFilePresentB() throws IOException {
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 
-		Run m = new Run();
-
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(f.getAbsolutePath(), ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("resource"));
 
@@ -1191,12 +1185,10 @@ public class TestRun extends BaseTest {
 		Cache.clearCache(Cache.CacheClass.jars);
 		File f = examplesTestFolder.resolve("one.java").toFile();
 
-		Run m = new Run();
-
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(f.getAbsolutePath(), ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("one"));
 
@@ -1251,13 +1243,12 @@ public class TestRun extends BaseTest {
 															" public static void hi() { System.out.println(\"hi\"); }" +
 															"}")));
 		wms.start();
-		Run m = new Run();
 
 		String url = "http://localhost:" + wms.port() + "/sub/one.java";
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(url, ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 
 	}
 
@@ -1292,13 +1283,12 @@ public class TestRun extends BaseTest {
 													.withBody("<h1>Yay!</hi>")));
 
 		wms.start();
-		Run m = new Run();
 
 		String url = "http://localhost:" + wms.port() + "/sub/one.java";
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(url, ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(src.getJarFile().toPath(), null)) {
 			Arrays	.asList("one.class", "index.html")
@@ -1331,13 +1321,12 @@ public class TestRun extends BaseTest {
 															"}")));
 
 		wms.start();
-		Run m = new Run();
 
 		String url = "http://localhost:" + wms.port() + "/sub/one";
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(url, ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 	}
 
 	@Test
@@ -1357,12 +1346,10 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		Run m = new Run();
-
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(dir.toPath().toString(), ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 
 	}
 
@@ -1390,13 +1377,12 @@ public class TestRun extends BaseTest {
 															"}")));
 
 		wms.start();
-		Run m = new Run();
 
 		String url = "http://localhost:" + wms.port() + "/sub/one/";
 		RunContext ctx = RunContext.empty();
 		Source src = Source.forResource(url, ctx);
 
-		m.build((ScriptSource) src, ctx);
+		BaseBuildCommand.build((ScriptSource) src, ctx);
 	}
 
 	@Test


### PR DESCRIPTION
- removed unused variables/fields
- used static access of static methods when necessary

0 warnings in VS Code \o/

<img width="147" alt="Screenshot 2021-09-22 at 11 06 52" src="https://user-images.githubusercontent.com/148698/134315556-dda15b8c-46c1-4937-b8bb-21ac20c00fff.png">


Signed-off-by: Fred Bricon <fbricon@gmail.com>
