### PR TITLE
fix: --sources now handle comma separated input

### DIFF
--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -61,7 +61,8 @@ class AliasAdd extends BaseAliasCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
-	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	@CommandLine.Option(names = { "-s",
+			"--sources" }, converter = CommaSeparatedConverter.class, description = "Add additional sources.")
 	List<String> sources;
 
 	@CommandLine.Option(names = { "--description",

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -17,7 +17,8 @@ public abstract class BaseBuildCommand extends BaseScriptCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
-	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	@CommandLine.Option(names = { "-s",
+			"--sources" }, converter = CommaSeparatedConverter.class, description = "Add additional sources.")
 	List<String> sources;
 
 	@CommandLine.Option(names = { "-m",

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -43,7 +43,8 @@ public class Edit extends BaseScriptCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
-	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	@CommandLine.Option(names = { "-s",
+			"--sources" }, converter = CommaSeparatedConverter.class, description = "Add additional sources.")
 	List<String> sources;
 
 	@CommandLine.Option(names = {

--- a/src/main/java/dev/jbang/cli/ExportMixin.java
+++ b/src/main/java/dev/jbang/cli/ExportMixin.java
@@ -31,7 +31,8 @@ public class ExportMixin {
 	}, description = "Force export, i.e. overwrite exported file if already exists")
 	boolean force;
 
-	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	@CommandLine.Option(names = { "-s",
+			"--sources" }, converter = CommaSeparatedConverter.class, description = "Add additional sources.")
 	List<String> sources;
 	@CommandLine.Parameters(paramLabel = "scriptOrFile", index = "0", description = "A file or URL to a Java code file", arity = "1")
 	String scriptOrFile;

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -31,7 +31,8 @@ abstract class BaseInfoCommand extends BaseScriptCommand {
 	@CommandLine.Mixin
 	DependencyInfoMixin dependencyInfoMixin;
 
-	@CommandLine.Option(names = { "-s", "--sources" }, description = "Add additional sources.")
+	@CommandLine.Option(names = { "-s",
+			"--sources" }, converter = CommaSeparatedConverter.class, description = "Add additional sources.")
 	List<String> sources;
 
 	static class ResourceFile {

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -151,7 +151,11 @@ public abstract class Source {
 				if (args.containsKey("ext")) {
 					gav = gav + "@" + args.get("ext");
 				}
-				return Stream.of(gav);
+				if (!gav.isEmpty()) { // protects when @Grab might be inside a string (like jbang source)
+					return Stream.of(gav);
+				} else {
+					return Stream.empty();
+				}
 			} else {
 				matcher = DEPS_ANNOT_SINGLE.matcher(line);
 				if (matcher.find()) {


### PR DESCRIPTION
Add comma separation handling to --sources + fix minor issue where "@Grab(" in jbang gets picked up when trying to build jbang with jbang.