### PR TITLE
docs: Make explicit why groovy is needed

### DIFF
--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -187,8 +187,8 @@ import groovy.lang.GrabResolver;
 @GrabResolver("mavenCentral") // <.>
 @GrabResolver(name='acme', root='https://maven.acme.local/maven')
 @Grapes({ // <.>
-		@Grab(group="org.codehaus.groovy", module="groovy", version="2.5.8"), // <.>
-		@Grab(group = "ch.qos.reload4j", module = "reload4j", version = "1.2.19")
+		@Grab(group = "ch.qos.reload4j", module = "reload4j", version = "1.2.19"), // <.>
+		@Grab(group = "org.apache.groovy", module = "groovy", version = "4.0.0"), // <.>
 })
 class classpath_example {
 
@@ -204,6 +204,7 @@ class classpath_example {
 <.> Using `GrabResolver` to enable `mavenCentral` and custom `acme` repository
 <.> In Groovy you normally put `@Grab` on import statements. That is not allowed in Java thus when having multiple imports you need to put them in a `@Grapes` annotation first.
 <.> `jbang` will grab any `@Grab` annotation and assume it is declaring dependencies.
+<.> In particular to be able to import `groovy.lang.*` annotations, groovy itself must be in the list of dependencies.
 
 === System properties and Environment variables
 

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -185,7 +185,7 @@ import groovy.lang.Grapes;
 import groovy.lang.GrabResolver;
 
 @GrabResolver("mavenCentral") // <.>
-@GrabResolver(name='acme', root='https://maven.acme.local/maven')
+@GrabResolver(name="acme", root="https://maven.acme.local/maven")
 @Grapes({ // <.>
 		@Grab(group = "ch.qos.reload4j", module = "reload4j", version = "1.2.19"), // <.>
 		@Grab(group = "org.apache.groovy", module = "groovy", version = "4.0.0"), // <.>


### PR DESCRIPTION
Make explicit why groovy is needed.

Use java quotes in the line:
`@GrabResolver(name="acme", root="https://maven.acme.local/maven")`

The example does still not compile:
```
classpath_example.java:15: error: GrabResolver is not a repeatable annotation type
@GrabResolver(name="acme", root="https://maven.acme.local/maven")
^
1 error
[jbang] [ERROR] Error during compile
[jbang] Run with --verbose for more details
```

But it is better.