### PR TITLE
fix: ignore dependencies without GVA for integration

### DIFF
--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -78,7 +78,9 @@ public class IntegrationManager {
 			repos.put(repo.getId(), repo.getUrl());
 		}
 		for (ArtifactInfo art : ss.getClassPath().getArtifacts()) {
-			deps.put(art.getCoordinate().toCanonicalForm(), art.getFile().toPath());
+			if (art.getCoordinate() != null) { // skipping dependencies that does not have a GAV
+				deps.put(art.getCoordinate().toCanonicalForm(), art.getFile().toPath());
+			}
 		}
 
 		List<String> comments = source.getTags().collect(Collectors.toList());


### PR DESCRIPTION
if you use --class-path xyz.jar no GVA is present which currently makes integration calls fail.

This fixes it so NPE does not occur; but long term we should find a way to include classpath for integration calls.