### PR TITLE
feat: Allow for a //GAV line in source files

### DIFF
--- a/itests/quote.java
+++ b/itests/quote.java
@@ -1,10 +1,12 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+//DEPS info.picocli:picocli:4.5.0
+//DESCRIPTION For testing purposes
+//GAV dev.jbang.itests:quote
+
 import java.util.Map;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
-
-//DEPS info.picocli:picocli:4.5.0
 
 public class quote implements Runnable {
     @Option(names = "-fix", split = "\\|")

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -28,7 +28,9 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
 
+import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.source.JarSource;
 import dev.jbang.source.RunContext;
 import dev.jbang.source.ScriptSource;
@@ -498,14 +500,22 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 			// ignore
 			Util.warnMsg("Could not locate pom.xml template");
 		} else {
-			String group = ctx.getProperties().getOrDefault("group", "g.a.v");
+			String group = "group";
+			String artifact = Util.getBaseName(src.getResourceRef().getFile().getName());
+			String version = "999-SNAPSHOT";
+			if (src.getGav().isPresent()) {
+				MavenCoordinate coord = DependencyUtil.depIdToArtifact(
+						DependencyUtil.gavWithVersion(src.getGav().get()));
+				group = coord.getGroupId();
+				artifact = coord.getArtifactId();
+				version = coord.getVersion();
+			}
 			String pomfile = pomTemplate
 										.data("baseName", Util.getBaseName(src.getResourceRef().getFile().getName()))
 										.data("group", group)
-										.data("artifact", ctx	.getProperties()
-																.getOrDefault("artifact", Util.getBaseName(
-																		src.getResourceRef().getFile().getName())))
-										.data("version", ctx.getProperties().getOrDefault("version", "999-SNAPSHOT"))
+										.data("artifact", artifact)
+										.data("version", version)
+										.data("description", src.getDescription().orElse(""))
 										.data("dependencies", ctx.getClassPath().getArtifacts())
 										.render();
 

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -26,10 +26,6 @@ public abstract class BaseCommand implements Callable<Integer> {
 	@CommandLine.Spec
 	CommandLine.Model.CommandSpec spec;
 
-	@CommandLine.Option(names = { "-V",
-			"--version" }, versionHelp = true, description = "Display version info (use `jbang --verbose version` for more details)")
-	boolean versionRequested;
-
 	@CommandLine.Option(names = { "-h",
 			"--help" }, usageHelp = true, description = "Display help/info. Use 'jbang <command> -h' for detailed usage.")
 	boolean helpRequested;

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -71,6 +71,8 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 		List<String> runtimeOptions;
 		List<ResourceFile> files;
 		List<ScriptInfo> sources;
+		String description;
+		String gav;
 
 		public ScriptInfo(Source src, RunContext ctx) {
 			originalResource = src.getResourceRef().getOriginalResource();
@@ -104,6 +106,8 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 				if (!ss.getCompileOptions().isEmpty()) {
 					compileOptions = ss.getCompileOptions();
 				}
+				gav = ss.getGav().orElse(null);
+				description = ss.getDescription().orElse(null);
 
 				if (ctx != null) {
 					applicationJar = src.getJarFile().getAbsolutePath();

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -49,6 +49,10 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 				Export.class })
 public class JBang extends BaseCommand {
 
+	@CommandLine.Option(names = { "-V",
+			"--version" }, versionHelp = true, description = "Display version info (use `jbang --verbose version` for more details)")
+	boolean versionRequested;
+
 	@CommandLine.ArgGroup(exclusive = true)
 	VerboseQuietExclusive verboseQuietExclusive = new VerboseQuietExclusive();
 

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -266,6 +266,13 @@ public class DependencyUtil {
 						.orElse(s);
 	}
 
+	public static String gavWithVersion(String gav) {
+		if (gav.replaceAll("[^:]", "").length() == 1) {
+			gav += ":999-SNAPSHOT";
+		}
+		return gav;
+	}
+
 	public static MavenRepo toMavenRepo(String repoReference) {
 		String[] split = repoReference.split("=");
 		String reporef = null;

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -92,6 +92,14 @@ public interface Source {
 	}
 
 	/**
+	 * Returns the resource's Maven GAV. Returns `Optional.empty()` if no GAV is
+	 * available.
+	 */
+	default Optional<String> getGav() {
+		return Optional.empty();
+	}
+
+	/**
 	 * Returns the list of dependencies that are necessary to add to the classpath
 	 * for the application to execute properly.
 	 */

--- a/src/main/resources/pom.qute.xml
+++ b/src/main/resources/pom.qute.xml
@@ -6,6 +6,7 @@
 	<groupId>{group}</groupId>
 	<artifactId>{artifact}</artifactId>
 	<version>{version}</version>
+	<description>{description}</description>
 	<dependencies>
 		{#for item in dependencies}
 		<dependency>

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -91,7 +91,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		ExecutionResult result = checkedRun(null, "export", "mavenrepo", "-O", outFile.toString(),
-				"-Dgroup=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
+				"--group=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
 		assertThat(result.err, matchesPattern("(?s).*Exported to.*target.*"));
 		assertThat(
 				outFile.toPath().resolve("my/thing/right/helloworld/999-SNAPSHOT/helloworld-999-SNAPSHOT.jar").toFile(),
@@ -107,7 +107,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		// outFile.mkdirs();
 		ExecutionResult result = checkedRun(null, "export", "mavenrepo", "-O", outFile.toString(),
-				"-Dgroup=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
+				"--group=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
 		assertThat(result.exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
 
 	}
@@ -127,6 +127,7 @@ public class TestExport extends BaseTest {
 	void testExportMavenPublishWithClasspath() throws IOException {
 		File outFile = Settings.getLocalMavenRepo();
 		ExecutionResult result = checkedRun(null, "export", "mavenrepo", "--force",
+				"--group=g.a.v",
 				examplesTestFolder.resolve("classpath_log.java").toString());
 		assertThat(result.exitCode, equalTo(BaseCommand.EXIT_OK));
 		assertThat(outFile.toPath().resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -40,6 +40,8 @@ public class TestInfo extends BaseTest {
 		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
 				hasSize(equalTo(1)),
 				everyItem(containsString("picocli"))));
+		assertThat(info.description, equalTo("For testing purposes"));
+		assertThat(info.gav, equalTo("dev.jbang.itests:quote"));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -637,6 +637,7 @@ public class TestRun extends BaseTest {
 
 		String base = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
 				"//DEPS info.picocli:picocli:4.5.0\n" +
+				"//GAV dev.jbang.tests:aclass\n" +
 				"\n" +
 				"import static java.lang.System.*;\n" +
 				"\n" +
@@ -658,7 +659,7 @@ public class TestRun extends BaseTest {
 		assertThat(ctx.getMainClassOr(src), equalTo("aclass"));
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(src.getJarFile().toPath(), null)) {
-			Path fileToExtract = fileSystem.getPath("META-INF/maven/g/a/v/pom.xml");
+			Path fileToExtract = fileSystem.getPath("META-INF/maven/dev/jbang/tests/pom.xml");
 
 			ByteArrayOutputStream s = new ByteArrayOutputStream();
 

--- a/src/test/java/dev/jbang/source/TestScript.java
+++ b/src/test/java/dev/jbang/source/TestScript.java
@@ -33,6 +33,7 @@ public class TestScript extends BaseTest {
 			+ "//JAVA_OPTIONS --enable-preview \"-Dvalue='this is space'\"\n"
 			+ "//JAVAC_OPTIONS --enable-preview\n"
 			+ "//JAVAC_OPTIONS --verbose \n"
+			+ "//GAV org.example:classpath\n"
 			+ "class classpath_example {\n" + "\n"
 			+ "\tString usage = \"jbang  - Enhanced scripting support for Java on *nix-based systems.\\n\" + \"\\n\" + \"Usage:\\n\"\n"
 			+ "\t\t\t+ \"    jbang ( -t | --text ) <version>\\n\"\n"
@@ -316,6 +317,13 @@ public class TestScript extends BaseTest {
 		writeString(p, example);
 		RunContext ctx = RunContext.empty();
 		ctx.forResource(p.toAbsolutePath().toString());
+	}
+
+	@Test
+	void testGav() {
+		Source src = new ScriptSource(example, null);
+		String gav = src.getGav().get();
+		assertEquals("org.example:classpath", gav);
 	}
 
 }


### PR DESCRIPTION
This adds support for a `//GAV group:artifact[:version]` to be added
to source files. This information is then used when generating POM
files, like when doing a build or when running `export mavenrepo`.

Fixes #1132
