### PR TITLE
Better deps continued

### DIFF
--- a/src/main/java/dev/jbang/dependencies/DependencyResolver.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyResolver.java
@@ -67,8 +67,12 @@ public class DependencyResolver {
 		ModularClassPath mcp = DependencyUtil.resolveDependencies(
 				new ArrayList<>(dependencies), new ArrayList<>(repositories),
 				Util.isOffline(), Util.isFresh(), !Util.isQuiet());
-		List<ArtifactInfo> arts = Stream.concat(mcp.getArtifacts().stream(), artifacts.stream())
-										.collect(Collectors.toList());
-		return new ModularClassPath(arts);
+		if (artifacts.isEmpty()) {
+			return mcp;
+		} else {
+			List<ArtifactInfo> arts = Stream.concat(mcp.getArtifacts().stream(), artifacts.stream())
+											.collect(Collectors.toList());
+			return new ModularClassPath(arts);
+		}
 	}
 }

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -1,36 +1,13 @@
 package dev.jbang.source;
 
-import static dev.jbang.util.Util.getMainClass;
-import static dev.jbang.util.Util.hasMainMethod;
-import static dev.jbang.util.Util.swizzleURL;
-
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-import dev.jbang.Cache;
-import dev.jbang.Settings;
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
-import dev.jbang.dependencies.DependencyUtil;
-import dev.jbang.dependencies.ModularClassPath;
-import dev.jbang.net.TrustedSources;
-import dev.jbang.util.ConsoleInput;
 import dev.jbang.util.Util;
 
 public class ResourceRef implements Comparable<ResourceRef> {
@@ -79,7 +56,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 			} else {
 				sr = Paths.get(originalResource).resolveSibling(siblingResource).toString();
 			}
-			ResourceRef result = forTrustedResource(sr);
+			ResourceRef result = forResource(sr);
 			if (result == null) {
 				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not find " + siblingResource);
 			}
@@ -137,298 +114,19 @@ public class ResourceRef implements Comparable<ResourceRef> {
 		return new ResourceRef(null, file);
 	}
 
