### PR TITLE
docs: fixed command for updating jbang using sdkman

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -79,7 +79,7 @@ To update run:
 
 [source]
 ----
-sdk update jbang
+sdk upgrade jbang
 ----
 
 == Chocolatey icon:windows[]


### PR DESCRIPTION
Hello

According to [sdkman][0]'s docs,
the correct command for updating a candidate is `upgrade`.


[0]: https://sdkman.io/usage#upgrade