### PR TITLE
fix: Renaming libs to lib when calling export portable

### DIFF
--- a/docs/modules/ROOT/pages/exporting.adoc
+++ b/docs/modules/ROOT/pages/exporting.adoc
@@ -16,8 +16,8 @@ If you want the generated jar or native binary you can use `jbang export local <
 for you to use directly.
 
 Note, the local generated jar will have classpath references that are machine dependent. If you want a portable
-jar use `jbang export portable <script>` and the dependent jars will be put in `libs` directory and
-generated jar will have relative references to the jars in the `libs` folder.
+jar use `jbang export portable <script>` and the dependent jars will be put in `lib` directory and
+generated jar will have relative references to the jars in the `lib` folder.
 
 == Exporting to Maven Repository
 

--- a/itests/export.feature
+++ b/itests/export.feature
@@ -7,7 +7,7 @@ Scenario: basic export no classpath
   Then match err contains "helloworld.jar"
 
   Scenario: basic export slim no classpath
-    When command('rm -rf helloworld.jar libs')
+    When command('rm -rf helloworld.jar lib')
     When command('jbang export portable helloworld.java')
     Then match err contains "Exported to"
     Then match err contains "helloworld.jar"

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -102,6 +102,7 @@ class ExportLocal extends BaseCommand implements Exporter {
 @Command(name = "portable", description = "Exports jar together with dependencies in way that makes it portable")
 class ExportPortable extends BaseCommand implements Exporter {
 
+	public static final String LIB = "lib";
 	@CommandLine.Mixin
 	ExportMixin exportMixin;
 
@@ -131,7 +132,7 @@ class ExportPortable extends BaseCommand implements Exporter {
 			try (JarFile jf = new JarFile(outputPath.toFile())) {
 				String cp = jf.getManifest().getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
 				String[] jars = cp == null ? new String[0] : cp.split(" ");
-				File libsdir = new File(outputPath.toFile().getParentFile(), "libs");
+				File libsdir = new File(outputPath.toFile().getParentFile(), LIB);
 				if (jars.length > 0) {
 					if (!libsdir.exists()) {
 						libsdir.mkdirs();
@@ -140,7 +141,7 @@ class ExportPortable extends BaseCommand implements Exporter {
 				StringBuilder newPath = new StringBuilder();
 				for (String jar : jars) {
 					Path file = downloadFile(new File(jar).toURI().toString(), libsdir);
-					newPath.append(" libs/" + file.toFile().getName());
+					newPath.append(" " + LIB + "/" + file.toFile().getName());
 				}
 
 				Path tempDirectory = Files.createTempDirectory("jbang-export");
@@ -162,6 +163,10 @@ class ExportPortable extends BaseCommand implements Exporter {
 			optionList.add("ufm");
 			optionList.add(outputPath.toString());
 			optionList.add(tempManifest.toString());
+            if (exportMixin.packageLibFolder) {
+				Util.infoMsg("Packaging jar file with " + LIB + " folder");
+				optionList.add(LIB + "/");
+            }
 			// System.out.println("Executing " + optionList);
 			Util.infoMsg("Updating jar manifest");
 			// no inheritIO as jar complains unnecessarily about dupilcate manifest entries.

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -103,6 +103,7 @@ class ExportLocal extends BaseCommand implements Exporter {
 class ExportPortable extends BaseCommand implements Exporter {
 
 	public static final String LIB = "lib";
+
 	@CommandLine.Mixin
 	ExportMixin exportMixin;
 
@@ -132,15 +133,15 @@ class ExportPortable extends BaseCommand implements Exporter {
 			try (JarFile jf = new JarFile(outputPath.toFile())) {
 				String cp = jf.getManifest().getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
 				String[] jars = cp == null ? new String[0] : cp.split(" ");
-				File libsdir = new File(outputPath.toFile().getParentFile(), LIB);
+				File libDir = new File(outputPath.toFile().getParentFile(), LIB);
 				if (jars.length > 0) {
-					if (!libsdir.exists()) {
-						libsdir.mkdirs();
+					if (!libDir.exists()) {
+						libDir.mkdirs();
 					}
 				}
 				StringBuilder newPath = new StringBuilder();
 				for (String jar : jars) {
-					Path file = downloadFile(new File(jar).toURI().toString(), libsdir);
+					Path file = downloadFile(new File(jar).toURI().toString(), libDir);
 					newPath.append(" " + LIB + "/" + file.toFile().getName());
 				}
 
@@ -163,10 +164,6 @@ class ExportPortable extends BaseCommand implements Exporter {
 			optionList.add("ufm");
 			optionList.add(outputPath.toString());
 			optionList.add(tempManifest.toString());
-            if (exportMixin.packageLibFolder) {
-				Util.infoMsg("Packaging jar file with " + LIB + " folder");
-				optionList.add(LIB + "/");
-            }
 			// System.out.println("Executing " + optionList);
 			Util.infoMsg("Updating jar manifest");
 			// no inheritIO as jar complains unnecessarily about dupilcate manifest entries.

--- a/src/main/java/dev/jbang/cli/ExportMixin.java
+++ b/src/main/java/dev/jbang/cli/ExportMixin.java
@@ -30,6 +30,10 @@ public class ExportMixin {
 	}, description = "Force export, i.e. overwrite exported file if already exists")
 	boolean force;
 
+	@CommandLine.Option(names = { "--package-lib",
+	}, description = "Package the lib folder into the final jar")
+	boolean packageLibFolder;
+
 	@CommandLine.Parameters(paramLabel = "scriptOrFile", index = "0", description = "A file or URL to a Java code file", arity = "1")
 	String scriptOrFile;
 

--- a/src/main/java/dev/jbang/cli/ExportMixin.java
+++ b/src/main/java/dev/jbang/cli/ExportMixin.java
@@ -30,10 +30,6 @@ public class ExportMixin {
 	}, description = "Force export, i.e. overwrite exported file if already exists")
 	boolean force;
 
-	@CommandLine.Option(names = { "--package-lib",
-	}, description = "Package the lib folder into the final jar")
-	boolean packageLibFolder;
-
 	@CommandLine.Parameters(paramLabel = "scriptOrFile", index = "0", description = "A file or URL to a Java code file", arity = "1")
 	String scriptOrFile;
 

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -41,7 +41,7 @@ public class TestExport extends BaseTest {
 		String outFile = cwdDir.resolve("helloworld.jar").toString();
 		ExecutionResult result = checkedRun(null, "export", "portable", "-O", outFile, src);
 		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
-		assertThat(new File("libs"), not(anExistingFileOrDirectory()));
+		assertThat(new File(ExportPortable.LIB), not(anExistingFileOrDirectory()));
 
 	}
 
@@ -51,8 +51,8 @@ public class TestExport extends BaseTest {
 		String outFile = cwdDir.resolve("classpath_log.jar").toString();
 		ExecutionResult result = checkedRun(null, "export", "portable", "-O", outFile, src);
 		assertThat(result.err, matchesPattern("(?s).*Exported to.*classpath_log.jar.*"));
-		assertThat(cwdDir.resolve("libs").toFile(), anExistingDirectory());
-		assertThat(cwdDir.resolve("libs").toFile().listFiles().length, Matchers.equalTo(1));
+		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile(), anExistingDirectory());
+		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile().listFiles().length, Matchers.equalTo(1));
 
 		File jar = new File(outFile);
 
@@ -72,7 +72,7 @@ public class TestExport extends BaseTest {
 		String outFile = cwdDir.resolve("classpath_log.jar").toString();
 		ExecutionResult result = checkedRun(null, "export", "local", "-O", outFile, src);
 		assertThat(result.err, matchesPattern("(?s).*Exported to.*classpath_log.jar.*"));
-		assertThat(new File("libs"), not(anExistingDirectory()));
+		assertThat(new File(ExportPortable.LIB), not(anExistingDirectory()));
 
 		File jar = new File(outFile);
 


### PR DESCRIPTION
- Option to put the lib folder into the final jar

