### PR TITLE
fix: Do not force .java suffix for Quarkus based templates

### DIFF
--- a/src/main/resources/jbang-catalog.json
+++ b/src/main/resources/jbang-catalog.json
@@ -17,15 +17,15 @@
       "description": "Basic kotlin Hello World template"
     },
     "qcli": {
-      "file-refs": {"{basename}.java":  "init-qcli.java.qute"},
+      "file-refs": {"{filename}":  "init-qcli.java.qute"},
       "description": "Quarkus CLI template"
     },
     "qmetrics": {
-      "file-refs": {"{basename}.java":  "init-qmetrics.java.qute"},
+      "file-refs": {"{filename}":  "init-qmetrics.java.qute"},
       "description": "Quarkus Metrics template"
     },
     "qrest": {
-      "file-refs": {"{basename}.java": "init-qrest.java.qute"},
+      "file-refs": {"{filename}": "init-qrest.java.qute"},
       "description": "Quarkus REST template"
     }
   },


### PR DESCRIPTION
Do not force `.java` suffix for Quarkus based templates

Fixes https://github.com/jbangdev/jbang/issues/984 as in case `jbang init --template=qcli kubectl-august` file `kubectl-august.java` was created, but with default template `kubectl-august`

Checked all the 3 templates (qcli, qmetrics, qrest) and are working fine when `jbang kubectl-august` is called

Example for `qrest` based file:
```java
$ cat kubectl-august

///usr/bin/env jbang "$0" "$@" ; exit $?
// Update the Quarkus version to what you want here or run jbang with
// `-Dquarkus.version=<version>` to override it.
//DEPS io.quarkus:quarkus-bom:${quarkus.version:1.11.0.Final}@pom
//DEPS io.quarkus:quarkus-resteasy
// //DEPS io.quarkus:quarkus-smallrye-openapi
// //DEPS io.quarkus:quarkus-swagger-ui
//JAVAC_OPTIONS -parameters

import io.quarkus.runtime.Quarkus;
import javax.enterprise.context.ApplicationScoped;
import javax.ws.rs.GET;
import javax.ws.rs.Path;

@Path("/hello")
@ApplicationScoped
public class KubectlAugust {

    @GET
    public String sayHello() {
        return "Hello from Quarkus with jbang.dev";
    }

}
```