### PR TITLE
fix: no longer throws NPE for config list

### DIFF
--- a/src/main/java/dev/jbang/Configuration.java
+++ b/src/main/java/dev/jbang/Configuration.java
@@ -188,7 +188,7 @@ public class Configuration {
 			if (cfgFileName != null) {
 				Path cfgFile = Util.getCwd().resolve(cfgFileName);
 				if (Files.isReadable(cfgFile)) {
-					global = read(cfgFile);
+					global = get(cfgFile);
 				} else {
 					global = defaults();
 				}
@@ -218,6 +218,17 @@ public class Configuration {
 			defaults = Configuration.getBuiltin();
 		}
 		return defaults;
+	}
+
+	public static Configuration get(Path catalogPath) {
+		return get(ResourceRef.forNamedFile(catalogPath.toString(), catalogPath.toFile()));
+	}
+
+	private static Configuration get(ResourceRef ref) {
+		Path configPath = ref.getFile().toPath();
+		Configuration cfg = read(configPath);
+		cfg.storeRef = ref;
+		return cfg;
 	}
 
 	/**

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -36,7 +36,7 @@ public abstract class BaseCommand implements Callable<Integer> {
 	@CommandLine.Option(names = { "--config" }, description = "Path to config file to be used instead of the default")
 	void setConfig(Path config) {
 		if (Files.isReadable(config)) {
-			Configuration.instance(Configuration.read(config));
+			Configuration.instance(Configuration.get(config));
 		} else {
 			warn("Configuration file does not exist or could not be read: " + config);
 		}

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -34,7 +34,7 @@ abstract class BaseConfigCommand extends BaseCommand {
 	protected Configuration getConfig(Path cwd, boolean strict) {
 		Path cfgFile = getConfigFile(strict);
 		if (cfgFile != null) {
-			return Configuration.read(cfgFile);
+			return Configuration.get(cfgFile);
 		} else {
 			return Configuration.getMerged();
 		}

--- a/src/test/java/dev/jbang/TestConfiguration.java
+++ b/src/test/java/dev/jbang/TestConfiguration.java
@@ -1,9 +1,7 @@
 package dev.jbang;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyOrNullString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -16,6 +14,7 @@ import dev.jbang.cli.Edit;
 import dev.jbang.cli.Init;
 import dev.jbang.cli.JBang;
 import dev.jbang.cli.Run;
+import dev.jbang.source.ResourceRef;
 import dev.jbang.util.Util;
 
 import picocli.CommandLine;
@@ -80,6 +79,16 @@ public class TestConfiguration extends BaseTest {
 		assertThat(cfg2.get("foo"), equalTo("abc"));
 		assertThat(cfg2.get("bar"), equalTo("ghi"));
 		assertThat(cfg2.get("baz"), equalTo("jkl"));
+	}
+
+	@Test
+	public void testReadAndGetConfig() throws IOException {
+		Path cfgFile = jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS);
+		Configuration cfgRead = Configuration.read(cfgFile);
+		assertThat(cfgRead.getStoreRef(), nullValue());
+		Configuration cfgGet = Configuration.get(cfgFile);
+		assertThat(cfgGet.getStoreRef(), notNullValue());
+		assertThat(cfgGet.getStoreRef(), equalTo(ResourceRef.forResource(cfgFile.toString())));
 	}
 
 	@Test


### PR DESCRIPTION
The `Configuration` wasn't storing the originating `ResourceRef` in the
case of single file configurations (which is what `--global` is).
To fix this the code has been made more similar to `Catalog`.

Fixes #1275

