### PR TITLE
fix: fixed check for using managed jbang

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1227,7 +1227,11 @@ public class Util {
 	 * install` or not
 	 */
 	public static boolean runningManagedJBang() {
-		return getJarLocation().startsWith(Settings.getConfigBinDir());
+		try {
+			return getJarLocation().toRealPath().startsWith(Settings.getConfigBinDir().toRealPath());
+		} catch (IOException e) {
+			return getJarLocation().startsWith(Settings.getConfigBinDir());
+		}
 	}
 
 	/**


### PR DESCRIPTION
We now compare "real paths" to determine if Jbang is managed or not

Fixes #1193
