### PR TITLE
fix: Fixed regression not showing catalog names

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -33,3 +33,15 @@ Scenario: add catalog twice with different name
 Scenario: access remote catalog
   When command('jbang build hello@jbangdev')
   Then  match exit == 0
+
+Scenario: list remote catalog aliases
+  When command('jbang alias list jbangdev/jbang-catalog')
+  Then  match exit == 0
+  And match out contains "@jbangdev"
+  And match out !contains "@jbangdev/jbang-catalog"
+
+Scenario: list remote catalog templates
+  When command('jbang template list jbangdev/jbang-catalog')
+  Then  match exit == 0
+  And match out contains "@jbangdev"
+  And match out !contains "@jbangdev/jbang-catalog"

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -141,7 +141,7 @@ public class Catalog {
 	 * @return An Aliases object
 	 */
 	public static Catalog getByName(String catalogName) {
-		CatalogRef catalogRef = CatalogRef.get(catalogName);
+		CatalogRef catalogRef = CatalogRef.get(simplifyName(catalogName));
 		if (catalogRef != null) {
 			return getByRef(catalogRef.catalogRef);
 		} else {
@@ -401,6 +401,14 @@ public class Catalog {
 	static void check(boolean ok, String message) {
 		if (!ok) {
 			throw new JsonParseException(message);
+		}
+	}
+
+	public static String simplifyName(String catalog) {
+		if (catalog.endsWith("/" + JBANG_CATALOG_REPO)) {
+			return catalog.substring(0, catalog.length() - 14);
+		} else {
+			return catalog.replace("/" + JBANG_CATALOG_REPO + "~", "~");
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -169,7 +169,7 @@ class AliasList extends BaseAliasCommand {
 			int indent) {
 		dev.jbang.catalog.Alias alias = catalog.aliases.get(name);
 		String catName = catalogName != null ? catalogName : Catalog.findImplicitName(alias.catalog);
-		String fullName = catName != null ? name + "@" + catName : name;
+		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
 		String scriptRef = alias.scriptRef;
 		if (!catalog.aliases.containsKey(scriptRef)
 				&& !Catalog.isValidCatalogReference(scriptRef)) {

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -240,7 +240,8 @@ class TemplateList extends BaseTemplateCommand {
 	private static void printTemplate(PrintStream out, String catalogName, Catalog catalog,
 			String name, boolean showFiles, int indent) {
 		dev.jbang.catalog.Template template = catalog.templates.get(name);
-		String fullName = catalogName != null ? name + "@" + catalogName : name;
+		String catName = catalogName != null ? catalogName : Catalog.findImplicitName(template.catalog);
+		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
 		out.print(Util.repeat(" ", indent));
 		if (template.description != null) {
 			out.println(ConsoleOutput.yellow(fullName) + " = " + template.description);

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -47,7 +47,7 @@ public class ResourceRef implements Comparable<ResourceRef> {
 			if (Util.isURL(siblingResource)) {
 				sr = new URI(siblingResource).toString();
 			} else if (isURL()) {
-				sr = new URI(originalResource).resolve(siblingResource).toString();
+				sr = new URI(Util.swizzleURL(originalResource)).resolve(siblingResource).toString();
 			} else if (Util.isClassPathRef(siblingResource)) {
 				sr = siblingResource;
 			} else if (isClasspath()) {

--- a/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
@@ -109,7 +109,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 		try {
 			String url = swizzleURL(scriptURL);
 			Path path = Util.downloadAndCacheFile(url);
-			return ResourceRef.forCachedResource(url, path.toFile());
+			return ResourceRef.forCachedResource(scriptURL, path.toFile());
 		} catch (IOException e) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
 		}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -942,6 +942,7 @@ public class Util {
 	}
 
 	public static String readStringFromURL(String requestURL, Map<String, String> headers) throws IOException {
+		verboseMsg("Reading information from: " + requestURL);
 		URLConnection connection = new URL(requestURL).openConnection();
 		if (headers != null) {
 			headers.forEach(connection::setRequestProperty);


### PR DESCRIPTION
Running `alias list` or `template list` would not show full catalog
names when appropriate. This now works again. Also added a minor fix
where implicit catalogs won't get added twice if different names point
to the same catalog, eg: `jbangdev` and `jbangdev/jbang-catalog` are
the same catalog but would be added twice with those different names.
We now first try simplify the name before using it. So in the above
case `jbangdev/jbang-catalog` would become `jbangdev`.

Fixes #1089 