### PR TITLE
fix: This fixes extraneous jbang.cmd output

### DIFF
--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -14,7 +14,7 @@ if exist "%~dp0jbang.jar" (
   set jarPath=%~dp0.jbang\jbang.jar
 ) else (
   if not exist "%JBDIR%\bin\jbang.jar" (
-    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1"
+    powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 version" > nul
     if !ERRORLEVEL! NEQ 0 ( exit /b %ERRORLEVEL% )
   )
   call "%JBDIR%\bin\jbang.cmd" %*


### PR DESCRIPTION
When the .cmd script installs JBang using the .ps1 script
some extra output is generated that will now be suppressed.

This is a fix for https://github.com/jbangdev/jbang/pull/1038