### PR TITLE
Use `tagName` instead of `projectVersion`

### DIFF
--- a/src/jreleaser/distributions/jbang/docker/README.md.tpl
+++ b/src/jreleaser/distributions/jbang/docker/README.md.tpl
@@ -63,7 +63,7 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-jbang-
     - name: jbang
-      uses: jbangdev/jbang-action@{{projectVersion}}
+      uses: jbangdev/jbang-action@{{tagName}}
       with:
         script: createissue.java
         scriptargs: "my world"


### PR DESCRIPTION
GH-Action requires the `v`. Fixes the readme for the action repository.