### PR TITLE
fix: move away from java.io.File to Path/Files

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -27,15 +27,15 @@ public class Settings {
 
 	final public static String CP_SEPARATOR = File.pathSeparator;
 
-	public static File getLocalMavenRepo() {
-		return new File(System	.getenv()
+	public static Path getLocalMavenRepo() {
+		return Paths.get(System	.getenv()
 								.getOrDefault(JBANG_REPO,
 										(String) System	.getProperties()
 														.getOrDefault("maven.repo.local",
 																System.getProperty("user.home")
 																		+ File.separator + ".m2" + File.separator
 																		+ "repository")))
-																							.getAbsoluteFile();
+					.toAbsolutePath();
 	}
 
 	public static Path getCacheDependencyFile() {

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -212,7 +212,7 @@ class ExportMavenPublish extends BaseCommand implements Exporter {
 		Path outputPath = exportMixin.outputFile;
 
 		if (outputPath == null) {
-			outputPath = Settings.getLocalMavenRepo().toPath();
+			outputPath = Settings.getLocalMavenRepo();
 		}
 		// Copy the JAR or native binary
 		Path source = code.getJarFile().toPath();

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -7,8 +7,8 @@ import static dev.jbang.util.Util.infoMsg;
 import static dev.jbang.util.Util.infoMsgFmt;
 import static dev.jbang.util.Util.verboseMsg;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -160,7 +160,7 @@ public class DependencyUtil {
 
 		customRepos.forEach(mavenRepo -> mavenRepo.apply(resolver, updateCache));
 
-		System.setProperty("maven.repo.local", Settings.getLocalMavenRepo().toPath().toAbsolutePath().toString());
+		System.setProperty("maven.repo.local", Settings.getLocalMavenRepo().toAbsolutePath().toString());
 
 		Map<Boolean, List<MavenCoordinate>> coordList = depIds	.stream()
 																.map(DependencyUtil::depIdToArtifact)
@@ -201,7 +201,7 @@ public class DependencyUtil {
 			buf.append(afterDepMgmt);
 			Path pompath = null;
 			try {
-				pompath = File.createTempFile("jbang", ".xml").toPath();
+				pompath = Files.createTempFile("jbang", ".xml");
 				Util.writeString(pompath, buf.toString());
 			} catch (IOException e) {
 				throw new ExitException(CommandLine.ExitCode.SOFTWARE,

--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -276,11 +276,11 @@ public abstract class BaseBuilder implements Builder {
 	}
 
 	protected void runNativeBuilder(List<String> optionList) throws IOException {
-		File nilog = File.createTempFile("jbang", "native-image");
+		Path nilog = Files.createTempFile("jbang", "native-image");
 		Util.verboseMsg("native-image: " + String.join(" ", optionList));
 		Util.infoMsg("log: " + nilog.toString());
 
-		Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog).start();
+		Process process = new ProcessBuilder(optionList).inheritIO().redirectOutput(nilog.toFile()).start();
 		try {
 			process.waitFor();
 		} catch (InterruptedException e) {

--- a/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
@@ -2,9 +2,10 @@ package dev.jbang.source.generators;
 
 import static dev.jbang.source.builders.BaseBuilder.*;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import dev.jbang.cli.BaseCommand;
@@ -47,8 +48,8 @@ public abstract class BaseCmdGenerator implements CmdGenerator {
 		if (useArgsFile) {
 			// @-files avoid problems on Windows with very long command lines
 			final String javaCmd = escapeOSArgument(fullArgs.get(0), shell);
-			final File argsFile = File.createTempFile("jbang", ".args");
-			try (PrintWriter pw = new PrintWriter(argsFile)) {
+			final Path argsFile = Files.createTempFile("jbang", ".args");
+			try (PrintWriter pw = new PrintWriter(argsFile.toFile())) {
 				// write all arguments except the first to the file
 				for (int i = 1; i < fullArgs.size(); ++i) {
 					pw.println(escapeArgsFileArgument(fullArgs.get(i)));

--- a/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
@@ -1,8 +1,13 @@
 package dev.jbang.source.generators;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.text.StringEscapeUtils;
@@ -62,7 +67,7 @@ public class JshCmdGenerator extends BaseCmdGenerator {
 
 		optionalArgs.add("--startup=DEFAULT");
 
-		File tempFile = File.createTempFile("jbang_arguments_", ss.getResourceRef().getFile().getName());
+		Path tempFile = Files.createTempFile("jbang_arguments_", ss.getResourceRef().getFile().getName());
 
 		String defaultImports = "import java.lang.*;\n" +
 				"import java.util.*;\n" +
@@ -70,7 +75,7 @@ public class JshCmdGenerator extends BaseCmdGenerator {
 				"import java.net.*;" +
 				"import java.math.BigInteger;\n" +
 				"import java.math.BigDecimal;\n";
-		Util.writeString(tempFile.toPath(),
+		Util.writeString(tempFile,
 				defaultImports + generateArgs(ctx.getArguments(), ctx.getProperties()) +
 						generateStdInputHelper() +
 						generateMain(ctx.getMainClass()));
@@ -82,7 +87,7 @@ public class JshCmdGenerator extends BaseCmdGenerator {
 				Util.infoMsg("You can run the main class `" + ctx.getMainClass() + "` using: userMain(args)");
 			}
 		}
-		optionalArgs.add("--startup=" + tempFile.getAbsolutePath());
+		optionalArgs.add("--startup=" + tempFile.toAbsolutePath());
 
 		if (ctx.isDebugEnabled()) {
 			Util.warnMsg("debug not possible when running via jshell.");
@@ -107,8 +112,8 @@ public class JshCmdGenerator extends BaseCmdGenerator {
 		}
 
 		if (!ctx.isInteractive()) {
-			File exitFile = File.createTempFile("jbang_exit_", ss.getResourceRef().getFile().getName());
-			Util.writeString(exitFile.toPath(), "/exit");
+			Path exitFile = Files.createTempFile("jbang_exit_", ss.getResourceRef().getFile().getName());
+			Util.writeString(exitFile, "/exit");
 			fullArgs.add(exitFile.toString());
 		}
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1438,6 +1438,15 @@ public class Util {
 		}
 	}
 
+	public static boolean mkdirs(Path p) {
+		try {
+			Files.createDirectories(p);
+		} catch (IOException e) {
+			return false;
+		}
+		return true;
+	}
+
 	private static ImageIcon getJbangIcon() {
 		URL url = Util.class.getResource("/jbang_icon_64x64.png");
 		if (url != null) {

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -46,31 +46,31 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(s);
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		assertThat(new File(project, "src"), FileMatchers.anExistingDirectory());
-		File build = new File(project, "build.gradle");
-		assert (build.exists());
-		MatcherAssert.assertThat(Util.readString(build.toPath()), containsString("dependencies"));
-		File src = new File(project, "src/edit.java");
+		assertThat(project.resolve("src").toFile(), FileMatchers.anExistingDirectory());
+		Path build = project.resolve("build.gradle");
+		assert (Files.exists(build));
+		MatcherAssert.assertThat(Util.readString(build), containsString("dependencies"));
+		Path src = project.resolve("src/edit.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
 		// symlink cannot be created, as fallback a hardlink will be created.
-		assert (Files.isSymbolicLink(src.toPath()) || src.exists());
+		assert (Files.isSymbolicLink(src) || Files.exists(src));
 
 		// check eclipse is there
-		assertThat(Arrays.stream(project.listFiles()).map(File::getName).collect(Collectors.toList()),
+		assertThat(Files.list(project).map(p -> p.getFileName().toString()).collect(Collectors.toList()),
 				containsInAnyOrder(".project", ".classpath", ".eclipse", "src", "build.gradle", ".vscode",
 						"README.md"));
-		File launchfile = new File(project, ".eclipse/edit.launch");
-		assert (launchfile.exists());
-		assertThat(Util.readString(launchfile.toPath()), containsString("launching.PROJECT_ATTR"));
-		assertThat(Util.readString(launchfile.toPath()), containsString("PROGRAM_ARGUMENTS\" value=\"\""));
+		Path launchfile = project.resolve(".eclipse/edit.launch");
+		assert (Files.exists(launchfile));
+		assertThat(Util.readString(launchfile), containsString("launching.PROJECT_ATTR"));
+		assertThat(Util.readString(launchfile), containsString("PROGRAM_ARGUMENTS\" value=\"\""));
 
-		launchfile = new File(project, ".eclipse/edit-port-4004.launch");
-		assert (launchfile.exists());
-		assertThat(Util.readString(launchfile.toPath()), containsString("launching.PROJECT_ATTR"));
-		assertThat(Util.readString(launchfile.toPath()), containsString("4004"));
+		launchfile = project.resolve(".eclipse/edit-port-4004.launch");
+		assert (Files.exists(launchfile));
+		assertThat(Util.readString(launchfile), containsString("launching.PROJECT_ATTR"));
+		assertThat(Util.readString(launchfile), containsString("4004"));
 	}
 
 	@Test
@@ -86,24 +86,24 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(s);
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		String buildGradle = Util.readString(gradle.toPath());
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		String buildGradle = Util.readString(gradle);
 		assertThat(buildGradle, not(containsString("bogus")));
 		assertThat(buildGradle, containsString("id 'application'"));
 		assertThat(buildGradle, containsString("mainClass = 'edit'"));
 		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
 		assertThat(buildGradle, not(containsString("jitpack.io"))); // auto-added jitpack repo
 
-		File java = new File(project, "src/edit.java");
+		Path java = project.resolve("src/edit.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
 		// symlink cannot be created, as fallback a hardlink will be created.
-		assert (Files.isSymbolicLink(java.toPath()) || java.exists());
+		assert (Files.isSymbolicLink(java) || Files.exists(java));
 
-		assertThat(Files.isSameFile(java.toPath(), p), equalTo(true));
+		assertThat(Files.isSameFile(java, p), equalTo(true));
 	}
 
 	@Test
@@ -121,24 +121,24 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(s);
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		String buildGradle = Util.readString(gradle.toPath());
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		String buildGradle = Util.readString(gradle);
 		assertThat(buildGradle, not(containsString("bogus")));
 		assertThat(buildGradle, containsString("id 'application'"));
 		assertThat(buildGradle, containsString("mainClass = 'edit'"));
 		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
 		assertThat(buildGradle, not(containsString("jitpack.io"))); // auto-added jitpack repo
 
-		File java = new File(project, "src/edit.java");
+		Path java = project.resolve("src/edit.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
 		// symlink cannot be created, as fallback a hardlink will be created.
-		assert (Files.isSymbolicLink(java.toPath()) || java.exists());
+		assert (Files.isSymbolicLink(java) || Files.exists(java));
 
-		assertThat(Files.isSameFile(java.toPath(), p), equalTo(true));
+		assertThat(Files.isSameFile(java, p), equalTo(true));
 	}
 
 	@Test
@@ -154,11 +154,11 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(s);
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		String buildGradle = Util.readString(gradle.toPath());
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		String buildGradle = Util.readString(gradle);
 		assertThat(buildGradle, not(containsString("github.com"))); // should be com.github
 		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
 		assertThat(buildGradle, containsString("jitpack.io")); // auto-added jitpack repo
@@ -174,17 +174,17 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(p.toString());
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		assertThat(Util.readString(gradle.toPath()), not(containsString("bogus")));
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		assertThat(Util.readString(gradle), not(containsString("bogus")));
 
 		Arrays	.asList("one.java", "Two.java", "gh_fetch_release_assets.java", "gh_release_stats.java")
 				.forEach(f -> {
-					File java = new File(project, "src/" + f);
+					Path java = project.resolve("src/" + f);
 
-					assertThat(f + " not found", java, aReadableFile());
+					assertThat(f + " not found", java.toFile(), aReadableFile());
 				});
 	}
 
@@ -199,13 +199,13 @@ public class TestEdit extends BaseTest {
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(s);
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File java = new File(project, "src/KubeExample.java");
+		Path java = project.resolve("src/KubeExample.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
 		// symlink cannot be created, as fallback a hardlink will be created.
-		assert (Files.isSymbolicLink(java.toPath()) || java.exists());
+		assert (Files.isSymbolicLink(java) || Files.exists(java));
 	}
 
 	@Test
@@ -218,17 +218,17 @@ public class TestEdit extends BaseTest {
 		SourceSet ss = (SourceSet) ctx.forResource(p.toString());
 		ss.getClassPath();
 
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		assertThat(Util.readString(gradle.toPath()), not(containsString("bogus")));
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		assertThat(Util.readString(gradle), not(containsString("bogus")));
 
 		Arrays	.asList("resource.java", "resource.properties", "renamed.properties", "META-INF/application.properties")
 				.forEach(f -> {
-					File java = new File(project, "src/" + f);
+					Path java = project.resolve("src/" + f);
 
-					assertThat(f + " not found", java, aReadableFile());
+					assertThat(f + " not found", java.toFile(), aReadableFile());
 				});
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestEditWithPackage.java
+++ b/src/test/java/dev/jbang/cli/TestEditWithPackage.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -57,23 +56,23 @@ public class TestEditWithPackage extends BaseTest {
 		assertTrue(mainPath.toFile().exists());
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(mainPath.toString());
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
-		assertTrue(new File(project, "src/A.java").exists());
-		assertTrue(new File(project, "src/person/B.java").exists());
-		assertTrue(new File(project, "src/person/model/C.java").exists());
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		assertTrue(Files.exists(project.resolve("src/A.java")));
+		assertTrue(Files.exists(project.resolve("src/person/B.java")));
+		assertTrue(Files.exists(project.resolve("src/person/model/C.java")));
 
-		File javaC = new File(project, "src/person/model/C.java");
+		Path javaC = project.resolve("src/person/model/C.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
 		// symlink cannot be created, as fallback a hardlink will be created.
-		assertTrue(Files.isSymbolicLink(javaC.toPath()) || javaC.exists());
-		assertTrue(Files.isSameFile(javaC.toPath(), CPath));
+		assertTrue(Files.isSymbolicLink(javaC) || Files.exists(javaC));
+		assertTrue(Files.isSameFile(javaC, CPath));
 
 		Arrays	.asList("A.java", "person/B.java", "person/model/C.java")
 				.forEach(f -> {
-					File java = new File(project, "src/" + f);
+					Path java = project.resolve("src/" + f);
 
-					assertThat(f + " not found", java, aReadableFile());
+					assertThat(f + " not found", java.toFile(), aReadableFile());
 				});
 	}
 

--- a/src/test/java/dev/jbang/cli/TestEditWithPom.java
+++ b/src/test/java/dev/jbang/cli/TestEditWithPom.java
@@ -4,8 +4,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
@@ -49,12 +49,12 @@ public class TestEditWithPom extends BaseTest {
 		assertTrue(mainPath.toFile().exists());
 		RunContext ctx = RunContext.empty();
 		SourceSet ss = (SourceSet) ctx.forResource(mainPath.toString());
-		File project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
-		assertTrue(new File(project, "src/main.java").exists());
+		Path project = new Edit().createProjectForLinkedEdit(ss, ctx, false);
+		assertTrue(project.resolve("src/main.java").toFile().exists());
 
-		File gradle = new File(project, "build.gradle");
-		assert (gradle.exists());
-		String buildGradle = Util.readString(gradle.toPath());
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		String buildGradle = Util.readString(gradle);
 		assertThat(buildGradle, containsString("implementation platform")); // should be com.github
 
 	}

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -125,17 +125,17 @@ public class TestExport extends BaseTest {
 
 	@Test
 	void testExportMavenPublishWithClasspath() throws IOException {
-		File outFile = Settings.getLocalMavenRepo();
+		Path outFile = Settings.getLocalMavenRepo();
 		ExecutionResult result = checkedRun(null, "export", "mavenrepo", "--force",
 				"--group=g.a.v",
 				examplesTestFolder.resolve("classpath_log.java").toString());
 		assertThat(result.exitCode, equalTo(BaseCommand.EXIT_OK));
-		assertThat(outFile.toPath().resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),
+		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
-		assertThat(outFile.toPath().resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.pom").toFile(),
+		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.pom").toFile(),
 				anExistingFile());
 
-		Files	.walk(outFile.toPath().resolve("g"))
+		Files	.walk(outFile.resolve("g"))
 				.sorted(Comparator.reverseOrder())
 				.map(Path::toFile)
 				.forEach(File::delete);


### PR DESCRIPTION
Moves away from java.io.File to use Path and Masters

simplifies  and remove a bunch of unnecessary toPath transforms we have