### PR TITLE
test: added docker compose file for testing proxy

### DIFF
--- a/misc/proxy/README.md
+++ b/misc/proxy/README.md
@@ -1,0 +1,37 @@
+# Testing with a proxy
+
+You can use the `docker-compose.yml` file in this folder to test how
+JBang behaves on a system that only has access to the Internet via a
+proxy.
+
+To do this you need to have `docker-compose` installed and then from
+this folder you can run the command:
+
+```
+docker-compose up -d tinyproxy
+```
+
+Which will start up a proxy server on an internal container network.
+When that's done you can run a container that has JBang pre-installed:
+
+```
+docker-compose run --rm jbang
+```
+
+You'll now have access to a shell in a container that can only access
+the Internet via the proxy at the URL `tinyproxy:8888`. Environment
+variables have already been set for Linux itself so `curl` will work
+just fine.
+
+Setting the proxy options for Java requires a bit more work and doesn't
+always work. One way is to inherit the settings from the OS, like this:
+
+```
+JAVA_TOOL_OPTIONS="-Djava.net.useSystemProxies=true"
+```
+
+The other option is to set it explicitly:
+
+```
+JAVA_TOOL_OPTIONS="-Dhttp.proxyHost=tinyproxy -Dhttp.proxyPort=8888 -Dhttps.proxyHost=tinyproxy -Dhttps.proxyPort=8888"
+```

--- a/misc/proxy/docker-compose.yml
+++ b/misc/proxy/docker-compose.yml
@@ -1,0 +1,31 @@
+
+version: "3.9"
+services:
+
+  tinyproxy:
+    image: vimagick/tinyproxy
+    networks:
+      - no-internet
+      - internet
+    restart: unless-stopped
+
+  jbang:
+    image: jbangdev/jbang-action
+    stdin_open: true
+    tty: true
+    entrypoint: /bin/bash
+    environment:
+      - http_proxy=http://tinyproxy:8888
+      - https_proxy=http://tinyproxy:8888
+    networks:
+      - no-internet
+    volumes:
+      - ../../build/install/jbang/bin:/jbang/bin:ro
+      - ../../itests:/itests:ro
+    working_dir: /itests
+
+networks:
+  internet: {}
+  no-internet:
+    internal: true
+


### PR DESCRIPTION
This allows you to easily start up a proxy and a container with a shell
and JBang pre-installed that is only allowed to connect to the proxy.
Includes a README with some instructions.

See #447