### PR TITLE
Better deps handling

### DIFF
--- a/itests/dependencies.feature
+++ b/itests/dependencies.feature
@@ -3,6 +3,6 @@ Feature: dependency fetching
 Scenario: fetch dependencies
 * command('jbang --verbose version')
 When command('jbang classpath_log.java', { JBANG_REPO: scratch + "/newrepo"})
-Then match err == '[jbang] Resolving dependencies...\n[jbang]     Resolving log4j:log4j:1.2.17...Done\n[jbang] Dependencies resolved\n[jbang] Building jar...\n'
+Then match err == '[jbang] Resolving dependencies...\n[jbang]     Resolving log4j:log4j:jar:1.2.17...Done\n[jbang] Dependencies resolved\n[jbang] Building jar...\n'
 And fileexist(scratch + "/newrepo")
 And match exit == 0

--- a/itests/test_suite.sh
+++ b/itests/test_suite.sh
@@ -81,7 +81,7 @@ esac
 
 ## test dependency resolution on custom local repo (to avoid conflicts with existing ~/.m2)
 export JBANG_REPO=$SCRATCH/testrepo
-assert_stderr "jbang classpath_log.java" "[jbang] Resolving dependencies...\n[jbang]     Resolving log4j:log4j:1.2.17...Done\n[jbang] Dependencies resolved\n[jbang] Building jar..."
+assert_stderr "jbang classpath_log.java" "[jbang] Resolving dependencies...\n[jbang]     Resolving log4j:log4j:jar:1.2.17...Done\n[jbang] Dependencies resolved\n[jbang] Building jar..."
 assert_raises "test -d $SCRATCH/testrepo" 0
 assert "grep -c $SCRATCH/testrepo ~/.jbang/cache/dependency_cache.json" 1
 # run it 2nd time and no resolution should happen

