### PR TITLE
feat: improve maven repo shorthand and logging

### DIFF
--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -11,7 +11,8 @@ public class DependencyInfoMixin {
 	@CommandLine.Option(names = {
 			"--deps" }, converter = CommaSeparatedConverter.class, description = "Add additional dependencies (Use commas to separate them).")
 	List<String> dependencies;
-	@CommandLine.Option(names = { "--repos" }, description = "Add additional repositories.")
+	@CommandLine.Option(names = {
+			"--repos" }, converter = CommaSeparatedConverter.class, description = "Add additional repositories.")
 	List<String> repositories;
 	@CommandLine.Option(names = { "--cp", "--class-path" }, description = "Add class path entries.")
 	List<String> classpaths;

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -5,6 +5,7 @@ import static dev.jbang.util.Util.errorMsg;
 import static dev.jbang.util.Util.infoHeader;
 import static dev.jbang.util.Util.infoMsg;
 import static dev.jbang.util.Util.infoMsgFmt;
+import static dev.jbang.util.Util.verboseMsg;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +56,11 @@ public class DependencyUtil {
 		aliasToRepos.put("google", "https://maven.google.com/");
 		aliasToRepos.put(ALIAS_JITPACK, REPO_JITPACK);
 		aliasToRepos.put("sponge", "https://repo.spongepowered.org/maven");
+		aliasToRepos.put("sonatype-snapshots", "https://oss.sonatype.org/content/repositories/snapshots");
+		aliasToRepos.put("s01sonatype-snapshots", "https://s01.oss.sonatype.org/content/repositories/snapshots");
+		aliasToRepos.put("spring-snapshot", "https://repo.spring.io/snapshot");
+		aliasToRepos.put("spring-milestone", "https://repo.spring.io/milestone");
+
 	}
 
 	public static final Pattern fullGavPattern = Pattern.compile(
@@ -100,6 +106,9 @@ public class DependencyUtil {
 		if (!depIds.equals(deps) && !repos.stream().anyMatch(r -> REPO_JITPACK.equals(r.getUrl()))) {
 			repos.add(toMavenRepo(ALIAS_JITPACK));
 		}
+
+		verboseMsg(String.format("Repositories: %s",
+				repos.stream().map(m -> m.toString()).collect(Collectors.joining(", "))));
 
 		String depsHash = String.join(CP_SEPARATOR, depIds);
 		if (!transitivity) { // the cached key need to be different for non-transivity


### PR DESCRIPTION
`--verbose` now print list of active maven repositories used for resolution.

`--deps` now work as comma separated list

spring-snapshot,spring-milestone,s01sonatype-snapshots and sontatype-snapshots now
available as short for maven repositories.

