### PR TITLE
feat: jbang init --deps

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -41,6 +41,9 @@ public class Init extends BaseScriptCommand {
 	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, Object> properties = new HashMap<>();
 
+	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	List<String> dependencies;
+
 	@Override
 	public Integer doCall() throws IOException {
 		dev.jbang.catalog.Template tpl = dev.jbang.catalog.Template.get(initTemplate);
@@ -57,6 +60,7 @@ public class Init extends BaseScriptCommand {
 
 		properties.put("scriptref", scriptOrFile);
 		properties.put("baseName", Util.getBaseName(Paths.get(scriptOrFile).getFileName().toString()));
+		properties.put("dependencies", dependencies);
 
 		List<RefTarget> refTargets = tpl.fileRefs	.entrySet()
 													.stream()

--- a/src/main/resources/init-agent.java.qute
+++ b/src/main/resources/init-agent.java.qute
@@ -1,5 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//// DEPS <avoid dependencies>
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
+{#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
 //JAVAAGENT Can-Redefine-Classes Can-Retransform-Classes Can-Set-Native-Method-Prefix
 
 import java.lang.instrument.ClassFileTransformer;

--- a/src/main/resources/init-cli.java.qute
+++ b/src/main/resources/init-cli.java.qute
@@ -1,5 +1,9 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS info.picocli:picocli:4.5.0
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
+{#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;

--- a/src/main/resources/init-hello.java.qute
+++ b/src/main/resources/init-hello.java.qute
@@ -1,5 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// //DEPS <dependency1> <dependency2>
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
+{#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
 
 import static java.lang.System.*;
 

--- a/src/main/resources/init-hello.kt.qute
+++ b/src/main/resources/init-hello.kt.qute
@@ -1,5 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// //DEPS <dependency1> <dependency2>
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
+{#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
 
 public fun main() {
     println("Hello World");

--- a/src/main/resources/init-qcli.java.qute
+++ b/src/main/resources/init-qcli.java.qute
@@ -3,6 +3,9 @@
 // `-Dquarkus.version=<version>` to override it.
 //DEPS io.quarkus:quarkus-bom:$\{quarkus.version:1.11.0.Final\}@pom
 //DEPS io.quarkus:quarkus-picocli
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
 //Q:CONFIG quarkus.banner.enabled=false
 //Q:CONFIG quarkus.log.level=WARN
 

--- a/src/main/resources/initClass.java.qute
+++ b/src/main/resources/initClass.java.qute
@@ -1,5 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// //DEPS <dependency1> <dependency2>
+{#for dep in dependencies.orEmpty}
+//DEPS {dep}
+{/for}
+{#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
 
 import static java.lang.System.*;
 

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -73,6 +73,28 @@ public class TestInit extends BaseTest {
 	}
 
 	@Test
+	void testDepsInit(@TempDir Path outputDir) throws IOException {
+		Path x = outputDir.resolve("edit.java");
+		String s = x.toString();
+		int result = JBang.getCommandLine().execute("init", "--deps", "a.b.c:mydep:1.0", s);
+		assertThat(result, is(0));
+		assertThat(new File(s).exists(), is(true));
+		assertThat(Util.readString(x), Matchers.containsString("//DEPS a.b.c:mydep:1.0"));
+	}
+
+	@Test
+	void testMultiDepsInit(@TempDir Path outputDir) throws IOException {
+		Path x = outputDir.resolve("edit.java");
+		String s = x.toString();
+		int result = JBang.getCommandLine().execute("init", "--deps", "a.b.c:mydep:1.0", "--deps", "q.z:rrr:2.0", s);
+		assertThat(result, is(0));
+		assertThat(new File(s).exists(), is(true));
+		assertThat(Util.readString(x), Matchers.containsString("//DEPS a.b.c:mydep:1.0"));
+		assertThat(Util.readString(x), Matchers.containsString("//DEPS q.z:rrr:2.0"));
+
+	}
+
+	@Test
 	void testDefaultInit(@TempDir Path outputDir) throws IOException {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
@@ -223,4 +245,5 @@ public class TestInit extends BaseTest {
 
 		assertThat(outcontent, containsString("propvaluerocks"));
 	}
+
 }


### PR DESCRIPTION
add jbang init --deps to create files with initial dependecies set up.

--deps currently does zero validation/resolution - should we make it do that so it will fail early if depndency not reachable/resolvable ?