### PR TITLE
chore: add explicit cast

### DIFF
--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -766,7 +766,7 @@ public class TestRun extends BaseTest {
 
 		assertThat(ctx.getMainClassOr(jar), equalTo("aclass"));
 
-		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), null)) {
+		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), (ClassLoader) null)) {
 			Path fileToExtract = fileSystem.getPath("META-INF/maven/dev/jbang/tests/pom.xml");
 
 			ByteArrayOutputStream s = new ByteArrayOutputStream();
@@ -1270,7 +1270,7 @@ public class TestRun extends BaseTest {
 
 		assertThat(ctx.getMainClassOr(jar), equalTo("resource"));
 
-		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), null)) {
+		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), (ClassLoader) null)) {
 
 			Arrays	.asList("resource.properties", "renamed.properties", "META-INF/application.properties")
 					.forEach(path -> {
@@ -1315,7 +1315,7 @@ public class TestRun extends BaseTest {
 
 		assertThat(ctx.getMainClassOr(jar), equalTo("one"));
 
-		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), null)) {
+		try (FileSystem fileSystem = FileSystems.newFileSystem(jar.getJarFile().toPath(), (ClassLoader) null)) {
 			Arrays	.asList("one.class", "Two.class", "gh_release_stats.class", "fetchlatestgraalvm.class")
 					.forEach(path -> {
 						try {
@@ -1560,7 +1560,7 @@ public class TestRun extends BaseTest {
 
 		ss.builder(ctx).build();
 
-		try (FileSystem fileSystem = FileSystems.newFileSystem(ss.getJarFile().toPath(), null)) {
+		try (FileSystem fileSystem = FileSystems.newFileSystem(ss.getJarFile().toPath(), (ClassLoader) null)) {
 			Arrays	.asList("one.class", "index.html")
 					.forEach(path -> {
 						try {


### PR DESCRIPTION
Because `java.nio.file.FileSystems#newFileSystem(java.nio.file.Path, java.util.Map<java.lang.String,?>)` was introduced in JDK 13+, using only `null` without casting leads to
compilation errors when building in JDK 17 for example



<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->