--- a/src/main/java/dev/jbang/dependencies/DependencyCache.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyCache.java
@@ -109,7 +109,7 @@ public class DependencyCache {
 												.flatMap(Collection::stream)
 												.filter(art -> art.getFile().equals(artifactPath))
 												.findFirst();
-		return result.orElse(null);
+		return result.orElseGet(() -> new ArtifactInfo(null, artifactPath));
 	}
 
 	public static void clear() {

--- a/src/main/java/dev/jbang/dependencies/DependencyResolver.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyResolver.java
@@ -1,0 +1,74 @@
+package dev.jbang.dependencies;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import dev.jbang.util.Util;
+
+public class DependencyResolver {
+	private final Set<MavenRepo> repositories;
+	private final Set<String> dependencies;
+	private final Set<ArtifactInfo> artifacts;
+
+	public DependencyResolver() {
+		repositories = new LinkedHashSet<>();
+		dependencies = new LinkedHashSet<>();
+		artifacts = new LinkedHashSet<>();
+	}
+
+	public DependencyResolver addRepository(MavenRepo repository) {
+		repositories.add(repository);
+		return this;
+	}
+
+	public DependencyResolver addRepositories(List<MavenRepo> repositories) {
+		this.repositories.addAll(repositories);
+		return this;
+	}
+
+	public DependencyResolver addDependency(String dependency) {
+		dependencies.add(dependency);
+		return this;
+	}
+
+	public DependencyResolver addDependencies(List<String> dependencies) {
+		this.dependencies.addAll(dependencies);
+		return this;
+	}
+
+	public DependencyResolver addArtifact(ArtifactInfo artifact) {
+		artifacts.add(artifact);
+		return this;
+	}
+
+	public DependencyResolver addArtifacts(List<ArtifactInfo> artifacts) {
+		this.artifacts.addAll(artifacts);
+		return this;
+	}
+
+	public DependencyResolver addClassPath(String classPath) {
+		return addArtifact(DependencyCache.findArtifactByPath(new File(classPath)));
+	}
+
+	public DependencyResolver addClassPaths(List<String> classPaths) {
+		for (String cp : classPaths) {
+			addClassPath(cp);
+		}
+		return this;
+	}
+
+	public DependencyResolver addClassPaths(String classPaths) {
+		return addClassPaths(Arrays.asList(classPaths.split(" ")));
+	}
+
+	public ModularClassPath resolve() {
+		ModularClassPath mcp = DependencyUtil.resolveDependencies(
+				new ArrayList<>(dependencies), new ArrayList<>(repositories),
+				Util.isOffline(), Util.isFresh(), !Util.isQuiet());
+		List<ArtifactInfo> arts = Stream.concat(mcp.getArtifacts().stream(), artifacts.stream())
+										.collect(Collectors.toList());
+		return new ModularClassPath(arts);
+	}
+}

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -16,6 +16,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.jboss.shrinkwrap.resolver.api.Coordinate;
 import org.jboss.shrinkwrap.resolver.api.maven.ConfigurableMavenResolverSystem;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.jboss.shrinkwrap.resolver.api.maven.MavenFormatStage;
@@ -145,10 +146,13 @@ public class DependencyUtil {
 
 		System.setProperty("maven.repo.local", Settings.getLocalMavenRepo().toPath().toAbsolutePath().toString());
 
-		PomEquippedResolveStage pomResolve = null;
+		List<MavenCoordinate> coords = depIds	.stream()
+												.map(DependencyUtil::depIdToArtifact)
+												.collect(Collectors.toList());
 
-		if (!depIds.isEmpty()) {
-			MavenCoordinate mc = depIdToArtifact(depIds.get(0));
+		PomEquippedResolveStage pomResolve = null;
+		if (!coords.isEmpty()) {
+			MavenCoordinate mc = coords.get(0);
 			if (PackagingType.POM.equals(mc.getType())) {
 				if (loggingEnabled) {
 					infoMsg("Loading " + mc);
@@ -158,53 +162,45 @@ public class DependencyUtil {
 				MavenStrategyStage resolve = resolver.resolve(mc.toCanonicalForm());
 				pomResolve = resolver.loadPomFromFile(resolve.withoutTransitivity().asSingleFile());
 				System.getProperties().remove("jbang-allowpom");
-				depIds.remove(0);
+				coords.remove(0);
 			}
 		}
 
-		final PomEquippedResolveStage ps = pomResolve;
+		Optional<MavenCoordinate> pom = coords.stream().filter(c -> c.getType().equals(PackagingType.POM)).findFirst();
+		if (pom.isPresent()) {
+			// proactively avoiding that we break users in future
+			// when we support more than one BOM POM
+			throw new ExitException(1, "POM imports as found in " + pom.get().toCanonicalForm()
+					+ " is only supported as the first import.");
+		}
 
-		return depIds.stream().flatMap(it -> {
+		List<String> canonicals = coords.stream().map(Coordinate::toCanonicalForm).collect(Collectors.toList());
 
-			MavenCoordinate artifact = depIdToArtifact(it);
+		if (loggingEnabled) {
+			infoHeader();
+			infoMsgFmt("    Resolving %s...", String.join(", ", canonicals));
+		}
 
-			if (PackagingType.POM.equals(artifact.getType())) {
-				// proactively avoiding that we break users in future
-				// when we support more than one BOM POM
-				throw new ExitException(1, "POM imports as found in " + it + " is only supported as the first import.");
+		try {
+			MavenStrategyStage resolve;
+			if (pomResolve != null) {
+				resolve = pomResolve.resolve(canonicals);
+			} else {
+				resolve = resolver.resolve(canonicals);
 			}
 
-			if (loggingEnabled) {
-				infoHeader();
-				infoMsgFmt("    Resolving %s...", it);
-			}
-
-			List<MavenResolvedArtifact> artifacts;
-			try {
-				MavenStrategyStage resolve;
-				MavenFormatStage stage = null;
-				if (ps != null) {
-					resolve = ps.resolve(artifact.toCanonicalForm());
-				} else {
-					resolve = resolver.resolve(artifact.toCanonicalForm());
-				}
-
-				if (transitively) {
-					stage = resolve.withTransitivity();
-				} else {
-					stage = resolve.withoutTransitivity();
-				}
-				artifacts = stage.asList(MavenResolvedArtifact.class); // , RUNTIME);
-
-			} catch (RuntimeException e) {
-				throw new ExitException(1, "Could not resolve dependency " + it, e);
-			}
+			MavenFormatStage stage = transitively ? resolve.withTransitivity() : resolve.withoutTransitivity();
+			List<MavenResolvedArtifact> artifacts = stage.asList(MavenResolvedArtifact.class); // , RUNTIME);
 
 			if (loggingEnabled)
 				infoMsgFmt("Done\n");
 
-			return artifacts.stream().map(xx -> new ArtifactInfo(xx.getCoordinate(), xx.asFile()));
-		}).collect(Collectors.toList());
+			return artifacts.stream()
+							.map(mra -> new ArtifactInfo(mra.getCoordinate(), mra.asFile()))
+							.collect(Collectors.toList());
+		} catch (RuntimeException e) {
+			throw new ExitException(1, "Could not resolve dependency", e);
+		}
 	}
 
 	public static String decodeEnv(String value) {

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.resolver.api.maven.ConfigurableMavenResolverSystem;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -291,13 +290,5 @@ public class DependencyUtil {
 		} else {
 			return new MavenRepo(repoid, reporef);
 		}
-	}
-
-	@SafeVarargs
-	public static List<ArtifactInfo> joinClasspaths(List<ArtifactInfo>... classpaths) {
-		return Stream	.of(classpaths)
-						.flatMap(x -> x.stream())
-						.distinct()
-						.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
 import org.codehaus.plexus.languages.java.jpms.LocationManager;
@@ -27,8 +26,6 @@ public class ModularClassPath {
 	static final String JAVAFX_PREFIX = "javafx";
 
 	private final List<ArtifactInfo> artifacts;
-	// raw entries provided via --cp/--class-path (not sure they should be here)
-	private final List<String> additionalClasspaths;
 
 	private List<String> classPaths;
 	private String classPath;
@@ -37,12 +34,6 @@ public class ModularClassPath {
 
 	public ModularClassPath(List<ArtifactInfo> artifacts) {
 		this.artifacts = artifacts;
-		this.additionalClasspaths = Collections.emptyList();
-	}
-
-	public ModularClassPath(List<ArtifactInfo> artifacts, List<String> additionalClasspaths) {
-		this.artifacts = artifacts;
-		this.additionalClasspaths = Collections.unmodifiableList(additionalClasspaths);
 	}
 
 	public List<String> getClassPaths() {
@@ -52,10 +43,6 @@ public class ModularClassPath {
 									.map(it -> it.contains(" ") ? '"' + it + '"' : it)
 									.distinct()
 									.collect(Collectors.toList());
-			if (!additionalClasspaths.isEmpty()) {
-				classPaths = new ArrayList<>(classPaths);
-				classPaths.addAll(additionalClasspaths);
-			}
 		}
 
 		return classPaths;
@@ -167,22 +154,5 @@ public class ModularClassPath {
 	 */
 	public boolean isValid() {
 		return artifacts.stream().allMatch(ArtifactInfo::isUpToDate);
-	}
-
-	/**
-	 * Returns a ModularClassPath with the artifacts from the given MANIFEST class
-	 * path string
-	 * 
-	 * @param classPath A class path string as found in a Jar MANIFEST
-	 */
-	public static ModularClassPath fromManifestClasspath(String classPath) {
-		List<ArtifactInfo> arts = Stream.of(classPath.split(" "))
-										.map(File::new)
-										.map(jar -> {
-											ArtifactInfo art = DependencyCache.findArtifactByPath(jar);
-											return art != null ? art : new ArtifactInfo(null, jar);
-										})
-										.collect(Collectors.toList());
-		return new ModularClassPath(arts);
 	}
 }

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -30,9 +30,9 @@ import dev.jbang.Settings;
 import dev.jbang.cli.BaseBuildCommand;
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
+import dev.jbang.dependencies.DependencyResolver;
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.dependencies.MavenRepo;
-import dev.jbang.dependencies.ModularClassPath;
 import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
 
@@ -196,12 +196,10 @@ public class ScriptSource implements Source {
 	}
 
 	@Override
-	public ModularClassPath resolveClassPath(List<String> dependencies) {
-		ModularClassPath classpath;
-		List<MavenRepo> repositories = getAllRepositories();
-		classpath = DependencyUtil.resolveDependencies(dependencies, repositories, Util.isOffline(),
-				Util.isFresh(), !Util.isQuiet());
-		return classpath;
+	public DependencyResolver updateDependencyResolver(DependencyResolver resolver) {
+		resolver.addRepositories(getAllRepositories());
+		resolver.addDependencies(getAllDependencies());
+		return resolver;
 	}
 
 	public String getSuggestedMain() {
@@ -289,6 +287,7 @@ public class ScriptSource implements Source {
 		return getLines()	.stream()
 							.filter(ScriptSource::isRepoDeclare)
 							.flatMap(ScriptSource::extractRepositories)
+							.map(replaceProperties)
 							.map(DependencyUtil::toMavenRepo)
 							.collect(Collectors.toCollection(ArrayList::new));
 	}

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dev.jbang.dependencies.ModularClassPath;
+import dev.jbang.dependencies.DependencyResolver;
 
 /**
  * A Source is an interface for classes representing different inputs (sources)
@@ -94,18 +94,14 @@ public interface Source {
 	/**
 	 * Returns the list of dependencies that are necessary to add to the classpath
 	 * for the application to execute properly.
-	 *
-	 * @param props A `Properties` object whose values can be used during dependency
-	 *              resolution
 	 */
 	List<String> getAllDependencies();
 
 	/**
-	 * Resolves the given list of dependencies
-	 *
-	 * @param dependencies List of dependencies
+	 * Updates the given resolver with the dependencies required by this Source
+	 * object
 	 */
-	ModularClassPath resolveClassPath(List<String> dependencies);
+	DependencyResolver updateDependencyResolver(DependencyResolver resolver);
 
 	default boolean isJar() {
 		return Source.isJar(getResourceRef().getFile());

--- a/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
+++ b/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
@@ -34,7 +34,7 @@ public class TestArtifactInfo extends BaseTest {
 		List<ArtifactInfo> wonka = DependencyCache.findDependenciesByHash("wonka");
 
 		assertThat(wonka, notNullValue());
-		assertThat(wonka, hasSize(6));
+		assertThat(wonka, hasSize(4));
 
 		assertThat(wonka, contains(classpath.getArtifacts().toArray()));
 	}


### PR DESCRIPTION
Includes these two important commits:

> **refactor: Improved dependency handling …**
>
> `Source` dependency handling has been improved so that regardless of the sources or command line options like `--deps` we'll only do a single call to the dependency resolver.

and

> **refactor: Aether now resolves all deps in a single go …**
>
> This fixes any problems with duplicate and conflicting dependencies because we used to handle each dependency separately. The downside, for now, is that we can't log the dependency resolution to the output for the user to see what's happening.
