### PR TITLE
fix: Fixed NPE for `info` on sources with `//SOURCES` lines

### DIFF
--- a/itests/sources.java
+++ b/itests/sources.java
@@ -1,0 +1,9 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//SOURCES quote.java
+
+public class sources {
+    public static void main(String[] args) {
+        new quote().main(args);
+    }
+}

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -93,7 +93,7 @@ class AliasAdd extends BaseAliasCommand {
 		}
 
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(scriptOrFile, ctx);
+		Source src = ctx.forResource(scriptOrFile);
 		if (name == null) {
 			name = CatalogUtil.nameFromRef(ctx.getOriginalRef());
 		}

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -98,7 +98,7 @@ class AppInstall extends BaseCommand {
 			return false;
 		}
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(scriptRef, ctx);
+		Source src = ctx.forResource(scriptRef);
 		if (name == null) {
 			name = CatalogUtil.nameFromRef(ctx.getOriginalRef());
 			if (!force && existScripts(binDir, name)) {

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -17,7 +17,7 @@ public class Build extends BaseBuildCommand {
 		}
 
 		RunContext ctx = getRunContext();
-		Source src = Source.forResource(scriptOrFile, ctx);
+		Source src = ctx.forResource(scriptOrFile);
 
 		buildIfNeeded(src, ctx);
 

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -70,7 +70,7 @@ public class Edit extends BaseScriptCommand {
 				dependencyInfoMixin.getRepositories(),
 				dependencyInfoMixin.getClasspaths(),
 				forcejsh);
-		Source src = Source.forResource(scriptOrFile, ctx);
+		Source src = ctx.forResource(scriptOrFile);
 
 		if (!(src instanceof ScriptSource)) {
 			throw new ExitException(EXIT_INVALID_INPUT, "You can only edit source files");
@@ -128,7 +128,7 @@ public class Edit extends BaseScriptCommand {
 								// TODO only regenerate when dependencies changes.
 								info("Regenerating project.");
 								ctx = RunContext.empty();
-								src = Source.forResource(scriptOrFile, ctx);
+								src = ctx.forResource(scriptOrFile);
 								createProjectForEdit((ScriptSource) src, ctx, true);
 							} catch (RuntimeException ee) {
 								warn("Error when re-generating project. Ignoring it, but state might be undefined: "
@@ -221,7 +221,7 @@ public class Edit extends BaseScriptCommand {
 	File createProjectForEdit(ScriptSource src, RunContext ctx, boolean reload) throws IOException {
 		File originalFile = src.getResourceRef().getFile();
 
-		List<String> dependencies = ctx.collectAllDependenciesFor(src);
+		List<String> dependencies = src.getAllDependencies();
 		String cp = ctx.resolveClassPath(src);
 		List<String> resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
 

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -47,7 +47,7 @@ public class Export {
 				false);
 		ctx.setJavaVersion(exportMixin.javaVersion);
 		ctx.setNativeImage(exportMixin.nativeImage);
-		Source src = Source.forResource(exportMixin.scriptOrFile, ctx);
+		Source src = ctx.forResource(exportMixin.scriptOrFile);
 
 		src = buildIfNeeded(src, ctx);
 		ctx.resolveClassPath(src);

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -79,7 +79,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 				backingResource = src.getResourceRef().getFile().toString();
 
 				ScriptSource ss = src.asScriptSource();
-				List<String> deps = ss.collectDependencies(ctx.getContextProperties());
+				List<String> deps = ss.collectDependencies();
 				if (!deps.isEmpty()) {
 					dependencies = deps;
 				}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -144,7 +144,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 				dependencyInfoMixin.getRepositories(),
 				dependencyInfoMixin.getClasspaths(),
 				forcejsh);
-		Source src = ctx.importJarMetadataFor(Source.forResource(scriptOrFile, ctx));
+		Source src = ctx.importJarMetadataFor(ctx.forResource(scriptOrFile));
 
 		scripts = new HashSet<>();
 		ScriptInfo info = new ScriptInfo(src, ctx);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -72,7 +72,7 @@ public class Run extends BaseBuildCommand {
 		}
 
 		RunContext ctx = getRunContext();
-		Source src = Source.forResource(scriptOrFile, ctx);
+		Source src = ctx.forResource(scriptOrFile);
 		src = prepareArtifacts(src, ctx);
 
 		String cmdline = generateOSCommandLine(src, ctx);
@@ -112,7 +112,7 @@ public class Run extends BaseBuildCommand {
 						forcejsh);
 				actx.setJavaVersion(ctx.getJavaVersion());
 				actx.setNativeImage(ctx.isNativeImage());
-				Source asrc = Source.forResource(javaAgent, actx);
+				Source asrc = actx.forResource(javaAgent);
 				actx.setJavaAgentOption(javaAgentOptions.orElse(null));
 				if (needsJar(asrc, actx)) {
 					info("Building javaagent...");

--- a/src/main/java/dev/jbang/source/JarSource.java
+++ b/src/main/java/dev/jbang/source/JarSource.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
@@ -97,7 +96,7 @@ public class JarSource implements Source {
 	}
 
 	@Override
-	public List<String> getAllDependencies(Properties props) {
+	public List<String> getAllDependencies() {
 		return Collections.emptyList();
 	}
 

--- a/src/main/java/dev/jbang/source/JarSource.java
+++ b/src/main/java/dev/jbang/source/JarSource.java
@@ -82,7 +82,7 @@ public class JarSource implements Source {
 	@Override
 	public ScriptSource asScriptSource() {
 		if (scriptSource == null) {
-			scriptSource = ScriptSource.prepareScript(resourceRef);
+			scriptSource = ScriptSource.prepareScript(resourceRef, null);
 		}
 		return scriptSource;
 	}

--- a/src/main/java/dev/jbang/source/KotlinScriptSource.java
+++ b/src/main/java/dev/jbang/source/KotlinScriptSource.java
@@ -4,6 +4,7 @@ import static dev.jbang.net.KotlinManager.resolveInKotlinHome;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jboss.jandex.ClassInfo;
@@ -13,8 +14,8 @@ import dev.jbang.net.KotlinManager;
 
 public class KotlinScriptSource extends ScriptSource {
 
-	protected KotlinScriptSource(ResourceRef script) {
-		super(script);
+	protected KotlinScriptSource(ResourceRef script, Function<String, String> replaceProperties) {
+		super(script, replaceProperties);
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -11,6 +11,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.Catalog;
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.Detector;
@@ -295,13 +296,6 @@ public class RunContext {
 		javaAgents.add(new AgentSourceContext(src, ctx));
 	}
 
-	public List<String> collectAllDependenciesFor(Source src) {
-		return src	.getAllDependencies()
-					.stream()
-					.map(it -> PropertiesValueResolver.replaceProperties(it, getContextProperties()))
-					.collect(Collectors.toList());
-	}
-
 	/**
 	 * Return resolved classpath lazily. resolution will only happen once, any
 	 * consecutive calls return the same classpath.
@@ -317,7 +311,7 @@ public class RunContext {
 			additionalMcp = src.resolveClassPath(acp);
 		}
 		if (mcp == null) {
-			mcp = src.resolveClassPath(collectAllDependenciesFor(src));
+			mcp = src.resolveClassPath(src.getAllDependencies());
 		}
 
 		if (combinedMcp == null) {
@@ -355,6 +349,81 @@ public class RunContext {
 		} else {
 			return src;
 		}
+	}
+
+	public Source forResource(String resource) {
+		ResourceRef resourceRef = ResourceRef.forScriptResource(resource);
+
+		Alias alias = null;
+		if (resourceRef == null) {
+			// Not found as such, so let's check the aliases
+			if (getCatalog() == null) {
+				alias = Alias.get(resource);
+			} else {
+				Catalog cat = Catalog.get(getCatalog().toPath());
+				alias = Alias.get(cat, resource);
+			}
+			if (alias != null) {
+				resourceRef = ResourceRef.forResource(alias.resolve());
+				if (getArguments() == null || getArguments().isEmpty()) {
+					setArguments(alias.arguments);
+				}
+				if (getJavaOptions() == null || getJavaOptions().isEmpty()) {
+					setJavaOptions(alias.javaOptions);
+				}
+				if (getAdditionalDependencies() == null || getAdditionalDependencies().isEmpty()) {
+					setAdditionalDependencies(alias.dependencies);
+				}
+				if (getAdditionalRepositories() == null || getAdditionalRepositories().isEmpty()) {
+					setAdditionalRepositories(alias.repositories);
+				}
+				if (getAdditionalClasspaths() == null || getAdditionalClasspaths().isEmpty()) {
+					setAdditionalClasspaths(alias.classpaths);
+				}
+				if (getProperties() == null || getProperties().isEmpty()) {
+					setProperties(alias.properties);
+				}
+				if (getJavaVersion() == null) {
+					setJavaVersion(alias.javaVersion);
+				}
+				if (getMainClass() == null) {
+					setMainClass(alias.mainClass);
+				}
+				setAlias(alias);
+				if (resourceRef == null) {
+					throw new IllegalArgumentException(
+							"Alias " + resource + " from " + alias.catalog.catalogRef + " failed to resolve "
+									+ alias.scriptRef);
+				}
+			}
+		}
+
+		// Support URLs as script files
+		// just proceed if the script file is a regular file at this point
+		if (resourceRef == null || !resourceRef.getFile().canRead()) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Script or alias could not be found or read: '" + resource + "'");
+		}
+
+		// note script file must be not null at this point
+		setOriginalRef(resource);
+		return forResourceRef(resourceRef);
+	}
+
+	public Source forResourceRef(ResourceRef resourceRef) {
+		Source src;
+		if (resourceRef.getFile().getName().endsWith(".jar")) {
+			src = JarSource.prepareJar(resourceRef);
+		} else {
+			src = ScriptSource.prepareScript(resourceRef,
+					it -> PropertiesValueResolver.replaceProperties(it, getContextProperties()));
+		}
+		return src;
+	}
+
+	public Source forFile(File resourceFile) {
+		ResourceRef resourceRef = ResourceRef.forFile(resourceFile);
+		return forResourceRef(resourceRef);
 	}
 
 }

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -296,7 +296,10 @@ public class RunContext {
 	}
 
 	public List<String> collectAllDependenciesFor(Source src) {
-		return src.getAllDependencies(getContextProperties());
+		return src	.getAllDependencies()
+					.stream()
+					.map(it -> PropertiesValueResolver.replaceProperties(it, getContextProperties()))
+					.collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -128,18 +127,18 @@ public class ScriptSource implements Source {
 	}
 
 	@Override
-	public List<String> getAllDependencies(Properties props) {
+	public List<String> getAllDependencies() {
 		if (dependencies == null) {
-			dependencies = collectAll(script -> script.collectDependencies(props));
+			dependencies = collectAll(script -> script.collectDependencies());
 		}
 		return dependencies;
 	}
 
-	public List<String> collectDependencies(Properties props) {
-		return collectDependencies(getLines(), props);
+	public List<String> collectDependencies() {
+		return collectDependencies(getLines());
 	}
 
-	private List<String> collectDependencies(List<String> lines, Properties props) {
+	private List<String> collectDependencies(List<String> lines) {
 
 		// Make sure that dependencies declarations are well formatted
 		if (lines.stream().anyMatch(it -> it.startsWith("// DEPS"))) {
@@ -149,7 +148,6 @@ public class ScriptSource implements Source {
 		return lines.stream()
 					.filter(ScriptSource::isDependDeclare)
 					.flatMap(ScriptSource::extractDependencies)
-					.map(it -> PropertiesValueResolver.replaceProperties(it, props))
 					.collect(Collectors.toList());
 	}
 

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -103,7 +102,7 @@ public interface Source {
 	 * @param props A `Properties` object whose values can be used during dependency
 	 *              resolution
 	 */
-	List<String> getAllDependencies(Properties props);
+	List<String> getAllDependencies();
 
 	/**
 	 * Resolves the given list of dependencies

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -8,10 +8,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dev.jbang.catalog.Alias;
-import dev.jbang.catalog.Catalog;
-import dev.jbang.cli.BaseCommand;
-import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.ModularClassPath;
 
 /**
@@ -137,84 +133,6 @@ public interface Source {
 	 * none.
 	 */
 	ScriptSource asScriptSource();
-
-	static Source forResource(String resource, RunContext ctx) {
-		ResourceRef resourceRef = ResourceRef.forScriptResource(resource);
-
-		Alias alias = null;
-		if (resourceRef == null) {
-			// Not found as such, so let's check the aliases
-			if (ctx.getCatalog() == null) {
-				alias = Alias.get(resource);
-			} else {
-				Catalog cat = Catalog.get(ctx.getCatalog().toPath());
-				alias = Alias.get(cat, resource);
-			}
-			if (alias != null) {
-				resourceRef = ResourceRef.forResource(alias.resolve());
-				if (ctx.getArguments() == null || ctx.getArguments().isEmpty()) {
-					ctx.setArguments(alias.arguments);
-				}
-				if (ctx.getJavaOptions() == null || ctx.getJavaOptions().isEmpty()) {
-					ctx.setJavaOptions(alias.javaOptions);
-				}
-				if (ctx.getAdditionalDependencies() == null || ctx.getAdditionalDependencies().isEmpty()) {
-					ctx.setAdditionalDependencies(alias.dependencies);
-				}
-				if (ctx.getAdditionalRepositories() == null || ctx.getAdditionalRepositories().isEmpty()) {
-					ctx.setAdditionalRepositories(alias.repositories);
-				}
-				if (ctx.getAdditionalClasspaths() == null || ctx.getAdditionalClasspaths().isEmpty()) {
-					ctx.setAdditionalClasspaths(alias.classpaths);
-				}
-				if (ctx.getProperties() == null || ctx.getProperties().isEmpty()) {
-					ctx.setProperties(alias.properties);
-				}
-				if (ctx.getJavaVersion() == null) {
-					ctx.setJavaVersion(alias.javaVersion);
-				}
-				if (ctx.getMainClass() == null) {
-					ctx.setMainClass(alias.mainClass);
-				}
-				ctx.setAlias(alias);
-				if (resourceRef == null) {
-					throw new IllegalArgumentException(
-							"Alias " + resource + " from " + alias.catalog.catalogRef + " failed to resolve "
-									+ alias.scriptRef);
-				}
-			}
-		}
-
-		// Support URLs as script files
-		// just proceed if the script file is a regular file at this point
-		if (resourceRef == null || !resourceRef.getFile().canRead()) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
-					"Script or alias could not be found or read: '" + resource + "'");
-		}
-
-		// note script file must be not null at this point
-		ctx.setOriginalRef(resource);
-		return forResourceRef(resourceRef);
-	}
-
-	static Source forFile(File resourceFile) {
-		ResourceRef resourceRef = ResourceRef.forFile(resourceFile);
-		return forResourceRef(resourceRef);
-	}
-
-	static Source forResourceRef(ResourceRef resourceRef) {
-		Source src;
-		if (resourceRef.getFile().getName().endsWith(".jar")) {
-			src = JarSource.prepareJar(resourceRef);
-		} else {
-			src = ScriptSource.prepareScript(resourceRef);
-		}
-		return src;
-	}
-
-	static ScriptSource forScript(String script) {
-		return new ScriptSource(script);
-	}
 
 	boolean isCreatedJar();
 }

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.io.TempDir;
 import dev.jbang.*;
 import dev.jbang.source.RunContext;
 import dev.jbang.source.ScriptSource;
-import dev.jbang.source.Source;
 import dev.jbang.util.Util;
 
 public class TestEdit extends BaseTest {
@@ -45,7 +44,7 @@ public class TestEdit extends BaseTest {
 		assertThat(new File(s).exists(), is(true));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource ssrc = (ScriptSource) Source.forResource(s, ctx);
+		ScriptSource ssrc = (ScriptSource) ctx.forResource(s);
 
 		File project = new Edit().createProjectForEdit(ssrc, ctx, false);
 
@@ -85,7 +84,7 @@ public class TestEdit extends BaseTest {
 		Util.writeString(p, "//DEPS org.openjfx:javafx-graphics:11.0.2${bougus:}\n" + Util.readString(p));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(s, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(s);
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 
@@ -120,7 +119,7 @@ public class TestEdit extends BaseTest {
 				"//DEPS io.quarkus:quarkus-rest-client-reactive-jackson\n" + Util.readString(p));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(s, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(s);
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 
@@ -153,7 +152,7 @@ public class TestEdit extends BaseTest {
 		Util.writeString(p, "//DEPS https://github.com/oldskoolsh/libvirt-schema/tree/0.0.2\n" + Util.readString(p));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(s, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(s);
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 
@@ -173,7 +172,7 @@ public class TestEdit extends BaseTest {
 		assertThat(p.toFile().exists(), is(true));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toString(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toString());
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 
@@ -198,7 +197,7 @@ public class TestEdit extends BaseTest {
 		assertThat(new File(s).exists(), is(true));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(s, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(s);
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 
@@ -216,7 +215,7 @@ public class TestEdit extends BaseTest {
 		assertThat(p.toFile().exists(), is(true));
 
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toString(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toString());
 		ctx.resolveClassPath(src);
 
 		File project = new Edit().createProjectForEdit(src, ctx, false);

--- a/src/test/java/dev/jbang/cli/TestEditWithPackage.java
+++ b/src/test/java/dev/jbang/cli/TestEditWithPackage.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 import dev.jbang.BaseTest;
 import dev.jbang.source.RunContext;
 import dev.jbang.source.ScriptSource;
-import dev.jbang.source.Source;
 import dev.jbang.source.TestScript;
 
 public class TestEditWithPackage extends BaseTest {
@@ -57,7 +56,7 @@ public class TestEditWithPackage extends BaseTest {
 		Path CPath = TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classC);
 		assertTrue(mainPath.toFile().exists());
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(mainPath.toString(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(mainPath.toString());
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 		assertTrue(new File(project, "src/A.java").exists());
 		assertTrue(new File(project, "src/person/B.java").exists());

--- a/src/test/java/dev/jbang/cli/TestEditWithPom.java
+++ b/src/test/java/dev/jbang/cli/TestEditWithPom.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import dev.jbang.BaseTest;
 import dev.jbang.source.RunContext;
 import dev.jbang.source.ScriptSource;
-import dev.jbang.source.Source;
 import dev.jbang.source.TestScript;
 import dev.jbang.util.Util;
 
@@ -49,7 +48,7 @@ public class TestEditWithPom extends BaseTest {
 		Path mainPath = TestScript.createTmpFileWithContent("", "main.java", main);
 		assertTrue(mainPath.toFile().exists());
 		RunContext ctx = RunContext.empty();
-		ScriptSource src = (ScriptSource) Source.forResource(mainPath.toString(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(mainPath.toString());
 		File project = new Edit().createProjectForEdit(src, ctx, false);
 		assertTrue(new File(project, "src/main.java").exists());
 

--- a/src/test/java/dev/jbang/cli/TestExternalDeps.java
+++ b/src/test/java/dev/jbang/cli/TestExternalDeps.java
@@ -46,7 +46,7 @@ class TestExternalDeps extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(f.getPath(), ctx);
+		Source src = ctx.forResource(f.getPath());
 		src = run.prepareArtifacts(src, ctx);
 
 		String result = run.generateCommandLine(src, ctx);
@@ -70,7 +70,7 @@ class TestExternalDeps extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(f.getPath(), ctx);
+		Source src = ctx.forResource(f.getPath());
 		src = run.prepareArtifacts(src, ctx);
 
 		String result = run.generateCommandLine(src, ctx);

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -100,4 +100,23 @@ public class TestInfo extends BaseTest {
 				hasSize(equalTo(1)),
 				everyItem(containsString(Paths.get("itests/hellojar.jar").toString()))));
 	}
+
+	@Test
+	void testInfoClasspathNested() {
+		String src = examplesTestFolder.resolve("sources.java").toString();
+		JBang jbang = new JBang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo(src));
+		assertThat(info.applicationJar, allOf(
+				containsString("sources.java."),
+				endsWith(".jar")));
+		assertThat(info.backingResource, equalTo(src));
+		assertThat(info.javaVersion, is(nullValue()));
+		assertThat(info.mainClass, is(nullValue()));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("picocli"))));
+	}
 }

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -91,7 +91,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(arg, ctx);
+		Source src = ctx.forResource(arg);
 
 		src = run.prepareArtifacts(src, ctx);
 		if (first) {
@@ -128,7 +128,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setCatalog(cat.toFile());
-		Source src = Source.forResource("helloworld", ctx);
+		Source src = ctx.forResource("helloworld");
 
 		src = run.prepareArtifacts(src, ctx);
 		String result = run.generateCommandLine(src, ctx);
@@ -160,7 +160,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -186,7 +186,7 @@ public class TestRun extends BaseTest {
 		empty.createNewFile();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(empty.toString(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(empty.toString());
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -208,7 +208,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -233,7 +233,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(jar, ctx);
+		Source src = ctx.forResource(jar);
 
 		String result = run.generateCommandLine(src, ctx);
 		assertThat(result, matchesPattern("^.*java(.exe)?.*"));
@@ -262,7 +262,7 @@ public class TestRun extends BaseTest {
 			Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 			RunContext ctx = run.getRunContext();
-			Source src = Source.forResource(jar, ctx);
+			Source src = ctx.forResource(jar);
 
 			String cmdline = run.generateCommandLine(src, ctx);
 
@@ -287,7 +287,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(jar, ctx);
+		Source src = ctx.forResource(jar);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*codegen-4.5.0.jar"));
 
@@ -321,7 +321,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(jar, ctx);
+		Source src = ctx.forResource(jar);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*.jar"));
 
@@ -345,7 +345,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(jar, ctx);
+		Source src = ctx.forResource(jar);
 
 		assertThat(src.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*eclipse.jgit.pgm.*.jar"));
 
@@ -368,7 +368,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(jar, ctx);
+		Source src = ctx.forResource(jar);
 
 		String cmd = run.generateCommandLine(src, ctx);
 
@@ -392,7 +392,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -417,7 +417,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -441,7 +441,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -463,7 +463,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -493,7 +493,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
-		ScriptSource src = (ScriptSource) Source.forResource(arg, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
 
 		String result = run.generateCommandLine(src, ctx);
 
@@ -516,7 +516,7 @@ public class TestRun extends BaseTest {
 		String url = examplesTestFolder.resolve("classpath_example.java").toFile().toURI().toString();
 
 		RunContext pctx = RunContext.empty();
-		ScriptSource pre = (ScriptSource) Source.forResource(url, pctx);
+		ScriptSource pre = (ScriptSource) pctx.forResource(url);
 
 		assertThat(pre.toString(), not(containsString(url)));
 
@@ -530,7 +530,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
-		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(url);
 
 		String s = run.generateCommandLine(src, ctx);
 
@@ -547,7 +547,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
-		ScriptSource src = (ScriptSource) Source.forResource(url, ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(url);
 
 		String s = run.generateCommandLine(src, ctx);
 		if (Util.isWindows()) {
@@ -562,7 +562,7 @@ public class TestRun extends BaseTest {
 
 		String url = examplesTestFolder.resolve("classpath_example.java.dontexist").toFile().toURI().toString();
 
-		assertThrows(ExitException.class, () -> Source.forResource(url, RunContext.empty()));
+		assertThrows(ExitException.class, () -> RunContext.empty().forResource(url));
 	}
 
 	@Test
@@ -595,7 +595,7 @@ public class TestRun extends BaseTest {
 
 		File out = new File(rootdir.toFile(), "content.jar");
 
-		ScriptSource src = Source.forScript("");
+		ScriptSource src = new ScriptSource("", null);
 		RunContext ctx = RunContext.empty();
 		ctx.setMainClass("wonkabear");
 
@@ -654,8 +654,8 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		Source src = Source.forFile(f);
 		RunContext ctx = RunContext.empty();
+		Source src = ctx.forFile(f);
 		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
 		assertThat(ctx.getMainClassOr(src), equalTo("aclass"));
@@ -703,8 +703,8 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		Source src = Source.forFile(f);
 		RunContext ctx = RunContext.empty();
+		Source src = ctx.forFile(f);
 
 		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -741,7 +741,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		Source src = Source.forResource(arg, ctx);
+		Source src = ctx.forResource(arg);
 
 		src = BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -939,8 +939,8 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg, "--cds");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		Source src = Source.forFile(new File(arg));
 		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties());
+		Source src = ctx.forFile(new File(arg));
 		ctx.setMainClass("fakemain");
 		String commandLine = run.generateCommandLine(src, ctx);
 
@@ -990,7 +990,7 @@ public class TestRun extends BaseTest {
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toFile().getAbsolutePath());
 
 		BaseBuildCommand.build(src, ctx);
 
@@ -1019,7 +1019,7 @@ public class TestRun extends BaseTest {
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toFile().getAbsolutePath());
 
 		BaseBuildCommand.build(src, ctx);
 
@@ -1065,9 +1065,9 @@ public class TestRun extends BaseTest {
 		assertThat(run.javaAgentSlots.containsKey(agentfile.getAbsolutePath()), is(true));
 		assertThat(run.javaAgentSlots.get(agentfile.getAbsolutePath()).get(), equalTo("optionA"));
 
-		Source src = Source.forFile(mainfile);
 		RunContext ctx = RunContext.create(run.userParams, null, run.dependencyInfoMixin.getProperties());
-		ScriptSource asrc = (ScriptSource) Source.forFile(agentfile);
+		Source src = ctx.forFile(mainfile);
+		ScriptSource asrc = (ScriptSource) ctx.forFile(agentfile);
 
 		assertThat(asrc.isAgent(), is(true));
 
@@ -1124,7 +1124,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
-		ScriptSource src = (ScriptSource) Source.forResource(f.getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(f.getAbsolutePath());
 
 		String line = run.generateCommandLine(src, ctx);
 
@@ -1142,7 +1142,7 @@ public class TestRun extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(f.getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(f.getAbsolutePath());
 
 		String line = run.generateCommandLine(src, ctx);
 
@@ -1154,7 +1154,7 @@ public class TestRun extends BaseTest {
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(f.getAbsolutePath(), ctx);
+		Source src = ctx.forResource(f.getAbsolutePath());
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -1186,7 +1186,7 @@ public class TestRun extends BaseTest {
 		File f = examplesTestFolder.resolve("one.java").toFile();
 
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(f.getAbsolutePath(), ctx);
+		Source src = ctx.forResource(f.getAbsolutePath());
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -1244,7 +1244,7 @@ public class TestRun extends BaseTest {
 
 		String url = "http://localhost:" + wms.port() + "/sub/one.java";
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(url, ctx);
+		Source src = ctx.forResource(url);
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -1284,7 +1284,7 @@ public class TestRun extends BaseTest {
 
 		String url = "http://localhost:" + wms.port() + "/sub/one.java";
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(url, ctx);
+		Source src = ctx.forResource(url);
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -1322,7 +1322,7 @@ public class TestRun extends BaseTest {
 
 		String url = "http://localhost:" + wms.port() + "/sub/one";
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(url, ctx);
+		Source src = ctx.forResource(url);
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 	}
@@ -1345,7 +1345,7 @@ public class TestRun extends BaseTest {
 		Util.writeString(f.toPath(), base);
 
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(dir.toPath().toString(), ctx);
+		Source src = ctx.forResource(dir.toPath().toString());
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 
@@ -1355,7 +1355,7 @@ public class TestRun extends BaseTest {
 	void testNoDefaultApp(@TempDir File dir) throws IOException {
 
 		ExitException e = assertThrows(ExitException.class,
-				() -> Source.forResource(dir.toPath().toString(), RunContext.empty()));
+				() -> RunContext.empty().forResource(dir.toPath().toString()));
 
 		assertThat(e.getMessage(), containsString("is a directory and no default application"));
 
@@ -1378,7 +1378,7 @@ public class TestRun extends BaseTest {
 
 		String url = "http://localhost:" + wms.port() + "/sub/one/";
 		RunContext ctx = RunContext.empty();
-		Source src = Source.forResource(url, ctx);
+		Source src = ctx.forResource(url);
 
 		BaseBuildCommand.build((ScriptSource) src, ctx);
 	}
@@ -1398,7 +1398,7 @@ public class TestRun extends BaseTest {
 
 		wms.start();
 		assertThrows(ExitException.class,
-				() -> Source.forResource("http://localhost:" + wms.port() + "/sub/one/", RunContext.empty()));
+				() -> RunContext.empty().forResource("http://localhost:" + wms.port() + "/sub/one/"));
 
 	}
 
@@ -1413,7 +1413,7 @@ public class TestRun extends BaseTest {
 		ctx.setMainClass("fakemain");
 
 		assert (run.enableFlightRecording());
-		String line = run.generateCommandLine(Source.forResource(arg, ctx), ctx);
+		String line = run.generateCommandLine(ctx.forResource(arg), ctx);
 
 		assertThat(line, containsString("helloworld.jfr"));
 		// testing it does not go to cache by accident
@@ -1431,7 +1431,7 @@ public class TestRun extends BaseTest {
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
 
-		String line = run.generateCommandLine(Source.forResource(arg, ctx), ctx);
+		String line = run.generateCommandLine(ctx.forResource(arg), ctx);
 
 		assertThat(line, containsString(" --show-version "));
 	}
@@ -1450,7 +1450,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
-		String line = run.generateCommandLine(Source.forResource(fileref.toString(), ctx), ctx);
+		String line = run.generateCommandLine(ctx.forResource(fileref.toString()), ctx);
 
 		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
 	}
@@ -1472,7 +1472,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
-		String line = run.generateCommandLine(Source.forResource(fileref.toString(), ctx), ctx);
+		String line = run.generateCommandLine(ctx.forResource(fileref.toString()), ctx);
 
 		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
 	}
@@ -1496,7 +1496,7 @@ public class TestRun extends BaseTest {
 
 		RunContext ctx = run.getRunContext();
 		ctx.setMainClass("fakemain");
-		String line = run.generateCommandLine(Source.forResource(fileref.toString(), ctx), ctx);
+		String line = run.generateCommandLine(ctx.forResource(fileref.toString()), ctx);
 
 		assertThat(line, containsString(" --module-path "));
 

--- a/src/test/java/dev/jbang/dependencies/TestGrape.java
+++ b/src/test/java/dev/jbang/dependencies/TestGrape.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
-import dev.jbang.source.RunContext;
+import dev.jbang.source.ScriptSource;
 import dev.jbang.source.Source;
 
 public class TestGrape extends BaseTest {
@@ -30,8 +30,8 @@ public class TestGrape extends BaseTest {
 				+
 				"})\n";
 
-		Source src = Source.forScript(grabBlock);
-		List<String> deps = RunContext.empty().collectAllDependenciesFor(src);
+		Source src = new ScriptSource(grabBlock, null);
+		List<String> deps = src.getAllDependencies();
 
 		assertThat(deps, hasItem("org.hibernate:hibernate-core:5.4.10.Final"));
 		assertThat(deps, hasItem("net.sf.json-lib:json-lib:2.2.3:jdk15"));

--- a/src/test/java/dev/jbang/source/TestSameSourceInDifferentPaths.java
+++ b/src/test/java/dev/jbang/source/TestSameSourceInDifferentPaths.java
@@ -67,7 +67,7 @@ public class TestSameSourceInDifferentPaths extends BaseTest {
 		Path BPath = TestScript.createTmpFileWithContent(mainPath.getParent(), "person", "B.java", classB);
 		TestScript.createTmpFileWithContent(mainPath.getParent(), "model", "C.java", classModelC);
 		TestScript.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classPersonModelC);
-		ScriptSource script = ScriptSource.prepareScript(mainPath.toString());
+		ScriptSource script = ScriptSource.prepareScript(mainPath.toString(), null);
 		assertEquals(script.getAllSources().size(), 3);
 	}
 

--- a/src/test/java/dev/jbang/source/TestScript.java
+++ b/src/test/java/dev/jbang/source/TestScript.java
@@ -148,7 +148,8 @@ public class TestScript extends BaseTest {
 
 		assertEquals(script.getJavaVersion(), "14+");
 
-		List<String> deps = script.getAllDependencies(System.getProperties());
+		RunContext ctx = RunContext.empty();
+		List<String> deps = ctx.collectAllDependenciesFor(script);
 
 		assertThat(deps, containsInAnyOrder("info.picocli:picocli:4.5.0"));
 	}
@@ -157,11 +158,12 @@ public class TestScript extends BaseTest {
 	void testFindDependencies() {
 		ScriptSource script = new ScriptSource(example);
 
-		List<String> dependencies = script.getAllDependencies(System.getProperties());
-		assertEquals(2, dependencies.size());
+		RunContext ctx = RunContext.empty();
+		List<String> deps = ctx.collectAllDependenciesFor(script);
+		assertEquals(2, deps.size());
 
-		assertTrue(dependencies.contains("com.offbytwo:docopt:0.6.0.20150202"));
-		assertTrue(dependencies.contains("log4j:log4j:1.2.14"));
+		assertTrue(deps.contains("com.offbytwo:docopt:0.6.0.20150202"));
+		assertTrue(deps.contains("log4j:log4j:1.2.14"));
 
 	}
 

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -105,7 +105,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 				classHelloInner);
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath.toFile());
-		ScriptSource script = ScriptSource.prepareScript(resourceRef);
+		ScriptSource script = ScriptSource.prepareScript(resourceRef, null);
 		List<ScriptSource> sources = script.getAllSources();
 		assertEquals(sources.size(), 4);
 		TreeSet<String> fileNames = new TreeSet<>();
@@ -139,7 +139,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 				classHelloInner);
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath.toFile());
-		ScriptSource script = ScriptSource.prepareScript(resourceRef);
+		ScriptSource script = ScriptSource.prepareScript(resourceRef, null);
 		Assertions.assertThrows(ExitException.class, () -> script.getAllSources());
 
 	}

--- a/src/test/java/dev/jbang/source/TestSourcesMutualDependency.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMutualDependency.java
@@ -39,7 +39,7 @@ public class TestSourcesMutualDependency extends BaseTest {
 		TestScript.createTmpFileWithContent("", "A.java", classA);
 		TestScript.createTmpFileWithContent("", "B.java", classB);
 		String scriptURL = mainPath.toString();
-		ScriptSource script = ScriptSource.prepareScript(scriptURL);
+		ScriptSource script = ScriptSource.prepareScript(scriptURL, null);
 		assertEquals(script.getAllSources().size(), 2);
 	}
 

--- a/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
@@ -78,7 +78,7 @@ class TestSourcesRecursivelyMultipleFiles extends BaseTest {
 				classHelloInner);
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath.toFile());
-		ScriptSource script = ScriptSource.prepareScript(resourceRef);
+		ScriptSource script = ScriptSource.prepareScript(resourceRef, null);
 		List<ScriptSource> sources = script.getAllSources();
 		assertEquals(sources.size(), 4);
 		TreeSet<String> fileNames = new TreeSet<>();


### PR DESCRIPTION
>    fix: Fixed NPE for `info` on sources with `//SOURCES` lines
>
>    Refactored API a bit because the `Source` classes were being asked to deal with context issues (like knowing about system properties) which are better handled at the level of `RunContext`.
>    
>    Fixes #1096

and

>    refactor: Removed use of static property resolver from `ScriptSource`
>    
>    Instead of relying on a static property resolver we now pass a resolver into the constructor of `ScriptSource`. For this the static factory methods for creating `Source` objects have been refactored as instance methods of `RunContext` (which knows about properties).