### PR TITLE
fix: `//SOURCES` now work in .jsh files too

### DIFF
--- a/docs/modules/ROOT/pages/organizing.adoc
+++ b/docs/modules/ROOT/pages/organizing.adoc
@@ -50,9 +50,10 @@ public class Person {
 There are some cases where the above does not work; i.e. if two packages refer to each other - i.e. `model.Person` referring to `util.Generator`
 will fail. Also `jbang edit` does not know about multiple sources as it runs and must run before compilation occurs.
 
-Thus version 0.46 there is now support for having that all work with multiple source files. The main script file defines all the
-dependencies and you add more source files into the application using `//SOURCES <filename>`.
-If included source has `//SOURCES` that will also get included recursively.
+Since version 0.46 there is now support for having that all work with multiple source files. The main script file defines all the
+dependencies and you add more source files into the application using `//SOURCES <filename>`. If included source has `//SOURCES`
+that will also get included recursively. In the case of `.jsh` scripts, the included sources will be added in the order they are
+found, depth-first.
 
 The listed file name(s) gets added to source list when compiling.
 

--- a/itests/funcs.jsh
+++ b/itests/funcs.jsh
@@ -1,0 +1,4 @@
+
+void print(String msg) {
+    System.out.println(msg);
+}

--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -32,3 +32,8 @@ Scenario: force jsh
   When command('jbang --jsh hellojsh hello')
   Then match err == ""
   Then match out == "hello\n"
+
+Scenario: jsh sources
+  When command('jbang main.jsh')
+  Then match err == ""
+  Then match out == "hello\n"

--- a/itests/main.jsh
+++ b/itests/main.jsh
@@ -1,0 +1,3 @@
+//SOURCES funcs.jsh
+
+print("hello");

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -194,6 +194,8 @@ public class Run extends BaseBuildCommand {
 					}
 				}
 
+				optionalArgs.add("--execution=local");
+
 				if (!Util.isBlankString(classpath)) {
 					optionalArgs.add("--class-path=" + classpath);
 				}

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -16,6 +16,7 @@ import org.apache.commons.text.StringEscapeUtils;
 
 import dev.jbang.Settings;
 import dev.jbang.source.RunContext;
+import dev.jbang.source.ScriptSource;
 import dev.jbang.source.Source;
 import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
@@ -181,9 +182,8 @@ public class Run extends BaseBuildCommand {
 			List<String> optionalArgs = new ArrayList<>();
 
 			String requestedJavaVersion = ctx.getJavaVersion() != null ? ctx.getJavaVersion() : src.getJavaVersion();
-			String javacmd = JavaUtil.resolveInJavaHome("java", requestedJavaVersion);
+			String javacmd;
 			if (ctx.isForceJsh() || src.isJShell() || interactive) {
-
 				javacmd = JavaUtil.resolveInJavaHome("jshell", requestedJavaVersion);
 
 				if (src.getJarFile() != null && src.getJarFile().exists()) {
@@ -229,6 +229,8 @@ public class Run extends BaseBuildCommand {
 				}
 
 			} else {
+				javacmd = JavaUtil.resolveInJavaHome("java", requestedJavaVersion);
+
 				addPropertyFlags(ctx.getProperties(), "-D", optionalArgs);
 
 				// optionalArgs.add("--source 11");
@@ -312,6 +314,11 @@ public class Run extends BaseBuildCommand {
 				fullArgs.add(mainClass);
 			} else {
 				if (ctx.isForceJsh() || src.isJShell()) {
+					if (src instanceof ScriptSource) {
+						for (Source s : ((ScriptSource) src).getAllSources()) {
+							fullArgs.add(s.getResourceRef().getFile().toString());
+						}
+					}
 					fullArgs.add(src.getResourceRef().getFile().toString());
 				} else if (!interactive /* && src.isJar() */) {
 					throw new ExitException(EXIT_INVALID_INPUT,

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -444,6 +444,25 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testWithSourcesShell() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		String arg = examplesTestFolder.resolve("main.jsh").toAbsolutePath().toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		RunContext ctx = run.getRunContext();
+		ScriptSource src = (ScriptSource) ctx.forResource(arg);
+
+		String result = run.generateCommandLine(src, ctx);
+
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, containsString("funcs.jsh"));
+		assertThat(result, containsString("main.jsh"));
+		assertThat(result, containsString("--startup=DEFAULT"));
+		assertThat(result, containsString("jbang_exit_"));
+	}
+
+	@Test
 	void testDebug() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -161,7 +161,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.generateCommandLine(src, ctx);
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --execution=local --startup.*$"));
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("helloworld.jsh"));
 		assertThat(result, not(containsString("--source 11")));
@@ -227,7 +227,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.generateCommandLine(src, ctx);
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --execution=local --startup.*$"));
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("empty.jsh"));
 		assertThat(result, not(containsString("--source 11")));
@@ -249,7 +249,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.generateCommandLine(src, ctx);
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --execution=local --startup.*$"));
 		assertThat(result, not(containsString("  ")));
 		assertThat(result, containsString("hellojsh"));
 		assertThat(result, not(containsString("--source 11")));
@@ -455,7 +455,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.generateCommandLine(src, ctx);
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? --startup.*$"));
+		assertThat(result, matchesPattern("^.*jshell(.exe)? --execution=local --startup.*$"));
 		assertThat(result, containsString("funcs.jsh"));
 		assertThat(result, containsString("main.jsh"));
 		assertThat(result, containsString("--startup=DEFAULT"));


### PR DESCRIPTION
Fixes #1220

