### PR TITLE
feat: Support colors under Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.13.1'
 	implementation 'org.codejive:java-properties:0.0.3'
 
+	implementation 'org.fusesource.jansi:jansi:2.4.0'
+
 	implementation 'com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-api:3.1.5-allowpom'
 	implementation 'com.github.jbangdev.jbang-resolver:shrinkwrap-resolver-impl-maven:3.1.5-allowpom'
 
@@ -170,6 +172,8 @@ shadowJar {
 		//exclude(dependency('org.slf4j:slf4j-api:.*'))
 		exclude(dependency('org.slf4j:slf4j-nop:.*'))
 		exclude(dependency('org.jboss.logging:jboss-logging:.*'))
+
+		exclude(dependency('org.fusesource.jansi:jansi:.*'))
 
 
 	}

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -3,15 +3,23 @@ package dev.jbang;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.fusesource.jansi.AnsiConsole;
+
 import dev.jbang.cli.JBang;
 
 import picocli.CommandLine;
 
 public class Main {
 	public static void main(String... args) {
+		if (isWindows()) {
+			AnsiConsole.systemInstall();
+		}
 		CommandLine cli = JBang.getCommandLine();
 		args = handleDefaultRun(cli.getCommandSpec(), args);
 		int exitcode = cli.execute(args);
+		if (isWindows()) {
+			AnsiConsole.systemUninstall();
+		}
 		System.exit(exitcode);
 	}
 
@@ -49,5 +57,9 @@ public class Main {
 							.anyMatch(o -> o.startsWith("-i=") || o.startsWith("--interactive=")
 									|| o.startsWith("-c=") || o.startsWith("--code="));
 		return res;
+	}
+
+	private static boolean isWindows() {
+		return System.getProperty("os.name").toLowerCase().startsWith("win");
 	}
 }


### PR DESCRIPTION
For various combinations of Windows terminal emulators and shells (e.g. Git Bash) the help displayed by picocli when running `jbang` is garbled with ANSI codes to the point that the help almost can't be deciphered.

According to the [documentation of picocli](https://picocli.info/#_windows) the ANSI support can be enabled by including Jansi and calling `AnsiConsole.systemInstall()`. That is what is being done in this commit.

Note that the Jansi JAR is 215 KB in size.

Please also note that this is not enough for native images. How to use Jansi in GraalVM native images is however also [documented](https://picocli.info/#_jansi_in_graalvm_native_images).