### PR TITLE
fix: support M1 initial macs java downloads

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -269,7 +269,7 @@ public class Util {
 	}
 
 	public enum Arch {
-		x32, x64, aarch64, ppc64, ppc64le, s390x, unknown
+		x32, x64, aarch64, arm64, ppc64, ppc64le, s390x, unknown
 	}
 
 	public enum Vendor {
@@ -428,6 +428,8 @@ public class Util {
 			return Arch.ppc64le;
 		} else if (arch.matches("^(s390x)$")) {
 			return Arch.s390x;
+		} else if (arch.matches("^(arm64)$")) {
+			return Arch.arm64;
 		} else {
 			Util.verboseMsg("Unknown Arch: " + arch);
 			return Arch.unknown;

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -100,6 +100,15 @@ case "$(uname -m)" in
     arch=ppc64le;;
   s390x)
     arch=s390x;;
+  arm64)
+    if [ "$os" = "mac" ]; then
+      arch=arm64
+      ## force use of 17 as 11 not yet available https://github.com/adoptium/adoptium/issues/96
+      javaVersion=17
+    else
+      arch=arm64
+    fi
+    ;;
   *)
     ## AIX gives a machine ID for `uname -m` but it only supports ppc64
     if [ "$os" = "aix" ]; then


### PR DESCRIPTION
Attempt to fix https://github.com/jbangdev/jbang/discussions/1265 that notices that on M1 that identifies as arm64 won't auto download java.