-	public static ResourceRef forNamedFile(String scriptResource, File file) {
-		return new ResourceRef(scriptResource, file);
+	public static ResourceRef forNamedFile(String resource, File file) {
+		return new ResourceRef(resource, file);
 	}
 
-	public static ResourceRef forCachedResource(String scriptResource, File cachedResource) {
-		return new ResourceRef(scriptResource, cachedResource);
+	public static ResourceRef forCachedResource(String resource, File cachedResource) {
+		return new ResourceRef(resource, cachedResource);
 	}
 
-	public static ResourceRef forScriptResource(String scriptResource, Function<String, ModularClassPath> depResolver) {
-		ResourceRef result = forScript(scriptResource);
-		if (result == null) {
-			result = forResource(scriptResource, ResourceRef::fetchScriptFromUntrustedURL, depResolver);
-		}
-		return result;
+	public static ResourceRef forResource(String resource) {
+		return ResourceResolver.forResources().resolve(resource);
 	}
 
-	public static ResourceRef forResource(String scriptResource, Function<String, ModularClassPath> depResolver) {
-		return forResource(scriptResource, ResourceRef::fetchFromURL, depResolver);
-	}
-
-	public static ResourceRef forResource(String scriptResource) {
-		return forResource(scriptResource, ResourceRef::fetchFromURL, ResourceRef::noDepResolve);
-	}
-
-	public static ResourceRef forTrustedResource(String scriptResource) {
-		return forResource(scriptResource, ResourceRef::fetchFromURL, ResourceRef::noDepResolve);
-	}
-
-	private static ResourceRef forScript(String scriptResource) {
-		ResourceRef result = null;
-
-		// map script argument to script file
-		File probe = null;
-		try {
-			probe = Util.getCwd().resolve(scriptResource).normalize().toFile();
-		} catch (InvalidPathException e) {
-			// Ignore
-		}
-
-		try {
-			if (probe != null && probe.canRead()) {
-				if (!probe.getName().endsWith(".jar") && !probe.getName().endsWith(".java")
-						&& !probe.getName().endsWith(".kt")
-						&& !probe.getName().endsWith(".jsh")) {
-					if (probe.isDirectory()) {
-						File defaultApp = new File(probe, "main.java");
-						if (defaultApp.exists()) {
-							Util.verboseMsg("Directory where main.java exists. Running main.java.");
-							probe = defaultApp;
-						} else {
-							throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Cannot run " + probe
-									+ " as it is a directory and no default application (i.e. `main.java`) found.");
-						}
-					}
-					String original = Util.readString(probe.toPath());
-					// TODO: move temp handling somewhere central
-					String urlHash = Util.getStableID(original);
-
-					if (original.startsWith("#!")) { // strip bash !# if exists
-						original = original.substring(original.indexOf("\n"));
-					}
-
-					File tempFile = Settings.getCacheDir(Cache.CacheClass.scripts)
-											.resolve(urlHash)
-											.resolve(Util.unkebabify(probe.getName()))
-											.toFile();
-					tempFile.getParentFile().mkdirs();
-					Util.writeString(tempFile.toPath().toAbsolutePath(), original);
-					result = forCachedResource(scriptResource, tempFile);
-				}
-			} else {
-				// support stdin
-				if (isStdin(scriptResource)) {
-					String scriptText = new BufferedReader(
-							new InputStreamReader(System.in, StandardCharsets.UTF_8))
-																						.lines()
-																						.collect(Collectors.joining(
-																								System.lineSeparator()));
-
-					String urlHash = Util.getStableID(scriptText);
-					File cache = Settings.getCacheDir(Cache.CacheClass.stdins).resolve(urlHash).toFile();
-					cache.mkdirs();
-					String basename = urlHash;
-					String suffix = ".jsh";
-					if (hasMainMethod(scriptText)) {
-						suffix = ".java";
-						basename = getMainClass(scriptText).orElse(basename);
-					}
-					File scriptFile = new File(cache, basename + suffix);
-					Util.writeString(scriptFile.toPath(), scriptText);
-					result = forCachedResource(scriptResource, scriptFile);
-				}
-			}
-		} catch (IOException e) {
-			throw new ExitException(BaseCommand.EXIT_UNEXPECTED_STATE, "Could not download " + scriptResource, e);
-		}
-
-		return result;
-	}
-
-	private static boolean isStdin(String scriptResource) {
+	public static boolean isStdin(String scriptResource) {
 		return scriptResource.equals("-") || scriptResource.equals("/dev/stdin");
-	}
-
-	private static ResourceRef forResource(String scriptResource,
-			Function<String, ResourceRef> urlFetcher,
-			Function<String, ModularClassPath> depResolver) {
-		ResourceRef result = null;
-
-		if (scriptResource.startsWith("http://") || scriptResource.startsWith("https://")
-				|| scriptResource.startsWith("file:/")) {
-			// support url's as script files
-			result = urlFetcher.apply(scriptResource);
-		} else if (scriptResource.startsWith("classpath:/")) {
-			result = getClasspathResource(scriptResource);
-		} else if (DependencyUtil.looksLikeAGav(scriptResource)) {
-			// todo honor offline
-			String gav = scriptResource;
-			ModularClassPath mcp = depResolver.apply(gav);
-			// We possibly get a whole bunch of artifacts but we're only interested in the
-			// one we asked for, which we assume is always the first one in the list
-			// (hopefully we're right).
-			File file = mcp.getArtifacts().get(0).getFile();
-			result = forCachedResource(scriptResource, file);
-		} else {
-			File probe = null;
-			try {
-				probe = Util.getCwd().resolve(scriptResource).normalize().toFile();
-			} catch (InvalidPathException e) {
-				// Ignore
-			}
-			if (probe != null && probe.canRead()) {
-				result = forNamedFile(scriptResource, probe);
-			}
-		}
-
-		return result;
-	}
-
-	private static ResourceRef fetchScriptFromUntrustedURL(String scriptURL) {
-		try {
-			java.net.URI uri = new java.net.URI(scriptURL);
-
-			if (!TrustedSources.instance().isURLTrusted(uri)) {
-				String[] options = new String[] {
-						null,
-						goodTrustURL(scriptURL),
-						"*." + uri.getAuthority(),
-						"*"
-				};
-				String exmsg = scriptURL
-						+ " is not from a trusted source and user did not confirm trust thus aborting.\n" +
-						"If you trust the url to be safe to run are here a few suggestions:\n" +
-						"Limited trust:\n     jbang trust add " + options[1] + "\n" +
-						"Trust all subdomains:\n    jbang trust add " + options[2] + "\n" +
-						"Trust all sources (WARNING! disables url protection):\n    jbang trust add " + options[3]
-						+ "\n" +
-						"\nFor more control edit ~/.jbang/trusted-sources.json" + "\n";
-
-				String question = scriptURL + " is not from a trusted source thus not running it automatically.\n\n" +
-						"If you trust the url to be safe to run you can do one of the following:\n" +
-						"0) Trust once: Add no trust, just run this time\n" +
-						"1) Trust " +
-						"limited url in future:\n    jbang trust add " + options[1] + "\n" +
-						"\n\nAny other response will result in exit.\n";
-
-				ConsoleInput con = new ConsoleInput(
-						1,
-						10,
-						TimeUnit.SECONDS);
-				Util.infoMsg(question);
-				Util.infoMsg("Type in your choice (0 or 1) and hit enter. Times out after 10 seconds.");
-				String input = con.readLine();
-
-				boolean abort = true;
-				try {
-					int result = Integer.parseInt(input);
-					TrustedSources ts = TrustedSources.instance();
-					if (result == 0) {
-						abort = false;
-					} else if (result == 1) {
-						ts.add(options[1], Settings.getTrustedSourcesFile().toFile());
-						abort = false;
-					}
-				} catch (NumberFormatException ef) {
-					Util.errorMsg("Could not parse answer as a number. Aborting");
-				}
-
-				if (abort)
-					throw new ExitException(10, exmsg);
-			}
-
-			scriptURL = swizzleURL(scriptURL);
-			Path path = Util.swizzleContent(scriptURL, Util.downloadAndCacheFile(scriptURL));
-
-			return forCachedResource(scriptURL, path.toFile());
-		} catch (IOException | URISyntaxException e) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
-		}
-	}
-
-	private static ResourceRef fetchFromURL(String scriptURL) {
-		try {
-			String url = swizzleURL(scriptURL);
-			Path path = Util.downloadAndCacheFile(url);
-			return forCachedResource(url, path.toFile());
-		} catch (IOException e) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
-		}
-	}
-
-	/**
-	 * Takes common patterns and return "parent" urls that are meaningfull to trust.
-	 * i.e. github.com/maxandersen/myproject/myfile.java will offer to trust the
-	 * github.com/maxandersen/myproject project.
-	 * 
-	 * @param url
-	 * @return
-	 */
-	static String goodTrustURL(String url) {
-		String originalUrl = url;
-
-		url = url.replaceFirst("^https://gist.github.com/(.*)?/(.*)$",
-				"https://gist.github.com/$1/");
-
-		url = url.replaceFirst("^https://github.com/(.*)/blob/(.*)$",
-				"https://github.com/$1/");
-
-		url = url.replaceFirst("^https://gitlab.com/(.*)/-/blob/(.*)$",
-				"https://gitlab.com/$1/");
-
-		url = url.replaceFirst("^https://bitbucket.org/(.*)/src/(.*)$",
-				"https://bitbucket.org/$1/");
-
-		url = url.replaceFirst("^https://twitter.com/(.*)/status/(.*)$",
-				"https://twitter.com/$1/");
-
-		url = url.replaceFirst("https://repo1.maven.org/maven2/(.*)/[0-9]+.*$",
-				"https://repo1.maven.org/maven2/$1/");
-
-		if (url.equals(originalUrl)) {
-			java.net.URI uri = null;
-			try {
-				uri = new java.net.URI(url);
-			} catch (URISyntaxException e) {
-				return url;
-			}
-			if (uri.getPath().isEmpty() || uri.getPath().equals("/")) {
-				return uri.toString();
-			} else {
-				return (uri.getPath().endsWith("/") ? uri.resolve("..") : uri.resolve(".")).toString();
-			}
-		}
-
-		return url;
-	}
-
-	private static ModularClassPath noDepResolve(String dep) {
-		throw new ExitException(BaseCommand.EXIT_INTERNAL_ERROR, "Dependency resolving not supported");
-	}
-
-	private static ResourceRef getClasspathResource(String cpResource) {
-		String ref = cpResource.substring(11);
-		Util.verboseMsg("Duplicating classpath resource " + ref);
-		ClassLoader cl = Thread.currentThread().getContextClassLoader();
-		if (cl == null) {
-			cl = ResourceRef.class.getClassLoader();
-		}
-		URL url = cl.getResource(ref);
-		if (url == null) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
-					"Resource not found on class path: " + ref);
-		}
-
-		try {
-			File f = new File(url.toURI());
-			if (f.canRead()) {
-				return forCachedResource(cpResource, f);
-			}
-		} catch (URISyntaxException | IllegalArgumentException e) {
-			// Ignore
-		}
-
-		// We couldn't read the file directly from the class path so let's make a copy
-		try (InputStream is = url.openStream()) {
-			Path to = Util.getUrlCache(cpResource);
-			Files.createDirectories(to.getParent());
-			Files.copy(is, to, StandardCopyOption.REPLACE_EXISTING);
-			return forCachedResource(cpResource, to.toFile());
-		} catch (IOException e) {
-			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR,
-					"Resource could not be copied from class path: " + ref, e);
-		}
 	}
 }

