### PR TITLE
fix: rename ".kts" ot ".kt"

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -76,7 +76,7 @@ public class Util {
 	public static final List<String> EXTENSIONS = asList(
 			".java",
 			".jsh",
-			".kts",
+			".kt",
 			".groovy",
 			".md");
 


### PR DESCRIPTION
This bug  will stop Kotlin source to compile, and it was introduce by me to test kts file during Groovy PR.  Sorry about this fault. 