### PR TITLE
fix: Allow --deps to specify multiple dependencies (#815)

### DIFF
--- a/src/main/java/dev/jbang/cli/CommaSeparatedConverter.java
+++ b/src/main/java/dev/jbang/cli/CommaSeparatedConverter.java
@@ -1,0 +1,13 @@
+package dev.jbang.cli;
+
+import java.util.Arrays;
+import java.util.List;
+
+import picocli.CommandLine.ITypeConverter;
+
+public class CommaSeparatedConverter implements ITypeConverter<List<String>> {
+	@Override
+	public List<String> convert(final String input) throws Exception {
+		return Arrays.asList(input.split(","));
+	}
+}

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -10,7 +10,7 @@ public class DependencyInfoMixin {
 	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, String> properties = new HashMap<String, String>();
 	@CommandLine.Option(names = {
-			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to provide several ones).")
+			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to separate them).")
 	List<String> dependencies;
 	@CommandLine.Option(names = { "--repos" }, description = "Add additional repositories.")
 	List<String> repositories;

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -9,7 +9,8 @@ import picocli.CommandLine;
 public class DependencyInfoMixin {
 	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, String> properties = new HashMap<String, String>();
-	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	@CommandLine.Option(names = {
+			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to provide several ones).")
 	List<String> dependencies;
 	@CommandLine.Option(names = { "--repos" }, description = "Add additional repositories.")
 	List<String> repositories;

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -42,7 +42,7 @@ public class Init extends BaseScriptCommand {
 	Map<String, Object> properties = new HashMap<>();
 
 	@CommandLine.Option(names = {
-			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to provide several ones).")
+			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to separate them).")
 	List<String> dependencies;
 
 	@Override

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -41,7 +41,8 @@ public class Init extends BaseScriptCommand {
 	@CommandLine.Option(names = { "-D" }, description = "set a system property", mapFallbackValue = "true")
 	Map<String, Object> properties = new HashMap<>();
 
-	@CommandLine.Option(names = { "--deps" }, description = "Add additional dependencies.")
+	@CommandLine.Option(names = {
+			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to provide several ones).")
 	List<String> dependencies;
 
 	@Override

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -65,8 +66,10 @@ public class TestInfo extends BaseTest {
 	void testInfoToolsWithDeps() {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "--deps",
-				"info.picocli:picocli:4.5.0", src);
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools",
+				"--deps", "info.picocli:picocli:4.5.0,commons-io:commons-io:2.8.0",
+				"--deps", "org.apache.commons:commons-lang3:3.12.0",
+				src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo();
 		assertThat(info.originalResource, equalTo(src));
@@ -77,8 +80,10 @@ public class TestInfo extends BaseTest {
 		assertThat(info.javaVersion, is(nullValue()));
 		assertThat(info.mainClass, is(nullValue()));
 		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString("picocli"))));
+				hasSize(equalTo(3)),
+				hasItem(containsString("picocli")),
+				hasItem(containsString("commons-io")),
+				hasItem(containsString("commons-lang3"))));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -91,7 +91,24 @@ public class TestInit extends BaseTest {
 		assertThat(new File(s).exists(), is(true));
 		assertThat(Util.readString(x), Matchers.containsString("//DEPS a.b.c:mydep:1.0"));
 		assertThat(Util.readString(x), Matchers.containsString("//DEPS q.z:rrr:2.0"));
+	}
 
+	@Test
+	void testMultiDepsInitUsingCommas(@TempDir Path outputDir) throws IOException {
+		Path x = outputDir.resolve("sqlline.java");
+		String s = x.toString();
+		int result = JBang	.getCommandLine()
+							.execute(
+									"init",
+									"--deps", "org.hsqldb:hsqldb:2.5.0,net.hydromatic:foodmart-data-hsqldb:0.4",
+									"--deps", "org.another.company:dep:0.1",
+									s);
+		assertThat(result, is(0));
+		assertThat(new File(s).exists(), is(true));
+		final String fileContent = Util.readString(x);
+		assertThat(fileContent, Matchers.containsString("//DEPS org.hsqldb:hsqldb:2.5.0"));
+		assertThat(fileContent, Matchers.containsString("//DEPS net.hydromatic:foodmart-data-hsqldb:0.4"));
+		assertThat(fileContent, Matchers.containsString("//DEPS org.another.company:dep:0.1"));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1550,6 +1550,27 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testJavaFXViaCommandLineDepsUsingCommas() throws IOException {
+		JBang jbang = new JBang();
+
+		Path fileref = examplesTestFolder.resolve("SankeyPlotTest.java").toAbsolutePath();
+
+		// todo fix so --deps can use system properties
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
+				"--deps",
+				"org.openjfx:javafx-graphics:17:mac,org.openjfx:javafx-controls:17:mac,eu.hansolo.fx:charts:RELEASE",
+				fileref.toString());
+
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		RunContext ctx = run.getRunContext();
+		ctx.setMainClass("fakemain");
+		String line = run.generateCommandLine(ctx.forResource(fileref.toString()), ctx);
+
+		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
+	}
+
+	@Test
 	void testJavaFXMagicPropertyViaCommandline() throws IOException {
 
 		JBang jbang = new JBang();


### PR DESCRIPTION
Allow several dependencies to be provided with `--deps` using comma separator. For example:

`--deps info.picocli:picocli:4.5.0,commons-io:commons-io:2.8.0`