### PR TITLE
fix: native image should not be searched in $PWD

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -319,7 +319,7 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	private static String resolveInGraalVMHome(String cmd, String requestedVersion) {
 		String newcmd = resolveInEnv("GRAALVM_HOME", cmd);
 
-		if (newcmd.equals(cmd) &&
+		if (!newcmd.equals(cmd) &&
 				!new File(newcmd).exists()) {
 			return JavaUtil.resolveInJavaHome(cmd, requestedVersion);
 		} else {


### PR DESCRIPTION
```
❯ j! --version
0.83.1

❯ cat Hello.java
class Hello { public static void main(String...args) { System.out.println("hello"); }}

❯ j!  --native Hello.java
[jbang] Building jar...
[jbang] log: /var/folders/w1/_rqy81z11wq9wzmwry53jtw80000gn/T/jbang5130338024397537915native-image
[jbang] [ERROR] Cannot run program "/Users/evacchi/Devel/rh/fun/jbang/build/distributions/jbang-0.83.1.8/bin/native-image": error=2, No such file or directory
[jbang] Run with --verbose for more details

```

this PR:

```
❯ bin/jbang --verbose --native Hello.java
[jbang] jbang version 0.83.1.8
[jbang] System Java version detected as 17
[jbang] System Java version matches requested version 17
[jbang] Building jar...
[jbang] compile: /Users/evacchi/.sdkman/candidates/java/21.3.0.r17-grl/bin/javac -d /Users/evacchi/.jbang/cache/jars/Hello.java.66f26be9ddf9929f9f99556305aef642db0145f9f235f51347ced6d30d109f2f.jar.tmp /Users/evacchi/Devel/rh/fun/jbang/build/distributions/jbang-0.83.1.8/Hello.java
...
```

this is also how I tested it... not sure if it is the "proper" way, but I couldn't find a guide for testing before submitting a PR ;)