### PR TITLE
fix: check for `javac` should now work on Mac

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -40,7 +40,7 @@ download() {
 }
 
 javacInPath() {
-  [[ -x "$(command -v javac)" && ( $os != "mac" || ! $(/usr/libexec/java_home &> /dev/null) ) ]]
+  [[ -x "$(command -v javac)" && ( $os != "mac" || $(/usr/libexec/java_home &> /dev/null) ) ]]
 }
 
 abs_jbang_dir=$(dirname $(resolve_symlink $(absolute_path $0)))


### PR DESCRIPTION
One character fix for inverted if-condition.

Fixes #642

