### PR TITLE
fix: Some regressions for Windows

### DIFF
--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -82,29 +82,36 @@ public class Jdk {
 		Path home = getJdkPath(version);
 		if (home != null) {
 			String homeStr = Util.pathToString(home);
+			String homeOsStr = Util.pathToOsString(home);
 			PrintStream out = System.out;
 			switch (Util.getShell()) {
 			case bash:
-				out.println("export PATH=\"" + homeStr + "/bin:$PATH\"");
-				out.println("export JAVA_HOME=\"" + homeStr + "\"");
-				out.println("# Run this command to configure your shell:");
+				// Not using `println()` here because it will output /n/r
+				// on Windows which causes problems
+				out.print("export PATH=\"" + homeStr + "/bin:$PATH\"\n");
+				out.print("export JAVA_HOME=\"" + homeOsStr + "\"\n");
+				out.print("# Run this command to configure your shell:\n");
 				out.print("# eval $(jbang jdk java-env");
 				if (version != null) {
 					out.print(" " + version);
 				}
-				out.println(")");
+				out.print(")\n");
 				break;
 			case cmd:
 				out.println("set PATH=" + homeStr + "\\bin;%PATH%");
-				out.println("set JAVA_HOME=" + homeStr);
+				out.println("set JAVA_HOME=" + homeOsStr);
 				out.println("rem Copy & paste the above commands in your CMD window or add");
 				out.println("rem them to your Environment Variables in the System Settings.");
 				break;
 			case powershell:
 				out.println("$env:PATH=\"" + homeStr + "\\bin:$env:PATH\"");
-				out.println("$env:JAVA_HOME=\"" + homeStr + "\"");
-				out.println("# Copy & paste the above commands in your Powershell window or add");
-				out.println("# them to your Environment Variables in the System Settings.");
+				out.println("$env:JAVA_HOME=\"" + homeOsStr + "\"");
+				out.println("# Run this command to configure your environment:");
+				out.print("# jbang jdk java-env");
+				if (version != null) {
+					out.print(" " + version);
+				}
+				out.println(" | iex");
 				break;
 			}
 		}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1150,10 +1150,10 @@ public class Util {
 	}
 
 	/**
-	 * Converts a Path to a String. This is normally a trivial operation, but in
-	 * certain circumstances, like for example when we need to write a bash shell
-	 * scripts when running inside a Cygwin bash on Windows, we need to do a bit
-	 * more.
+	 * Converts a Path to a String. This is normally a trivial operation, but this
+	 * method handles the special case when running in a Bash shell on Windows,
+	 * where paths have a special format that Java doesn't know about (eg.
+	 * C:\Directory\File.txt becomes /c/Directory/File.txt).
 	 *
 	 * @param path the Path to convert
 	 * @return a String representing the given Path
@@ -1177,6 +1177,24 @@ public class Util {
 				}
 			}
 			return str.toString();
+		} else {
+			return path.toString();
+		}
+	}
+
+	/**
+	 * Converts a Path to a String. This is normally a trivial operation, but this
+	 * method handles the special case when running in a Bash shell on Windows,
+	 * where the default output format would cause problems because the backslashes
+	 * would be interpreted as escape sequences. So we need to escape the
+	 * backslashes.
+	 *
+	 * @param path the Path to convert
+	 * @return a String representing the given Path
+	 */
+	public static String pathToOsString(Path path) {
+		if (isWindows() && getShell() == Shell.bash) {
+			return path.toString().replace("\\", "\\\\");
 		} else {
 			return path.toString();
 		}

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -117,6 +117,10 @@ else
   $JBDIR/bin/jbang "$@"
   exit $?
 fi
+if [ -f "$jarPath.new" ]; then
+  # a new jbang version was found, we replace the old one with it
+  mv "$jarPath.new" "$jarPath"
+fi
 
 # Find/get a JDK
 unset JAVA_EXEC


### PR DESCRIPTION
Running inside a Bash shell on Windows we got a couple of regressions:

- the bash script needs to be able to perform the Windows update procedure. (The issue is that when using Cygwin/Git Bash on Windows and trying to update Jbang will download the new version but the switch to the new version won't actually be performed.)
-  `jbang edit` using wrong paths on Windows (All paths that get printed out to the output need to be passed through `Util.pathToString()`)