### PR TITLE
chore: Update release settings for JReleaser 0.9

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,7 +19,7 @@ jobs:
       JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-      JRELEASER_VERSION: 0.8.0
+      JRELEASER_VERSION: 0.9.0
     steps:
       - uses: actions/checkout@v1
       - name: install-java11

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,7 +19,7 @@ jobs:
       JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-      JRELEASER_VERSION: 0.8.0
+      JRELEASER_VERSION: 0.9.0
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -11,6 +11,7 @@ project:
   authors:
     - Max Rydahl Andersen
   license: MIT
+  licenseUrl: https://github.com/jbangdev/jbang/blob/main/LICENSE
   tags:
     - jbang
     - bash
@@ -66,6 +67,7 @@ files:
 
 distributions:
   jbang:
+    executableExtension: cmd
     docker:  ## not ready to release this way.
       active: release
       continueOnError: true
@@ -91,6 +93,7 @@ distributions:
       active: release
       continueOnError: true
       remoteBuild: true
+      title: JBang
     snap:
       active: release
       continueOnError: true


### PR DESCRIPTION
Update the JReleaser configuration ad GH workflows with latest changes required by v0.9