### PR TITLE
fix: Improved `main()` method lookup

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           java-version: 8
       - name: build-gradle
-        run: ./gradlew build installDist --build-cache --scan -s
+        run: ./gradlew clean build installDist --build-cache --scan -s
       - name: integration-test-non-windows
         if: runner.os != 'Windows'
         run: |

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.function.Predicate;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
@@ -411,56 +412,47 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 										.filter(f -> f.toFile().getName().endsWith(".class"))
 										.collect(Collectors.toList());
 
-				if (items.size() > 1) { // todo: this feels like a very sketchy way to find the proper class
-					// name
-					// but it works.
-					String mainname = src.getSuggestedMain();
-					items = items	.stream()
-									.filter(f -> f.toFile().getName().equalsIgnoreCase(mainname))
-									.collect(Collectors.toList());
+				Indexer indexer = new Indexer();
+				Index index;
+				for (Path item : items) {
+					try (InputStream stream = new FileInputStream(item.toFile())) {
+						indexer.index(stream);
+					}
+				}
+				index = indexer.complete();
+
+				Collection<ClassInfo> classes = index.getKnownClasses();
+
+				List<ClassInfo> mains = classes	.stream()
+												.filter(src.getMainFinder())
+												.collect(Collectors.toList());
+				String mainName = src.getSuggestedMain();
+				if (mains.size() > 1 && mainName != null) {
+					mains = mains.stream().filter(ci -> ci.simpleName().equals(mainName)).collect(Collectors.toList());
+				}
+				if (mains.size() > 1) {
+					throw new ExitException(EXIT_GENERIC_ERROR,
+							"Could not locate unique main() method. Found " + mains.size() + " candidates.");
+				}
+				if (!mains.isEmpty()) {
+					ctx.setMainClass(mains.get(0).name().toString());
 				}
 
-				if (items.size() != 1) {
-					throw new ExitException(1,
-							"Could not locate unique class. Found " + items.size() + " candidates.");
-				} else {
-					Path classfile = items.get(0);
-					// TODO: could we use jandex to find the right main class more sanely ?
-					// String mainClass = findMainClass(tmpJarDir.toPath(), classfile);
+				if (src.isAgent()) {
+					Optional<ClassInfo> agentmain = classes	.stream()
+															.filter(pubClass -> pubClass.method("agentmain",
+																	STRINGTYPE,
+																	INSTRUMENTATIONTYPE) != null
+																	||
+																	pubClass.method("agentmain",
+																			STRINGTYPE) != null)
+															.findFirst();
 
-					Indexer indexer = new Indexer();
-					Index index;
-					try (InputStream stream = new FileInputStream(classfile.toFile())) {
-						indexer.index(stream);
-						index = indexer.complete();
+					if (agentmain.isPresent()) {
+						ctx.setAgentMainClass(agentmain.get().name().toString());
 					}
 
-					Collection<ClassInfo> clazz = index.getKnownClasses();
-
-					Optional<ClassInfo> main = clazz.stream()
-													.filter(src.getMainFinder())
-													.findFirst();
-
-					if (main.isPresent()) {
-						ctx.setMainClass(main.get().name().toString());
-					}
-
-					if (src.isAgent()) {
-
-						Optional<ClassInfo> agentmain = clazz	.stream()
-																.filter(pubClass -> pubClass.method("agentmain",
-																		STRINGTYPE,
-																		INSTRUMENTATIONTYPE) != null
-																		||
-																		pubClass.method("agentmain",
-																				STRINGTYPE) != null)
-																.findFirst();
-
-						if (agentmain.isPresent()) {
-							ctx.setAgentMainClass(agentmain.get().name().toString());
-						}
-
-						Optional<ClassInfo> premain = clazz	.stream()
+					Optional<ClassInfo> premain = classes	.stream()
 															.filter(pubClass -> pubClass.method("premain",
 																	STRINGTYPE,
 																	INSTRUMENTATIONTYPE) != null
@@ -469,16 +461,18 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 																			STRINGTYPE) != null)
 															.findFirst();
 
-						if (premain.isPresent()) {
-							ctx.setPreMainClass(premain.get().name().toString());
-						}
+					if (premain.isPresent()) {
+						ctx.setPreMainClass(premain.get().name().toString());
 					}
-
 				}
 			}
 		} catch (IOException e) {
 			throw new ExitException(1, e);
 		}
+	}
+
+	private Predicate<ClassInfo> getMainFinder() {
+		return pubClass -> pubClass.method("main", BaseBuildCommand.STRINGARRAYTYPE) != null;
 	}
 
 	protected static Path generatePom(ScriptSource src, RunContext ctx, File tmpJarDir) throws IOException {

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -53,6 +53,10 @@ public class ResourceRef implements Comparable<ResourceRef> {
 		return originalResource != null && Util.isClassPathRef(originalResource);
 	}
 
+	public boolean isStdin() {
+		return originalResource != null && isStdin(originalResource);
+	}
+
 	public File getFile() {
 		return file;
 	}
@@ -202,7 +206,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 				}
 			} else {
 				// support stdin
-				if (scriptResource.equals("-") || scriptResource.equals("/dev/stdin")) {
+				if (isStdin(scriptResource)) {
 					String scriptText = new BufferedReader(
 							new InputStreamReader(System.in, StandardCharsets.UTF_8))
 																						.lines()
@@ -228,6 +232,10 @@ public class ResourceRef implements Comparable<ResourceRef> {
 		}
 
 		return result;
+	}
+
+	private static boolean isStdin(String scriptResource) {
+		return scriptResource.equals("-") || scriptResource.equals("/dev/stdin");
 	}
 
 	private static ResourceRef forResource(String scriptResource, Function<String, ResourceRef> urlFetcher) {

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -205,7 +205,11 @@ public class ScriptSource implements Source {
 	}
 
 	public String getSuggestedMain() {
-		return getResourceRef().getFile().getName().replace(getMainExtension(), ".class");
+		if (!getResourceRef().isStdin()) {
+			return getResourceRef().getFile().getName().replace(getMainExtension(), "");
+		} else {
+			return null;
+		}
 	}
 
 	public static class KeyValue {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1269,7 +1269,7 @@ public class TestRun extends BaseTest {
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toFile().getAbsolutePath());
 
 		BaseBuildCommand.build(src, ctx);
 
@@ -1298,7 +1298,7 @@ public class TestRun extends BaseTest {
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toFile().getAbsolutePath());
 
 		BaseBuildCommand.build(src, ctx);
 
@@ -1317,7 +1317,7 @@ public class TestRun extends BaseTest {
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		RunContext ctx = run.getRunContext();
-		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+		ScriptSource src = (ScriptSource) ctx.forResource(p.toFile().getAbsolutePath());
 
 		BaseBuildCommand.build(src, ctx);
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1250,6 +1250,30 @@ public class TestRun extends BaseTest {
 
 	}
 
+	String script = "" +
+			"class One {\n" +
+			"}" +
+			"class Two {\n" +
+			"public static void main(String... args) { };\n" +
+			"}" +
+			"class Three {\n" +
+			"}";
+
+	@Test
+	void testMultiSourcesNonPublic(@TempDir Path output) throws IOException {
+		JBang jbang = new JBang();
+		Path p = output.resolve("script");
+		writeString(p, script);
+
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
+		Build run = (Build) pr.subcommand().commandSpec().userObject();
+
+		RunContext ctx = run.getRunContext();
+		ScriptSource src = (ScriptSource) Source.forResource(p.toFile().getAbsolutePath(), ctx);
+
+		BaseBuildCommand.build(src, ctx);
+	}
+
 	WireMockServer wms;
 
 	@BeforeEach


### PR DESCRIPTION
Before it would just assume that the `main()` method was located
in a class with the same name as the Java source file, but that's
not always the case. For example, when reading from stdin it's
hard to detect the right class and even more so when dealing with
non-public classes (non-public classes can still have `main()`
methods!)

Fixes #1099
