### PR TITLE
docs: Formatting fixes

### DIFF
--- a/docs/modules/ROOT/pages/intro.adoc
+++ b/docs/modules/ROOT/pages/intro.adoc
@@ -52,8 +52,8 @@ toc::[]
 
 * `.java` Scripting for Java 8 and upwards
 * `.jsh` via JShell from Java 9 and upwards
-* .kt` via kotlinc (EXPERIMENTAL)
-* .groovy` via groovyc (EXPERIMENTAL)
+* `.kt` via kotlinc (EXPERIMENTAL)
+* `.groovy` via groovyc (EXPERIMENTAL)
 * Extract codeblocks from Markdown files (`.md`) (EXPERIMENTAL)
 * Works on icon:windows[] Windows, icon:apple[] OSX and icon:linux[] Linux and AIX
 * Install using curl, power shell, SDKMan (icon:apple[]/icon:linux[]), Homebrew (icon:apple[]), Chocolatey (icon:windows[]) or Scoop (icon:windows[])


### PR DESCRIPTION
Add missing backticks for `.kt` and `.groovy`