### PR TITLE
fix: stop tools info .jsh from failing

### DIFF
--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -110,7 +110,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 				description = ss.getDescription().orElse(null);
 
 				if (ctx != null) {
-					applicationJar = src.getJarFile().getAbsolutePath();
+					applicationJar = src.getJarFile() == null ? null : src.getJarFile().getAbsolutePath();
 					mainClass = ctx.getMainClassOr(src);
 					requestedJavaVersion = src.getJavaVersion();
 					availableJdkPath = Objects.toString(JdkManager.getCurrentJdk(requestedJavaVersion), null);

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -126,4 +126,21 @@ public class TestInfo extends BaseTest {
 				hasSize(equalTo(1)),
 				everyItem(containsString("picocli"))));
 	}
+
+	@Test
+	void testInfoJShell() {
+		String src = examplesTestFolder.resolve("basic.jsh").toString();
+		JBang jbang = new JBang();
+		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo(src));
+		assertThat(info.applicationJar, equalTo(null));
+		assertThat(info.backingResource, equalTo(src));
+		assertThat(info.javaVersion, is(nullValue()));
+		assertThat(info.mainClass, is(nullValue()));
+		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
+				hasSize(equalTo(1)),
+				everyItem(containsString("commons-lang3"))));
+	}
 }


### PR DESCRIPTION
Fixes #1171



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->