### PR TITLE
fix: fixed problem `--deps` and `//REPOS`

### DIFF
--- a/src/main/java/dev/jbang/source/Jar.java
+++ b/src/main/java/dev/jbang/source/Jar.java
@@ -85,6 +85,16 @@ public class Jar implements Code {
 	public SourceSet asSourceSet() {
 		if (sourceSet == null) {
 			sourceSet = SourceSet.forSource(Source.forResourceRef(resourceRef, null));
+			sourceSet.setMainClass(getMainClass());
+			sourceSet.addRuntimeOptions(getRuntimeOptions());
+			sourceSet.setJavaVersion(getJavaVersion().orElse(null));
+			// TODO deduplicate with code from updateDependencyResolver()
+			if (resourceRef.getOriginalResource() != null
+					&& DependencyUtil.looksLikeAGav(resourceRef.getOriginalResource())) {
+				sourceSet.addDependency(resourceRef.getOriginalResource());
+			} else if (classPath != null) {
+				sourceSet.addClassPaths(Arrays.asList(classPath.split(" ")));
+			}
 		}
 		return sourceSet;
 	}

--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -350,7 +350,7 @@ public class RunContext {
 			if (code instanceof Jar) {
 				updateDependencyResolver(resolver);
 			}
-			code.updateDependencyResolver(resolver);
+			code.asSourceSet().updateDependencyResolver(resolver);
 			mcp = resolver.resolve();
 		}
 		return mcp.getClassPath();

--- a/src/main/java/dev/jbang/source/SourceSet.java
+++ b/src/main/java/dev/jbang/source/SourceSet.java
@@ -32,6 +32,7 @@ public class SourceSet implements Code {
 	private String javaVersion;
 	private String description;
 	private String gav;
+	private String mainClass;
 
 	private ModularClassPath mcp;
 	private File jarFile;
@@ -253,6 +254,15 @@ public class SourceSet implements Code {
 	public SourceSet setGav(String gav) {
 		this.gav = gav;
 		return this;
+	}
+
+	@Override
+	public String getMainClass() {
+		return mainClass;
+	}
+
+	public void setMainClass(String mainClass) {
+		this.mainClass = mainClass;
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -301,15 +301,6 @@ public abstract class BaseBuilder implements Builder {
 		}
 	}
 
-	static public String findMainClass(Path base, Path classfile) {
-		StringBuilder mainClass = new StringBuilder(classfile.getFileName().toString().replace(".class", ""));
-		while (!classfile.getParent().equals(base)) {
-			classfile = classfile.getParent();
-			mainClass.insert(0, classfile.getFileName().toString() + ".");
-		}
-		return mainClass.toString();
-	}
-
 	private static String resolveInGraalVMHome(String cmd, String requestedVersion) {
 		String newcmd = resolveInEnv("GRAALVM_HOME", cmd);
 
@@ -434,7 +425,7 @@ public abstract class BaseBuilder implements Builder {
 				}
 
 				if (!mains.isEmpty()) {
-					ctx.setMainClass(mains.get(0).name().toString());
+					ss.setMainClass(mains.get(0).name().toString());
 					if (mains.size() > 1) {
 						Util.warnMsg(
 								"Could not locate unique main() method. Use -m to specify explicit main method. Falling back to use first found: "


### PR DESCRIPTION
If the code had `//REPOS` tags and it would get run with `--deps`
on the command line then those deps would not get resolved against
the repostories mentioned in the `//REPOS` tags if no build was being
performed.

Fixes #1292
