### PR TITLE
fix: Prevent jbang edit --live from entering endless loop 

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -124,7 +124,6 @@ public class Edit extends BaseScriptDepsCommand {
 								// TODO only regenerate when dependencies changes.
 								info("Regenerating project.");
 								ctx = RunContext.empty();
-								src = Source.forResource(scriptOrFile, ctx);
 								createProjectForEdit((ScriptSource) src, ctx, true);
 							} catch (RuntimeException ee) {
 								warn("Error when re-generating project. Ignoring it, but state might be undefined: "

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -196,7 +196,14 @@ public class ResourceRef implements Comparable<ResourceRef> {
 											.resolve(Util.unkebabify(probe.getName()))
 											.toFile();
 					tempFile.getParentFile().mkdirs();
-					Util.writeString(tempFile.toPath().toAbsolutePath(), original);
+					if (!Util.createLink(tempFile.toPath().toAbsolutePath(), probe.toPath())) {
+						// Creating a link didn't work so we just create a copy
+						// TODO: Handle case of not being able to create link better.
+						// If this happens when using `jbang edit` any changes the
+						// user make will NOT be reflected in the original file!
+						// Perhaps there is a way to warn the user in this case?
+						Util.writeString(tempFile.toPath().toAbsolutePath(), original);
+					}
 					result = forCachedResource(scriptResource, tempFile);
 				}
 			} else {

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -962,18 +962,18 @@ public class Util {
 		return err[0] == null;
 	}
 
-	public static boolean createLink(Path src, Path target) {
-		if (!Files.exists(src)
-				&& !createSymbolicLink(src, target.toAbsolutePath())) {
-			return createHardLink(src, target.toAbsolutePath());
+	public static boolean createLink(Path link, Path target) {
+		if (!Files.exists(link)
+				&& !createSymbolicLink(link, target.toAbsolutePath())) {
+			return createHardLink(link, target.toAbsolutePath());
 		} else {
 			return false;
 		}
 	}
 
-	private static boolean createSymbolicLink(Path src, Path target) {
+	private static boolean createSymbolicLink(Path link, Path target) {
 		try {
-			Files.createSymbolicLink(src, target);
+			Files.createSymbolicLink(link, target);
 			return true;
 		} catch (IOException e) {
 			infoMsg(e.toString());
@@ -987,10 +987,10 @@ public class Util {
 		return false;
 	}
 
-	private static boolean createHardLink(Path src, Path target) {
+	private static boolean createHardLink(Path link, Path target) {
 		try {
 			infoMsg("Now try creating a hard link instead of symbolic.");
-			Files.createLink(src, target);
+			Files.createLink(link, target);
 		} catch (IOException e) {
 			infoMsg("Creation of hard link failed. Script must be on the same drive as $JBANG_CACHE_DIR (typically under $HOME) for hardlink creation to work. Or call the command with admin rights.");
 			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR, e);


### PR DESCRIPTION
Also using links now for files with improper names.

Fixes #1027 
