### PR TITLE
fix: Run locally with 'act' fails (jbangdev/jbang-action#28)

### DIFF
--- a/src/jreleaser/distributions/jbang/docker/Dockerfile.tpl
+++ b/src/jreleaser/distributions/jbang/docker/Dockerfile.tpl
@@ -25,6 +25,7 @@ ADD ./entrypoint /bin/entrypoint
 
 ENV SCRIPTS_HOME /scripts
 ENV JBANG_VERSION {{projectVersion}}
+ENV JBANG_PATH=/jbang/bin
 
 VOLUME /scripts
 

--- a/src/jreleaser/distributions/jbang/docker/entrypoint
+++ b/src/jreleaser/distributions/jbang/docker/entrypoint
@@ -14,8 +14,8 @@ EOF
 fi
 
 if [[ ! -z "$INPUT_TRUST" ]]; then
-  jbang trust add $INPUT_TRUST
+  $JBANG_PATH/jbang trust add $INPUT_TRUST
 fi
 
 echo jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_ARGS "${@}"
-exec jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"
+exec $JBANG_PATH/jbang $INPUT_JBANGARGS $INPUT_SCRIPT $INPUT_SCRIPTARGS "${@}"


### PR DESCRIPTION
Use jbang full path to bypass 'act' issue with PATH environment variable