### PR TITLE
feat: Added `--code` option for running literal scripts

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -230,6 +230,12 @@ jbang init -t hello.kt hello.kt
 Hello World
 ----
 
+== Running script passed as argument
+
+jbang can run scripts that are passed directly on the command line using the `--code` option:
+
+`jbang --code System.out.println("Hello World!")`
+
 == Running script from standard input
 
 jbang can run scripts directly from standard input using `-` or `/dev/stdin` as input.

--- a/itests/bar/Bar.java
+++ b/itests/bar/Bar.java
@@ -1,0 +1,6 @@
+import static java.lang.System.*;
+public class Bar {
+    public static void main(String... args) {
+        out.println("Hello World");
+    }
+}

--- a/itests/foo.java
+++ b/itests/foo.java
@@ -1,0 +1,7 @@
+import static java.lang.System.*;
+
+public class foo {
+    public static void main(String... args) {
+        out.println(Bar.class.getName());
+    }
+}

--- a/itests/jsh.feature
+++ b/itests/jsh.feature
@@ -43,3 +43,7 @@ Scenario: jsh with deps 1
   Then match err !contains ".NoClassDef"
   Then match out contains "Fake output:"
 
+Scenario: as code option
+  * command('jbang --code "System.out.println(\\\"Hello\\\")" jbangtest')
+  * match out == "Hello\n"
+  

--- a/itests/run-nix.feature
+++ b/itests/run-nix.feature
@@ -1,0 +1,14 @@
+Feature: run on non-windows
+
+Background:
+  * if (windows) karate.abort()
+
+Scenario: as code option 2
+  * command('jbang --code "$(cat helloworld.java)" jbangtest')
+  * match err == "[jbang] Building jar...\n"
+  * match out == "Hello jbangtest\n"
+
+Scenario: as code option 3
+  * command('jbang "--code=$(cat helloworld.java)" jbangtest')
+  * match err == "[jbang] Building jar...\n"
+  * match out == "Hello jbangtest\n"

--- a/itests/run.feature
+++ b/itests/run.feature
@@ -28,6 +28,10 @@ Scenario: java run multiple matching sources
   Then match out contains "NestedOne"
   Then match out contains "NestedTwo"
 
+Scenario: java run multiple sources via cli
+  When command('jbang -s bar/Bar.java foo.java')
+  Then match out contains "Bar"
+
 Scenario: java run multiple files
   When command('jbang res/resource.java')
   Then match out contains "hello properties"

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -31,7 +31,8 @@ public class Main {
 		}
 		// Check if we have a parameter and it's not the same as any of the subcommand
 		// names
