### PR TITLE
fix: hint to users to run with --fresh to get latest

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -46,7 +46,8 @@ public class Init extends BaseScriptCommand {
 		dev.jbang.catalog.Template tpl = dev.jbang.catalog.Template.get(initTemplate);
 		if (tpl == null) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
-					"Could not find init template named: " + initTemplate);
+					"Could not find init template named: " + initTemplate
+							+ ". Try run with --fresh to get latest catalog updates.");
 		}
 
 		boolean absolute = new File(scriptOrFile).isAbsolute();


### PR DESCRIPTION
when updating things like jbangdev/jbang-catalog users need to run wit --fresh to get latest.

lets tell them ...at least until we find better way to handle it ;)