### PR TITLE
fix: Fixed link to "Usage on Windows"

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -980,7 +980,7 @@ public class Util {
 		}
 		if (Util.isWindows()) {
 			infoMsg("Creation of symbolic link failed." +
-					"For potential causes and resolutions see https://github.com/jbangdev/jbang/blob/main/readme.adoc#usage-on-windows");
+					"For potential causes and resolutions see https://www.jbang.dev/documentation/guide/latest/usage.html#usage-on-windows");
 		} else {
 			infoMsg("Creation of symbolic link failed.");
 		}


### PR DESCRIPTION
The link to the "Usage on Windows" section was outdated. This PR fixes this issue.