-		if (!remainingArgs.isEmpty() && !spec.subcommands().containsKey(remainingArgs.get(0))) {
+		if (!remainingArgs.isEmpty() && !spec.subcommands().containsKey(remainingArgs.get(0))
+				|| hasRunOpts(leadingOpts)) {
 			List<String> result = new ArrayList<>();
 			result.add("run");
 			result.addAll(leadingOpts);
@@ -39,5 +40,14 @@ public class Main {
 			args = result.toArray(args);
 		}
 		return args;
+	}
+
+	private static boolean hasRunOpts(List<String> opts) {
+		boolean res = opts.contains("-i") || opts.contains("--interactive")
+				|| opts.contains("-c") || opts.contains("--code");
+		res = res || opts	.stream()
+							.anyMatch(o -> o.startsWith("-i=") || o.startsWith("--interactive=")
+									|| o.startsWith("-c=") || o.startsWith("--code="));
+		return res;
 	}
 }

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -20,6 +20,7 @@ public class Alias extends CatalogItem {
 	public final List<String> arguments;
 	@SerializedName(value = "java-options")
 	public final List<String> javaOptions;
+	public final List<String> sources;
 	public final List<String> dependencies;
 	public final List<String> repositories;
 	public final List<String> classpaths;
@@ -30,13 +31,14 @@ public class Alias extends CatalogItem {
 	public final String mainClass;
 
 	private Alias() {
-		this(null, null, null, null, null, null, null, null, null, null, null);
+		this(null, null, null, null, null, null, null, null, null, null, null, null);
 	}
 
 	public Alias(String scriptRef,
 			String description,
 			List<String> arguments,
 			List<String> javaOptions,
+			List<String> sources,
 			List<String> dependencies,
 			List<String> repositories,
 			List<String> classpaths,
@@ -49,6 +51,7 @@ public class Alias extends CatalogItem {
 		this.description = description;
 		this.arguments = arguments;
 		this.javaOptions = javaOptions;
+		this.sources = sources;
 		this.dependencies = dependencies;
 		this.repositories = repositories;
 		this.classpaths = classpaths;
@@ -118,6 +121,8 @@ public class Alias extends CatalogItem {
 			List<String> args = a1.arguments != null && !a1.arguments.isEmpty() ? a1.arguments : a2.arguments;
 			List<String> opts = a1.javaOptions != null && !a1.javaOptions.isEmpty() ? a1.javaOptions
 					: a2.javaOptions;
+			List<String> srcs = a1.sources != null && !a1.sources.isEmpty() ? a1.sources
+					: a2.sources;
 			List<String> deps = a1.dependencies != null && !a1.dependencies.isEmpty() ? a1.dependencies
 					: a2.dependencies;
 			List<String> repos = a1.repositories != null && !a1.repositories.isEmpty() ? a1.repositories
@@ -129,7 +134,7 @@ public class Alias extends CatalogItem {
 			String javaVersion = a1.javaVersion != null ? a1.javaVersion : a2.javaVersion;
 			String mainClass = a1.mainClass != null ? a1.mainClass : a2.mainClass;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
-			return new Alias(a2.scriptRef, desc, args, opts, deps, repos, cpaths, props, javaVersion, mainClass,
+			return new Alias(a2.scriptRef, desc, args, opts, srcs, deps, repos, cpaths, props, javaVersion, mainClass,
 					catalog);
 		} else {
 			return a1;

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -56,8 +56,8 @@ public class Catalog {
 		catalogs.forEach((key, c) -> this.catalogs.put(key,
 				new CatalogRef(c.catalogRef, c.description, this)));
 		aliases.forEach((key, a) -> this.aliases.put(key,
-				new Alias(a.scriptRef, a.description, a.arguments, a.javaOptions, a.dependencies, a.repositories,
-						a.classpaths, a.properties, a.javaVersion, a.mainClass, this)));
+				new Alias(a.scriptRef, a.description, a.arguments, a.javaOptions, a.sources, a.dependencies,
+						a.repositories, a.classpaths, a.properties, a.javaVersion, a.mainClass, this)));
 		templates.forEach((key, t) -> this.templates.put(key,
 				new Template(t.fileRefs, t.description, t.properties, this)));
 	}

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -35,6 +35,7 @@ public class CatalogUtil {
 			String scriptRef,
 			String description,
 			List<String> arguments,
+			List<String> sources,
 			List<String> dependencies,
 			List<String> repositories,
 			List<String> classPaths,
@@ -43,8 +44,8 @@ public class CatalogUtil {
 			String javaVersion,
 			String mainClass) {
 		Path catalogFile = Catalog.getCatalogFile(null);
-		addAlias(catalogFile, name, scriptRef, description, arguments, javaRuntimeOptions, dependencies, repositories,
-				classPaths, properties, javaVersion, mainClass);
+		addAlias(catalogFile, name, scriptRef, description, arguments, javaRuntimeOptions, sources, dependencies,
+				repositories, classPaths, properties, javaVersion, mainClass);
 		return catalogFile;
 	}
 
@@ -60,6 +61,7 @@ public class CatalogUtil {
 			String description,
 			List<String> arguments,
 			List<String> javaRuntimeOptions,
+			List<String> sources,
 			List<String> dependencies,
 			List<String> repositories,
 			List<String> classPaths,
@@ -70,7 +72,8 @@ public class CatalogUtil {
 		catalogFile = cwd.resolve(catalogFile);
 		Catalog catalog = Catalog.get(catalogFile);
 		scriptRef = catalog.relativize(scriptRef);
-		Alias alias = new Alias(scriptRef, description, arguments, javaRuntimeOptions, dependencies, repositories,
+		Alias alias = new Alias(scriptRef, description, arguments, javaRuntimeOptions, sources, dependencies,
+				repositories,
 				classPaths, properties, javaVersion, mainClass, catalog);
 		catalog.aliases.put(name, alias);
 		try {

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -61,6 +61,9 @@ class AliasAdd extends BaseAliasCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
+	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	List<String> sources;
+
 	@CommandLine.Option(names = { "--description",
 			"-d" }, description = "A description for the alias")
 	String description;
@@ -102,11 +105,11 @@ class AliasAdd extends BaseAliasCommand {
 
 		Path catFile = getCatalog(false);
 		if (catFile != null) {
-			CatalogUtil.addAlias(catFile, name, scriptOrFile, desc, userParams, javaRuntimeOptions,
+			CatalogUtil.addAlias(catFile, name, scriptOrFile, desc, userParams, javaRuntimeOptions, sources,
 					dependencyInfoMixin.getDependencies(), dependencyInfoMixin.getRepositories(),
 					dependencyInfoMixin.getClasspaths(), dependencyInfoMixin.getProperties(), javaVersion, mainClass);
 		} else {
-			catFile = CatalogUtil.addNearestAlias(name, scriptOrFile, desc, userParams, javaRuntimeOptions,
+			catFile = CatalogUtil.addNearestAlias(name, scriptOrFile, desc, userParams, javaRuntimeOptions, sources,
 					dependencyInfoMixin.getDependencies(), dependencyInfoMixin.getRepositories(),
 					dependencyInfoMixin.getClasspaths(), dependencyInfoMixin.getProperties(), javaVersion, mainClass);
 		}

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -59,6 +59,9 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
+	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	List<String> sources;
+
 	@CommandLine.Option(names = { "-m",
 			"--main" }, description = "Main class to use when running. Used primarily for running jar's.")
 	String main;
@@ -179,7 +182,7 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 
 		// add source files to compile
 		optionList.add(src.getResourceRef().getFile().getPath());
-		optionList.addAll(src	.getAllSources()
+		optionList.addAll(ctx	.getAllSources(src)
 								.stream()
 								.map(x -> x.getResourceRef().getFile().getPath())
 								.collect(Collectors.toList()));

--- a/src/main/java/dev/jbang/cli/BaseScriptCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseScriptCommand.java
@@ -24,8 +24,14 @@ public abstract class BaseScriptCommand extends BaseCommand {
 	@CommandLine.Option(names = { "--jsh" }, description = "Force input to be interpreted with jsh/jshell")
 	boolean forcejsh = false;
 
-	@CommandLine.Parameters(index = "0", arity = "1", description = "A file with java code or if named .jsh will be run with jshell")
+	@CommandLine.Parameters(index = "0", arity = "0..1", description = "A reference to a source file")
 	String scriptOrFile;
+
+	protected void requireScriptArgument() {
+		if (scriptOrFile == null) {
+			throw new IllegalArgumentException("Missing required parameter: '<scriptOrFile>'");
+		}
+	}
 
 	static protected boolean needsJar(Source source, RunContext context) {
 		// anything but .jar and .jsh files needs jar

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -12,6 +12,7 @@ public class Build extends BaseBuildCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
+		requireScriptArgument();
 		if (insecure) {
 			enableInsecure();
 		}

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -36,6 +36,7 @@ public class Build extends BaseBuildCommand {
 		ctx.setMainClass(main);
 		ctx.setNativeImage(nativeImage);
 		ctx.setCatalog(catalog);
+		ctx.setAdditionalSources(sources);
 		return ctx;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -258,7 +258,7 @@ public class Edit extends BaseScriptCommand {
 		Path srcFile = srcDir.toPath().resolve(name);
 		Util.createLink(srcFile, originalFile.toPath());
 
-		for (ScriptSource source : src.getAllSources()) {
+		for (ScriptSource source : ctx.getAllSources(src)) {
 			File sfile = null;
 			if (source.getJavaPackage().isPresent()) {
 				File packageDir = new File(srcDir, source.getJavaPackage().get().replace(".", File.separator));

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -58,7 +58,7 @@ public class Edit extends BaseScriptCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
-
+		requireScriptArgument();
 		if (insecure) {
 			enableInsecure();
 		}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -138,6 +138,7 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 	private static Set<String> scripts;
 
 	ScriptInfo getInfo() {
+		requireScriptArgument();
 		if (insecure) {
 			enableInsecure();
 		}

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -46,6 +46,7 @@ public class Init extends BaseScriptCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
+		requireScriptArgument();
 		dev.jbang.catalog.Template tpl = dev.jbang.catalog.Template.get(initTemplate);
 		if (tpl == null) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -125,6 +125,7 @@ public class Run extends BaseBuildCommand {
 		ctx.setMainClass(main);
 		ctx.setNativeImage(nativeImage);
 		ctx.setCatalog(catalog);
+		ctx.setAdditionalSources(sources);
 		return ctx;
 	}
 
@@ -353,7 +354,7 @@ public class Run extends BaseBuildCommand {
 			} else {
 				if (ctx.isForceJsh() || src.isJShell()) {
 					if (src instanceof ScriptSource) {
-						for (Source s : ((ScriptSource) src).getAllSources()) {
+						for (Source s : ctx.getAllSources((ScriptSource) src)) {
 							fullArgs.add(s.getResourceRef().getFile().toString());
 						}
 					}

--- a/src/main/java/dev/jbang/source/MarkdownScriptSource.java
+++ b/src/main/java/dev/jbang/source/MarkdownScriptSource.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
-import dev.jbang.source.resolvers.StdinScriptResourceResolver;
+import dev.jbang.source.resolvers.LiteralScriptResourceResolver;
 
 public class MarkdownScriptSource extends ScriptSource {
 
@@ -22,7 +22,7 @@ public class MarkdownScriptSource extends ScriptSource {
 			// this will cache the content in stdin cache which is not optimal but needed to
 			// have the transformed script stored
 			// seperately from the possibly originally cached file.
-			resourceRef = StdinScriptResourceResolver.stringToResourceRef(resourceRef.getOriginalResource(),
+			resourceRef = LiteralScriptResourceResolver.stringToResourceRef(resourceRef.getOriginalResource(),
 					scriptText);
 		} catch (IOException e) {
 			throw new ExitException(BaseCommand.EXIT_UNEXPECTED_STATE,

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -16,6 +16,8 @@ public class ResourceRef implements Comparable<ResourceRef> {
 	// cache folder it is stored inside
 	private final File file;
 
+	public static final ResourceRef nullRef = new ResourceRef(null, null);
+
 	private ResourceRef(String ref, File file) {
 		this.originalResource = ref;
 		this.file = file;

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -3,6 +3,7 @@ package dev.jbang.source;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
@@ -56,7 +57,8 @@ public class ResourceRef implements Comparable<ResourceRef> {
 				sr = Paths.get(originalResource.substring(11)).resolveSibling(siblingResource).toString();
 				sr = "classpath:" + sr;
 			} else {
-				sr = Paths.get(originalResource).resolveSibling(siblingResource).toString();
+				Path baseDir = originalResource != null ? Paths.get(originalResource) : Util.getCwd().resolve("dummy");
+				sr = baseDir.resolveSibling(siblingResource).toString();
 			}
 			ResourceRef result = forResource(sr);
 			if (result == null) {

--- a/src/main/java/dev/jbang/source/ResourceResolver.java
+++ b/src/main/java/dev/jbang/source/ResourceResolver.java
@@ -38,7 +38,7 @@ public interface ResourceResolver {
 	static ResourceResolver forScripts(Function<String, ModularClassPath> depResolver) {
 		return new CombinedResourceResolver(
 				new RenamingScriptResourceResolver(),
-				new StdinScriptResourceResolver(),
+				new LiteralScriptResourceResolver(),
 				new RemoteResourceResolver(RemoteResourceResolver::fetchScriptFromUntrustedURL),
 				new ClasspathResourceResolver(),
 				new GavResourceResolver(depResolver),

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -28,6 +28,7 @@ public class RunContext {
 	private List<String> javaOptions;
 	private Map<String, String> properties;
 
+	private List<String> additionalSources = Collections.emptyList();
 	private List<String> additionalDeps = Collections.emptyList();
 	private List<String> additionalRepos = Collections.emptyList();
 	private List<String> additionalClasspaths = Collections.emptyList();
@@ -63,7 +64,8 @@ public class RunContext {
 	}
 
 	public static RunContext create(List<String> arguments, List<String> javaRuntimeOptions,
-			Map<String, String> properties, List<String> dependencies, List<String> repositories,
+			Map<String, String> properties,
+			List<String> dependencies, List<String> repositories,
 			List<String> classpaths, boolean forceJsh) {
 		RunContext ctx = new RunContext(arguments, javaRuntimeOptions, properties);
 		ctx.setAdditionalDependencies(dependencies);
@@ -97,6 +99,35 @@ public class RunContext {
 
 	public void setProperties(Map<String, String> properties) {
 		this.properties = properties;
+	}
+
+	public List<ScriptSource> getAllSources(ScriptSource src) {
+		List<ScriptSource> ssrcs = src.getAllSources();
+		List<ScriptSource> asrcs = getAdditionalSources()	.stream()
+															.map(src::getSibling)
+															.collect(Collectors.toList());
+		if (asrcs.isEmpty()) {
+			return ssrcs;
+		} else if (ssrcs.isEmpty()) {
+			return asrcs;
+		} else {
+			ArrayList<ScriptSource> result = new ArrayList<>();
+			result.addAll(ssrcs);
+			result.addAll(asrcs);
+			return result;
+		}
+	}
+
+	public List<String> getAdditionalSources() {
+		return additionalSources;
+	}
+
+	public void setAdditionalSources(List<String> sources) {
+		if (sources != null) {
+			this.additionalSources = new ArrayList<>(sources);
+		} else {
+			this.additionalSources = Collections.emptyList();
+		}
 	}
 
 	public List<String> getAdditionalDependencies() {
@@ -377,6 +408,9 @@ public class RunContext {
 				}
 				if (getJavaOptions() == null || getJavaOptions().isEmpty()) {
 					setJavaOptions(alias.javaOptions);
+				}
+				if (getAdditionalSources() == null || getAdditionalSources().isEmpty()) {
+					setAdditionalSources(alias.sources);
 				}
 				if (getAdditionalDependencies() == null || getAdditionalDependencies().isEmpty()) {
 					setAdditionalDependencies(alias.dependencies);

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -531,20 +531,15 @@ public class ScriptSource implements Source {
 		if (getLines() == null) {
 			return Collections.emptyList();
 		} else {
+			String org = getResourceRef().getOriginalResource();
+			Path baseDir = getResourceRef().getFile().getAbsoluteFile().getParentFile().toPath();
 			return getLines()	.stream()
 								.filter(f -> f.startsWith(SOURCES_COMMENT_PREFIX))
 								.flatMap(line -> Arrays	.stream(line.split(" // ")[0].split("[ ;,]+"))
 														.skip(1)
 														.map(String::trim))
 								.map(replaceProperties)
-								.flatMap(line -> Util
-														.explode(getResourceRef().getOriginalResource(),
-																getResourceRef().getFile()
-																				.getAbsoluteFile()
-																				.getParentFile()
-																				.toPath(),
-																line)
-														.stream())
+								.flatMap(line -> Util.explode(org, baseDir, line).stream())
 								.map(resourceRef::asSibling)
 								.map(it -> prepareScript(it, replaceProperties))
 								.collect(Collectors.toCollection(ArrayList::new));

--- a/src/main/java/dev/jbang/source/ScriptSource.java
+++ b/src/main/java/dev/jbang/source/ScriptSource.java
@@ -532,7 +532,8 @@ public class ScriptSource implements Source {
 			return Collections.emptyList();
 		} else {
 			String org = getResourceRef().getOriginalResource();
-			Path baseDir = getResourceRef().getFile().getAbsoluteFile().getParentFile().toPath();
+			Path baseDir = org != null ? getResourceRef().getFile().getAbsoluteFile().getParentFile().toPath()
+					: Util.getCwd();
 			return getLines()	.stream()
 								.filter(f -> f.startsWith(SOURCES_COMMENT_PREFIX))
 								.flatMap(line -> Arrays	.stream(line.split(" // ")[0].split("[ ;,]+"))
@@ -540,10 +541,14 @@ public class ScriptSource implements Source {
 														.map(String::trim))
 								.map(replaceProperties)
 								.flatMap(line -> Util.explode(org, baseDir, line).stream())
-								.map(resourceRef::asSibling)
-								.map(it -> prepareScript(it, replaceProperties))
+								.map(this::getSibling)
 								.collect(Collectors.toCollection(ArrayList::new));
 		}
+	}
+
+	public ScriptSource getSibling(String resource) {
+		ResourceRef siblingRef = resourceRef.asSibling(resource);
+		return prepareScript(siblingRef, replaceProperties);
 	}
 
 	protected <R> List<R> collectAll(Function<ScriptSource, List<R>> func) {

--- a/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
@@ -23,7 +23,7 @@ import dev.jbang.util.Util;
  * will try to create a copy in the cache with a proper file name and return a
  * reference to that file.
  */
-public class StdinScriptResourceResolver implements ResourceResolver {
+public class LiteralScriptResourceResolver implements ResourceResolver {
 	@Override
 	public ResourceRef resolve(String resource) {
 		ResourceRef result = null;

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -202,7 +202,7 @@ public class Util {
 
 		List<String> results = new ArrayList<>();
 
-		if (Util.isURL(source)) {
+		if (source != null && Util.isURL(source)) {
 			// if url then just return it back for others to resolve.
 			// TODO: technically this is really where it should get resolved!
 			if (isPattern(filepattern)) {

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -150,7 +150,7 @@ public class TestAliasNearest extends BaseTest {
 	void testAddLocal(String ref, String result) throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -162,8 +162,8 @@ public class TestAliasNearest extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		CatalogUtil.addAlias(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", "dummy.java", null, null, null, null, null,
-				null, null, null,
-				null);
+				null,
+				null, null, null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -185,7 +185,7 @@ public class TestAliasNearest extends BaseTest {
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		Path dotLocalCatalog = cwd.resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
@@ -210,7 +210,7 @@ public class TestAliasNearest extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
@@ -239,7 +239,7 @@ public class TestAliasNearest extends BaseTest {
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
 		Files.delete(parentCatalog);
-		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", ref, null, null, null, null, null, null, null, null, null, null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));

--- a/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
@@ -64,7 +64,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 	void testAddLocal() throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null,
+				null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.aliases.keySet(), hasItem("new"));
@@ -77,7 +78,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		Path dotLocalCatalog = cwd.resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null,
+				null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
@@ -93,7 +95,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null);
+		CatalogUtil.addNearestAlias("new", "scripts/local.java", null, null, null, null, null, null, null, null, null,
+				null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
@@ -111,6 +114,7 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
 		CatalogUtil.addNearestAlias("new", "../scripts/parent.java", null, null, null, null, null, null, null, null,
+				null,
 				null);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));


### PR DESCRIPTION
The `--code` (or `-c`) option either takes a String argument (using `=`)
that will be taken as a literal script or it can appear without argument
in which case the `scriptOrFile` argument will be assumed to contain a
literal script. In both cases the literal script will be executed in
the same way as if the code was passed on the stdin (that is, the code
will be assumed to be Jshell code unless it obviously is plain Java).
Also allows the `--interactive` option to be used without any script
reference at all.
The shortcut `-i` was added for `--interactive`.

Fixes #1242