--- a/src/main/java/dev/jbang/source/ResourceResolver.java
+++ b/src/main/java/dev/jbang/source/ResourceResolver.java
@@ -1,0 +1,60 @@
+package dev.jbang.source;
+
+import java.util.function.Function;
+
+import dev.jbang.dependencies.ModularClassPath;
+import dev.jbang.source.resolvers.*;
+
+/**
+ * An interface used for analysing a resource string, resolving what exact file
+ * it refers to and returning a <code>ResourceRef</code> for it.
+ */
+public interface ResourceResolver {
+	/**
+	 * Given a resource string either returns a `ResourceRef` that identifies that
+	 * resource or <code>null</code> if the resolver wasn't able to handle the
+	 * resource string.
+	 *
+	 * The method should _only_ return <code>null</code> if it does not recognize
+	 * the resource string, thereby informing the caller it should probably try some
+	 * other resolver. In case the resolver _does_ recognize the resource string as
+	 * having a supported format but something goes wrong and no reference can be
+	 * created it's normal to throw an exception.
+	 *
+	 * @param resource The resource string to resolve
+	 * @return A <code>ResourceRef</code> or <code>null</code>
+	 */
+	ResourceRef resolve(String resource);
+
+	/**
+	 * Factory method that returns a resource resolver that knows how to deal with
+	 * script/source files. It should be passed a function for dealing with Maven
+	 * GAVs.
+	 *
+	 * @param depResolver A function which, given a GAV string, returns a
+	 *                    <code>ModularClassPath</code>
+	 * @return A <code>ResourceRef</code> or <code>null</code>
+	 */
+	static ResourceResolver forScripts(Function<String, ModularClassPath> depResolver) {
+		return new CombinedResourceResolver(
+				new RenamingScriptResourceResolver(),
+				new StdinScriptResourceResolver(),
+				new RemoteResourceResolver(RemoteResourceResolver::fetchScriptFromUntrustedURL),
+				new ClasspathResourceResolver(),
+				new GavResourceResolver(depResolver),
+				new FileResourceResolver());
+	}
+
+	/**
+	 * Factory method that returns a resource resolver that knows how to deal with
+	 * simple resource files (so it's _not_ meant for resolving sources/scripts).
+	 *
+	 * @return A <code>ResourceRef</code> or <code>null</code>
+	 */
+	static ResourceResolver forResources() {
+		return new CombinedResourceResolver(
+				new RemoteResourceResolver(RemoteResourceResolver::fetchFromURL),
+				new ClasspathResourceResolver(),
+				new FileResourceResolver());
+	}
+}

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -358,9 +358,10 @@ public class RunContext {
 	}
 
 	public Source forResource(String resource) {
-		ResourceRef resourceRef = ResourceRef.forScriptResource(resource, this::resolveDependency);
+		ResourceResolver resolver = ResourceResolver.forScripts(this::resolveDependency);
+		ResourceRef resourceRef = resolver.resolve(resource);
 
-		Alias alias = null;
+		Alias alias;
 		if (resourceRef == null) {
 			// Not found as such, so let's check the aliases
 			if (getCatalog() == null) {
@@ -370,7 +371,7 @@ public class RunContext {
 				alias = Alias.get(cat, resource);
 			}
 			if (alias != null) {
-				resourceRef = ResourceRef.forResource(alias.resolve(), this::resolveDependency);
+				resourceRef = resolver.resolve(alias.resolve());
 				if (getArguments() == null || getArguments().isEmpty()) {
 					setArguments(alias.arguments);
 				}

--- a/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
@@ -1,0 +1,70 @@
+package dev.jbang.source.resolvers;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.Util;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string which
+ * looks like a classpath URL, will look up the referenced resource and, if it's
+ * a file on the local file system return a direct reference to that file or if
+ * it's a JAR resource it will create a copy of it in the cache and return a
+ * reference to that.
+ */
+public class ClasspathResourceResolver implements ResourceResolver {
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		if (resource.startsWith("classpath:/")) {
+			result = getClasspathResource(resource);
+		}
+
+		return result;
+	}
+
+	private static ResourceRef getClasspathResource(String cpResource) {
+		String ref = cpResource.substring(11);
+		Util.verboseMsg("Duplicating classpath resource " + ref);
+		ClassLoader cl = Thread.currentThread().getContextClassLoader();
+		if (cl == null) {
+			cl = ResourceRef.class.getClassLoader();
+		}
+		URL url = cl.getResource(ref);
+		if (url == null) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Resource not found on class path: " + ref);
+		}
+
+		try {
+			File f = new File(url.toURI());
+			if (f.canRead()) {
+				return ResourceRef.forCachedResource(cpResource, f);
+			}
+		} catch (URISyntaxException | IllegalArgumentException e) {
+			// Ignore
+		}
+
+		// We couldn't read the file directly from the class path so let's make a copy
+		try (InputStream is = url.openStream()) {
+			Path to = Util.getUrlCache(cpResource);
+			Files.createDirectories(to.getParent());
+			Files.copy(is, to, StandardCopyOption.REPLACE_EXISTING);
+			return ResourceRef.forCachedResource(cpResource, to.toFile());
+		} catch (IOException e) {
+			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR,
+					"Resource could not be copied from class path: " + ref, e);
+		}
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
@@ -1,0 +1,31 @@
+package dev.jbang.source.resolvers;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string will
+ * delegate the resolving of that string to a list of resolvers one by one until
+ * one of them returns a result and that will then be the result of this
+ * resolver.
+ */
+public class CombinedResourceResolver implements ResourceResolver {
+	private final List<ResourceResolver> resolvers;
+
+	public CombinedResourceResolver(ResourceResolver... resolvers) {
+		this.resolvers = Arrays.asList(resolvers);
+	}
+
+	@Override
+	public ResourceRef resolve(String resource) {
+		return resolvers.stream()
+						.map(r -> r.resolve(resource))
+						.filter(Objects::nonNull)
+						.findFirst()
+						.orElse(null);
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
@@ -1,0 +1,33 @@
+package dev.jbang.source.resolvers;
+
+import java.io.File;
+import java.nio.file.InvalidPathException;
+
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.Util;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string which
+ * looks like a path to a file on the local file system, will return a reference
+ * to that file.
+ */
+public class FileResourceResolver implements ResourceResolver {
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		File probe = null;
+		try {
+			probe = Util.getCwd().resolve(resource).normalize().toFile();
+		} catch (InvalidPathException e) {
+			// Ignore
+		}
+
+		if (probe != null && probe.canRead()) {
+			result = ResourceRef.forNamedFile(resource, probe);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
@@ -1,0 +1,39 @@
+package dev.jbang.source.resolvers;
+
+import java.io.File;
+import java.util.function.Function;
+
+import dev.jbang.dependencies.DependencyUtil;
+import dev.jbang.dependencies.ModularClassPath;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string which
+ * looks like a Maven GAV, will try to resolve that dependency and return a
+ * reference to the downloaded artifact JAR.
+ */
+public class GavResourceResolver implements ResourceResolver {
+	private final Function<String, ModularClassPath> depResolver;
+
+	public GavResourceResolver(Function<String, ModularClassPath> depResolver) {
+		this.depResolver = depResolver;
+	}
+
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		if (DependencyUtil.looksLikeAGav(resource)) {
+			// todo honor offline
+			ModularClassPath mcp = depResolver.apply(resource);
+			// We possibly get a whole bunch of artifacts but we're only interested in the
+			// one we asked for, which we assume is always the first one in the list
+			// (hopefully we're right).
+			File file = mcp.getArtifacts().get(0).getFile();
+			result = ResourceRef.forCachedResource(resource, file);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
@@ -1,0 +1,117 @@
+package dev.jbang.source.resolvers;
+
+import static dev.jbang.util.Util.goodTrustURL;
+import static dev.jbang.util.Util.swizzleURL;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import dev.jbang.Settings;
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.net.TrustedSources;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.ConsoleInput;
+import dev.jbang.util.Util;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string which
+ * looks like a http, https or file URL, will try to download the referenced
+ * document to the cache and return a reference to that file.
+ */
+public class RemoteResourceResolver implements ResourceResolver {
+	private final Function<String, ResourceRef> urlFetcher;
+
+	public RemoteResourceResolver(Function<String, ResourceRef> urlFetcher) {
+		this.urlFetcher = urlFetcher;
+	}
+
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		if (resource.startsWith("http://") || resource.startsWith("https://") || resource.startsWith("file:/")) {
+			// support url's as script files
+			result = urlFetcher.apply(resource);
+		}
+
+		return result;
+	}
+
+	public static ResourceRef fetchScriptFromUntrustedURL(String scriptURL) {
+		try {
+			java.net.URI uri = new java.net.URI(scriptURL);
+
+			if (!TrustedSources.instance().isURLTrusted(uri)) {
+				String[] options = new String[] {
+						null,
+						goodTrustURL(scriptURL),
+						"*." + uri.getAuthority(),
+						"*"
+				};
+				String exmsg = scriptURL
+						+ " is not from a trusted source and user did not confirm trust thus aborting.\n" +
+						"If you trust the url to be safe to run are here a few suggestions:\n" +
+						"Limited trust:\n     jbang trust add " + options[1] + "\n" +
+						"Trust all subdomains:\n    jbang trust add " + options[2] + "\n" +
+						"Trust all sources (WARNING! disables url protection):\n    jbang trust add " + options[3]
+						+ "\n" +
+						"\nFor more control edit ~/.jbang/trusted-sources.json" + "\n";
+
+				String question = scriptURL + " is not from a trusted source thus not running it automatically.\n\n"
+						+
+						"If you trust the url to be safe to run you can do one of the following:\n" +
+						"0) Trust once: Add no trust, just run this time\n" +
+						"1) Trust " +
+						"limited url in future:\n    jbang trust add " + options[1] + "\n" +
+						"\n\nAny other response will result in exit.\n";
+
+				ConsoleInput con = new ConsoleInput(
+						1,
+						10,
+						TimeUnit.SECONDS);
+				Util.infoMsg(question);
+				Util.infoMsg("Type in your choice (0 or 1) and hit enter. Times out after 10 seconds.");
+				String input = con.readLine();
+
+				boolean abort = true;
+				try {
+					int result = Integer.parseInt(input);
+					TrustedSources ts = TrustedSources.instance();
+					if (result == 0) {
+						abort = false;
+					} else if (result == 1) {
+						ts.add(options[1], Settings.getTrustedSourcesFile().toFile());
+						abort = false;
+					}
+				} catch (NumberFormatException ef) {
+					Util.errorMsg("Could not parse answer as a number. Aborting");
+				}
+
+				if (abort)
+					throw new ExitException(10, exmsg);
+			}
+
+			scriptURL = swizzleURL(scriptURL);
+			Path path = Util.swizzleContent(scriptURL, Util.downloadAndCacheFile(scriptURL));
+
+			return ResourceRef.forCachedResource(scriptURL, path.toFile());
+		} catch (IOException | URISyntaxException e) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
+		}
+	}
+
+	public static ResourceRef fetchFromURL(String scriptURL) {
+		try {
+			String url = swizzleURL(scriptURL);
+			Path path = Util.downloadAndCacheFile(url);
+			return ResourceRef.forCachedResource(url, path.toFile());
+		} catch (IOException e) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
+		}
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
@@ -1,0 +1,72 @@
+package dev.jbang.source.resolvers;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.InvalidPathException;
+
+import dev.jbang.Cache;
+import dev.jbang.Settings;
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.Util;
+
+/**
+ * A <code>ResourceResolver</code> that, when given a resource string which
+ * looks like a path to a file on the local file system not ending in one of the
+ * known source extensions, will try to create a copy in the cache with a proper
+ * file name and return a reference to that file.
+ */
+public class RenamingScriptResourceResolver implements ResourceResolver {
+
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		// map script argument to script file
+		File probe = null;
+		try {
+			probe = Util.getCwd().resolve(resource).normalize().toFile();
+		} catch (InvalidPathException e) {
+			// Ignore
+		}
+
+		try {
+			if (probe != null && probe.canRead()) {
+				String ext = "." + Util.extension(probe.getName());
+				if (!ext.equals(".jar") && !Util.EXTENSIONS.contains(ext)) {
+					if (probe.isDirectory()) {
+						File defaultApp = new File(probe, "main.java");
+						if (defaultApp.exists()) {
+							Util.verboseMsg("Directory where main.java exists. Running main.java.");
+							probe = defaultApp;
+						} else {
+							throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Cannot run " + probe
+									+ " as it is a directory and no default application (i.e. `main.java`) found.");
+						}
+					}
+					String original = Util.readString(probe.toPath());
+					// TODO: move temp handling somewhere central
+					String urlHash = Util.getStableID(original);
+
+					if (original.startsWith("#!")) { // strip bash !# if exists
+						original = original.substring(original.indexOf("\n"));
+					}
+
+					File tempFile = Settings.getCacheDir(Cache.CacheClass.scripts)
+											.resolve(urlHash)
+											.resolve(Util.unkebabify(probe.getName()))
+											.toFile();
+					tempFile.getParentFile().mkdirs();
+					Util.writeString(tempFile.toPath().toAbsolutePath(), original);
+					result = ResourceRef.forCachedResource(resource, tempFile);
+				}
+			}
+		} catch (IOException e) {
+			throw new ExitException(BaseCommand.EXIT_UNEXPECTED_STATE, "Could not download " + resource, e);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/StdinScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/StdinScriptResourceResolver.java
@@ -1,0 +1,59 @@
+package dev.jbang.source.resolvers;
+
+import static dev.jbang.util.Util.getMainClass;
+import static dev.jbang.util.Util.hasMainMethod;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import dev.jbang.Cache;
+import dev.jbang.Settings;
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.Util;
+
+/**
+ * A <code>ResourceResolver</code> that, when given "-" as a resource string,
+ * will try to create a copy in the cache with a proper file name and return a
+ * reference to that file.
+ */
+public class StdinScriptResourceResolver implements ResourceResolver {
+	@Override
+	public ResourceRef resolve(String resource) {
+		ResourceRef result = null;
+
+		try {
+			// support stdin
+			if (ResourceRef.isStdin(resource)) {
+				String scriptText = new BufferedReader(
+						new InputStreamReader(System.in, StandardCharsets.UTF_8))
+																					.lines()
+																					.collect(Collectors.joining(
+																							System.lineSeparator()));
+
+				String urlHash = Util.getStableID(scriptText);
+				File cache = Settings.getCacheDir(Cache.CacheClass.stdins).resolve(urlHash).toFile();
+				cache.mkdirs();
+				String basename = urlHash;
+				String suffix = ".jsh";
+				if (hasMainMethod(scriptText)) {
+					suffix = ".java";
+					basename = getMainClass(scriptText).orElse(basename);
+				}
+				File scriptFile = new File(cache, basename + suffix);
+				Util.writeString(scriptFile.toPath(), scriptText);
+				result = ResourceRef.forCachedResource(resource, scriptFile);
+			}
+		} catch (IOException e) {
+			throw new ExitException(BaseCommand.EXIT_UNEXPECTED_STATE, "Could not cache script from stdin", e);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -72,7 +72,8 @@ public class Util {
 	public static final Pattern mainClassMethod = Pattern.compile(
 			"(?<=\\n|\\A)(?:public\\s)\\s*(class)\\s*([^\\n\\s]*)");
 
-	private static final List<String> EXTENSIONS = asList(".java", ".jsh", ".kt");
+	public static final List<String> EXTENSIONS = asList(".java", ".jsh", ".kt");
+
 	private static boolean verbose;
 	private static boolean quiet;
 	private static boolean offline;
@@ -787,6 +788,52 @@ public class Util {
 				// ignore
 			}
 
+		}
+
+		return url;
+	}
+
+	/**
+	 * Takes common patterns and return "parent" urls that are meaningfull to trust.
+	 * i.e. github.com/maxandersen/myproject/myfile.java will offer to trust the
+	 * github.com/maxandersen/myproject project.
+	 *
+	 * @param url
+	 * @return
+	 */
+	public static String goodTrustURL(String url) {
+		String originalUrl = url;
+
+		url = url.replaceFirst("^https://gist.github.com/(.*)?/(.*)$",
+				"https://gist.github.com/$1/");
+
+		url = url.replaceFirst("^https://github.com/(.*)/blob/(.*)$",
+				"https://github.com/$1/");
+
+		url = url.replaceFirst("^https://gitlab.com/(.*)/-/blob/(.*)$",
+				"https://gitlab.com/$1/");
+
+		url = url.replaceFirst("^https://bitbucket.org/(.*)/src/(.*)$",
+				"https://bitbucket.org/$1/");
+
+		url = url.replaceFirst("^https://twitter.com/(.*)/status/(.*)$",
+				"https://twitter.com/$1/");
+
+		url = url.replaceFirst("https://repo1.maven.org/maven2/(.*)/[0-9]+.*$",
+				"https://repo1.maven.org/maven2/$1/");
+
+		if (url.equals(originalUrl)) {
+			java.net.URI uri = null;
+			try {
+				uri = new java.net.URI(url);
+			} catch (URISyntaxException e) {
+				return url;
+			}
+			if (uri.getPath().isEmpty() || uri.getPath().equals("/")) {
+				return uri.toString();
+			} else {
+				return (uri.getPath().endsWith("/") ? uri.resolve("..") : uri.resolve(".")).toString();
+			}
 		}
 
 		return url;

--- a/src/test/java/dev/jbang/util/TestTrustedSources.java
+++ b/src/test/java/dev/jbang/util/TestTrustedSources.java
@@ -1,4 +1,4 @@
-package dev.jbang.source;
+package dev.jbang.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -16,20 +16,20 @@ public class TestTrustedSources extends BaseTest {
 	@Test
 	void testGoodUrlsToTrust() throws IOException {
 		assertEquals("https://github.com/maxandersen/myproject/",
-				ResourceRef.goodTrustURL("https://github.com/maxandersen/myproject/blob/master/file.java"));
+				Util.goodTrustURL("https://github.com/maxandersen/myproject/blob/master/file.java"));
 
 		assertEquals("https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/",
-				ResourceRef.goodTrustURL(
+				Util.goodTrustURL(
 						"https://repo1.maven.org/maven2/io/quarkus/quarkus-cli/2.0.0.Final/quarkus-cli-2.0.0.Final-runner.jar"));
 
 		assertEquals("https://github.com/",
-				ResourceRef.goodTrustURL("https://github.com/t.java"));
+				Util.goodTrustURL("https://github.com/t.java"));
 
 		assertEquals("https://github.com/",
-				ResourceRef.goodTrustURL("https://github.com/"));
+				Util.goodTrustURL("https://github.com/"));
 
 		assertEquals("https://acme.org",
-				ResourceRef.goodTrustURL("https://acme.org"));
+				Util.goodTrustURL("https://acme.org"));
 
 	}
 


### PR DESCRIPTION
This is a continuation of the work on #1111 

The `--deps` and `--repos` now also work when dealing with GAVs.

There's also a pretty decent refactor included that splits out the resolving of `ResourceRef`s out into a separate `ResourceResolver` that uses a plugin system where each type of resolving (remote, from classpath, from stdin, etc) is done by its own class. There's a bit more code now but it's much clearer who's responsible for what.