### PR TITLE
fix: kotlin edit now link to source rather than cache location

### DIFF
--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -171,6 +171,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 		try {
 			if (probe != null && probe.canRead()) {
 				if (!probe.getName().endsWith(".jar") && !probe.getName().endsWith(".java")
+						&& !probe.getName().endsWith(".kt")
 						&& !probe.getName().endsWith(".jsh")) {
 					if (probe.isDirectory()) {
 						File defaultApp = new File(probe, "main.java");


### PR DESCRIPTION
Fixes #1004


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->