### PR TITLE
feat: allow aliases for `//SOURCES`

### DIFF
--- a/src/main/java/dev/jbang/catalog/CatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/CatalogRef.java
@@ -52,6 +52,15 @@ public class CatalogRef extends CatalogItem {
 		if (catalog != null) {
 			catalogRef = catalog.catalogs.get(catalogName);
 		}
+		if (catalogRef == null && Util.isValidPath(catalogName)) {
+			Path p = Paths.get(catalogName);
+			if (!p.getFileName().toString().equals(Catalog.JBANG_CATALOG_JSON)) {
+				p = p.resolve(Catalog.JBANG_CATALOG_JSON);
+			}
+			if (Files.isRegularFile(p)) {
+				catalogRef = createByRefOrImplicit(p.toString());
+			}
+		}
 		if (catalogRef == null) {
 			Util.verboseMsg("Local catalog '" + catalogName + "' not found, trying implicit catalogs...");
 			Optional<String> url = ImplicitCatalogRef.getImplicitCatalogUrl(catalogName);

--- a/src/main/java/dev/jbang/catalog/CatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/CatalogRef.java
@@ -53,7 +53,7 @@ public class CatalogRef extends CatalogItem {
 			catalogRef = catalog.catalogs.get(catalogName);
 		}
 		if (catalogRef == null && Util.isValidPath(catalogName)) {
-			Path p = Paths.get(catalogName);
+			Path p = Util.getCwd().resolve(catalogName);
 			if (!p.getFileName().toString().equals(Catalog.JBANG_CATALOG_JSON)) {
 				p = p.resolve(Catalog.JBANG_CATALOG_JSON);
 			}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -17,10 +17,7 @@ import com.google.gson.GsonBuilder;
 
 import dev.jbang.dependencies.MavenRepo;
 import dev.jbang.net.JdkManager;
-import dev.jbang.source.Code;
-import dev.jbang.source.RefTarget;
-import dev.jbang.source.RunContext;
-import dev.jbang.source.Source;
+import dev.jbang.source.*;
 
 import picocli.CommandLine;
 

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -19,6 +19,7 @@ import javax.lang.model.SourceVersion;
 import dev.jbang.catalog.TemplateProperty;
 import dev.jbang.source.RefTarget;
 import dev.jbang.source.ResourceRef;
+import dev.jbang.source.resolvers.SiblingResourceResolver;
 import dev.jbang.util.TemplateEngine;
 import dev.jbang.util.Util;
 
@@ -69,9 +70,9 @@ public class Init extends BaseScriptCommand {
 															resolveBaseName(e.getKey(), e.getValue(), outName),
 															tpl.resolve(e.getValue())))
 													.map(e -> RefTarget.create(
-															tpl.catalog.catalogRef.getFile().getAbsolutePath(),
 															e.getValue(),
-															e.getKey()))
+															e.getKey(),
+															new SiblingResourceResolver(tpl.catalog.catalogRef)))
 													.collect(Collectors.toList());
 
 		applyTemplateProperties(tpl);

--- a/src/main/java/dev/jbang/source/RefTarget.java
+++ b/src/main/java/dev/jbang/source/RefTarget.java
@@ -53,7 +53,7 @@ public class RefTarget {
 		}
 	}
 
-	public static RefTarget create(String base, String fileReference) {
+	public static RefTarget create(String fileReference, ResourceResolver siblingResolver) {
 		String[] split = fileReference.split(" // ")[0].split("=", 2);
 		String ref;
 		String dest = null;
@@ -76,10 +76,10 @@ public class RefTarget {
 					"Only relative paths allowed in //FILES. Found absolute path: " + dest);
 		}
 
-		return create(base, ref, p);
+		return create(ref, p, siblingResolver);
 	}
 
-	public static RefTarget create(String base, String ref, Path dest) {
-		return new RefTarget(ResourceRef.forResource(base).asSibling(ref), dest);
+	public static RefTarget create(String ref, Path dest, ResourceResolver siblingResolver) {
+		return new RefTarget(siblingResolver.resolve(ref), dest);
 	}
 }

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -1,16 +1,10 @@
 package dev.jbang.source;
 
 import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import dev.jbang.cli.BaseCommand;
