### PR TITLE
fix: Not using JAVA_HOME anymore if it's invalid

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -133,6 +133,7 @@ fi
 if [[ -z "$JAVA_EXEC" ]]; then
   # Determine if a (working) JDK is available on the PATH
   if [ -x "$(command -v javac)" ]; then
+    unset JAVA_HOME
     JAVA_EXEC="java";
   elif [ -x "$JBDIR/currentjdk/bin/javac" ]; then
     export JAVA_HOME="$JBDIR/currentjdk"

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -40,6 +40,7 @@ if "!JAVA_EXEC!"=="" (
   rem Determine if a (working) JDK is available on the PATH
   where javac > nul 2>&1
   if !errorlevel! equ 0 (
+    set JAVA_HOME=
     set JAVA_EXEC=java.exe
   ) else if exist "%JBDIR%\currentjdk\bin\javac" (
     set JAVA_HOME=%JBDIR%\currentjdk

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -106,6 +106,7 @@ if ($JAVA_EXEC -eq "") {
   # Determine if a (working) JDK is available on the PATH
   $ok=$false; try { if (Get-Command "javac") { $ok=$true } } catch {}
   if ($ok) {
+    $env:JAVA_HOME=""
     $JAVA_EXEC="java.exe"
   } elseif (Test-Path "$JBDIR\currentjdk\bin\javac") {
     $env:JAVA_HOME="$JBDIR\currentjdk"


### PR DESCRIPTION
Before the startup scripts would actually check if JAVA_HOME
points to a (seemingly) valid JDK, but the Java code would
not. The easiest solution was to just unset the JAVA_HOME
env var in the case it's invalid.

Fixes #1103