### PR TITLE
fix: `edit` now sets up correct Java environment

### DIFF
--- a/src/main/java/dev/jbang/source/RunContext.java
+++ b/src/main/java/dev/jbang/source/RunContext.java
@@ -298,6 +298,10 @@ public class RunContext {
 		return javaVersion;
 	}
 
+	public String getJavaVersionOr(Code code) {
+		return javaVersion != null ? javaVersion : code.getJavaVersion().orElse(null);
+	}
+
 	public File getCatalog() {
 		return catalogFile;
 	}

--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -67,7 +67,7 @@ public abstract class BaseBuilder implements Builder {
 		File outjar = ss.getJarFile();
 		boolean nativeBuildRequired = ctx.isNativeImage() && !getImageName(outjar).exists();
 		IntegrationResult integrationResult = new IntegrationResult(null, null, null);
-		String requestedJavaVersion = getRequestedJavaVersion();
+		String requestedJavaVersion = ctx.getJavaVersionOr(ss);
 		// always build the jar for native mode
 		// it allows integrations the options to produce the native image
 		boolean buildRequired = true;
@@ -127,7 +127,7 @@ public abstract class BaseBuilder implements Builder {
 
 	// build with javac and then jar...
 	public IntegrationResult compile() throws IOException {
-		String requestedJavaVersion = getRequestedJavaVersion();
+		String requestedJavaVersion = ctx.getJavaVersionOr(ss);
 		File compileDir = getCompileDir();
 		List<String> optionList = new ArrayList<>();
 		optionList.add(getCompilerBinary(requestedJavaVersion));
@@ -256,7 +256,7 @@ public abstract class BaseBuilder implements Builder {
 	protected void buildNative()
 			throws IOException {
 		List<String> optionList = new ArrayList<>();
-		optionList.add(resolveInGraalVMHome("native-image", getRequestedJavaVersion()));
+		optionList.add(resolveInGraalVMHome("native-image", ctx.getJavaVersionOr(ss)));
 
 		optionList.add("-H:+ReportExceptionStackTraces");
 
@@ -517,10 +517,6 @@ public abstract class BaseBuilder implements Builder {
 			Util.writeString(pomPath, pomfile);
 		}
 		return pomPath;
-	}
-
-	protected String getRequestedJavaVersion() {
-		return ctx.getJavaVersion() != null ? ctx.getJavaVersion() : ss.getJavaVersion().orElse(null);
 	}
 
 	protected File getCompileDir() {

--- a/src/main/java/dev/jbang/source/builders/GroovyBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/GroovyBuilder.java
@@ -38,7 +38,7 @@ public class GroovyBuilder extends BaseBuilder {
 	protected void runCompiler(ProcessBuilder processBuilder) throws IOException {
 		if (ss.getMainSource() instanceof GroovySource) {
 			processBuilder	.environment()
-							.put("JAVA_HOME", JdkManager.getCurrentJdk(getRequestedJavaVersion()).toString());
+							.put("JAVA_HOME", JdkManager.getCurrentJdk(ctx.getJavaVersionOr(ss)).toString());
 			processBuilder.environment().remove("GROOVY_HOME");
 		}
 		super.runCompiler(processBuilder);


### PR DESCRIPTION
The `edit` command now sets `JAVA_HOME` and adds the Java bin folder
to the `PATH` to make sure the editor/IDE uses the correct Java version.

Especially useful if the code has a higher Java version than the one on the user's PATH.

The problem I can see is that perhaps the editor/IDE doesn't like the version specified in the code.
Wdyt @maxandersen ?