-import dev.jbang.cli.ExitException;
 import dev.jbang.util.Util;
 
 public class ResourceRef implements Comparable<ResourceRef> {
@@ -48,32 +42,6 @@ public class ResourceRef implements Comparable<ResourceRef> {
 	@Nullable
 	public String getOriginalResource() {
 		return originalResource;
-	}
-
-	public ResourceRef asSibling(String siblingResource) {
-		String sr;
-		try {
-			if (Util.isURL(siblingResource)) {
-				sr = new URI(siblingResource).toString();
-			} else if (isURL()) {
-				sr = new URI(Util.swizzleURL(originalResource)).resolve(siblingResource).toString();
-			} else if (Util.isClassPathRef(siblingResource)) {
-				sr = siblingResource;
-			} else if (isClasspath()) {
-				sr = Paths.get(originalResource.substring(11)).resolveSibling(siblingResource).toString();
-				sr = "classpath:" + sr;
-			} else {
-				Path baseDir = originalResource != null ? Paths.get(originalResource) : Util.getCwd().resolve("dummy");
-				sr = baseDir.resolveSibling(siblingResource).toString();
-			}
-			ResourceRef result = forResource(sr);
-			if (result == null) {
-				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not find " + siblingResource);
-			}
-			return result;
-		} catch (URISyntaxException e) {
-			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR, e);
-		}
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/ResourceResolver.java
+++ b/src/main/java/dev/jbang/source/ResourceResolver.java
@@ -22,10 +22,39 @@ public interface ResourceResolver {
 	 * having a supported format but something goes wrong and no reference can be
 	 * created it's normal to throw an exception.
 	 *
+	 * The <code>trusted</code> argument is used to indicate if a resolve request
+	 * should be considered trusted or not. Untrusted requests might cause a
+	 * resolver to check a request against some kind of trust provider and throwing
+	 * an exception if the request was considered unauthorized. Trusted requests
+	 * should never do that.
+	 *
+	 * @param resource The resource string to resolve
+	 * @param trusted  If the request should be considered trusted or not
+	 * @return A <code>ResourceRef</code> or <code>null</code>
+	 */
+	default ResourceRef resolve(String resource, boolean trusted) {
+		return resolve(resource);
+	}
+
+	/**
+	 * Given a resource string either returns a `ResourceRef` that identifies that
+	 * resource or <code>null</code> if the resolver wasn't able to handle the
+	 * resource string.
+	 *
+	 * The method should _only_ return <code>null</code> if it does not recognize
+	 * the resource string, thereby informing the caller it should probably try some
+	 * other resolver. In case the resolver _does_ recognize the resource string as
+	 * having a supported format but something goes wrong and no reference can be
+	 * created it's normal to throw an exception.
+	 *
+	 * Calls to this method are always considered untrusted.
+	 *
 	 * @param resource The resource string to resolve
 	 * @return A <code>ResourceRef</code> or <code>null</code>
 	 */
-	ResourceRef resolve(String resource);
+	default ResourceRef resolve(String resource) {
+		return resolve(resource, false);
+	}
 
 	/**
 	 * Factory method that returns a resource resolver that knows how to deal with
@@ -41,7 +70,7 @@ public interface ResourceResolver {
 				new CombinedResourceResolver(
 						new RenamingScriptResourceResolver(),
 						new LiteralScriptResourceResolver(),
-						new RemoteResourceResolver(RemoteResourceResolver::fetchScriptFromUntrustedURL),
+						new RemoteResourceResolver(false),
 						new ClasspathResourceResolver(),
 						new GavResourceResolver(depResolver),
 						new FileResourceResolver()));
@@ -55,7 +84,7 @@ public interface ResourceResolver {
 	 */
 	static ResourceResolver forResources() {
 		return new CombinedResourceResolver(
-				new RemoteResourceResolver(RemoteResourceResolver::fetchFromURL),
+				new RemoteResourceResolver(true),
 				new ClasspathResourceResolver(),
 				new FileResourceResolver());
 	}

--- a/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
@@ -22,12 +22,12 @@ public class AliasResourceResolver implements ResourceResolver {
 	}
 
 	@Override
-	public ResourceRef resolve(String resource) {
-		ResourceRef ref = resolver.resolve(resource);
+	public ResourceRef resolve(String resource, boolean trusted) {
+		ResourceRef ref = resolver.resolve(resource, trusted);
 		if (ref == null) {
 			Alias alias = (catalog != null) ? Alias.get(catalog, resource) : Alias.get(resource);
 			if (alias != null) {
-				ResourceRef aliasRef = resolver.resolve(alias.resolve());
+				ResourceRef aliasRef = resolver.resolve(alias.resolve(), trusted);
 				if (aliasRef == null) {
 					throw new IllegalArgumentException(
 							"Alias " + resource + " from " + alias.catalog.catalogRef + " failed to resolve "

--- a/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
@@ -21,9 +21,9 @@ public class CombinedResourceResolver implements ResourceResolver {
 	}
 
 	@Override
-	public ResourceRef resolve(String resource) {
+	public ResourceRef resolve(String resource, boolean trusted) {
 		return resolvers.stream()
-						.map(r -> r.resolve(resource))
+						.map(r -> r.resolve(resource, trusted))
 						.filter(Objects::nonNull)
 						.findFirst()
 						.orElse(null);

--- a/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
@@ -8,7 +8,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
 
 import dev.jbang.Settings;
 import dev.jbang.cli.BaseCommand;
@@ -24,19 +23,18 @@ import dev.jbang.util.Util;
  * document to the cache and return a reference to that file.
  */
 public class RemoteResourceResolver implements ResourceResolver {
-	private final Function<String, ResourceRef> urlFetcher;
+	private final boolean alwaysTrust;
 
-	public RemoteResourceResolver(Function<String, ResourceRef> urlFetcher) {
-		this.urlFetcher = urlFetcher;
+	public RemoteResourceResolver(boolean alwaysTrust) {
+		this.alwaysTrust = alwaysTrust;
 	}
 
 	@Override
-	public ResourceRef resolve(String resource) {
+	public ResourceRef resolve(String resource, boolean trusted) {
 		ResourceRef result = null;
 
 		if (resource.startsWith("http://") || resource.startsWith("https://") || resource.startsWith("file:/")) {
-			// support url's as script files
-			result = urlFetcher.apply(resource);
+			result = alwaysTrust || trusted ? fetchFromURL(resource) : fetchScriptFromUntrustedURL(resource);
 		}
 
 		return result;

--- a/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
@@ -1,0 +1,58 @@
+package dev.jbang.source.resolvers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import dev.jbang.catalog.Catalog;
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+import dev.jbang.util.Util;
+
+public class SiblingResourceResolver implements ResourceResolver {
+	private final ResourceRef sibling;
+	private final ResourceResolver resolver;
+
+	public SiblingResourceResolver(ResourceRef sibling) {
+		this.sibling = sibling;
+		this.resolver = ResourceResolver.forResources();
+	}
+
+	public SiblingResourceResolver(ResourceRef sibling, ResourceResolver resolver) {
+		this.sibling = sibling;
+		this.resolver = resolver;
+	}
+
+	@Override
+	public ResourceRef resolve(String resource, boolean trusted) {
+		try {
+			String originalResource = sibling.getOriginalResource();
+			String sr;
+			if (Util.isURL(resource)) {
+				sr = new URI(resource).toString();
+			} else if (sibling.isURL()) {
+				sr = new URI(Util.swizzleURL(originalResource)).resolve(resource).toString();
+			} else if (Util.isClassPathRef(resource)) {
+				sr = resource;
+			} else if (sibling.isClasspath()) {
+				sr = Paths.get(originalResource.substring(11)).resolveSibling(resource).toString();
+				sr = "classpath:" + sr;
+			} else if (Catalog.isValidCatalogReference(resource)) {
+				sr = resource;
+			} else {
+				Path baseDir = originalResource != null ? Paths.get(originalResource) : Util.getCwd().resolve("dummy");
+				sr = baseDir.resolveSibling(resource).toString();
+			}
+			ResourceRef result = resolver.resolve(sr, true);
+			if (result == null) {
+				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not find " + resource);
+			}
+			return result;
+		} catch (URISyntaxException e) {
+			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR, e);
+		}
+	}
+}

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -5,10 +5,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import dev.jbang.net.GroovyManager;
-import dev.jbang.source.ResourceRef;
-import dev.jbang.source.RunContext;
-import dev.jbang.source.Source;
-import dev.jbang.source.SourceSet;
+import dev.jbang.source.*;
 import dev.jbang.source.builders.BaseBuilder;
 import dev.jbang.source.builders.GroovyBuilder;
 

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -3,10 +3,7 @@ package dev.jbang.source.sources;
 import java.util.List;
 import java.util.function.Function;
 
-import dev.jbang.source.ResourceRef;
-import dev.jbang.source.RunContext;
-import dev.jbang.source.Source;
-import dev.jbang.source.SourceSet;
+import dev.jbang.source.*;
 import dev.jbang.source.builders.BaseBuilder;
 import dev.jbang.source.builders.JavaBuilder;
 

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -5,10 +5,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import dev.jbang.net.KotlinManager;
-import dev.jbang.source.ResourceRef;
-import dev.jbang.source.RunContext;
-import dev.jbang.source.Source;
-import dev.jbang.source.SourceSet;
+import dev.jbang.source.*;
 import dev.jbang.source.builders.BaseBuilder;
 import dev.jbang.source.builders.KotlinBuilder;
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1167,6 +1167,15 @@ public class Util {
 		return ref.startsWith("classpath:");
 	}
 
+	public static boolean isValidPath(String path) {
+		try {
+			Paths.get(path);
+			return true;
+		} catch (InvalidPathException e) {
+			return false;
+		}
+	}
+
 	/**
 	 *
 	 * @param content


### PR DESCRIPTION
You can now use aliases within `//SOURCES` tags.
NB: Only qualified aliases are supported! So the alias needs to have a `@`.