### PR TITLE
fix: fixes erroneous config property

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -42,7 +42,7 @@ classpath:/jbang.properties
    init.template = hello
    run.debug = 4004
    run.jfr = filename={baseName}.jfr
-   wrapper.dir = .
+   wrapper.install.dir = .
 ```
 
 

--- a/itests/wrapper.feature
+++ b/itests/wrapper.feature
@@ -29,3 +29,8 @@ When command('jbang wrapper install -d ' + scratch)
   * match exit == 0
   * command('jbang wrapper install -f -d ' + scratch)
   * match exit == 0
+
+Scenario: test plain wrapper install
+When command('jbang wrapper install')
+  * match exit == 0
+

--- a/src/main/resources/jbang.properties
+++ b/src/main/resources/jbang.properties
@@ -1,4 +1,4 @@
 init.template=hello
 run.debug=4004
 run.jfr=filename={baseName}.jfr
-wrapper.dir=.
+wrapper.install.dir=.

--- a/src/test/java/dev/jbang/cli/TestConfig.java
+++ b/src/test/java/dev/jbang/cli/TestConfig.java
@@ -47,7 +47,7 @@ public class TestConfig extends BaseTest {
 						"run.jfr = filename={baseName}.jfr\n" +
 						"three = baz\n" +
 						"two = bar\n" +
-						"wrapper.dir = .\n"));
+						"wrapper.install.dir = .\n"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #1233

Simple fix. It was only because the wrong config property name was used in the default config file.