### PR TITLE
fix: fixed certain commands not validating input correctly

### DIFF
--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -87,6 +87,7 @@ class AliasAdd extends BaseAliasCommand {
 
 	@Override
 	public Integer doCall() {
+		scriptMixin.validate();
 		if (name != null && !Catalog.isValidName(name)) {
 			throw new IllegalArgumentException(
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -37,6 +37,8 @@ public class Export {
 
 	static int handle(ExportMixin exportMixin,
 			Exporter style) throws IOException {
+		exportMixin.scriptMixin.validate();
+
 		RunContext ctx = getRunContext(exportMixin);
 		Code code = ctx.forResource(exportMixin.scriptMixin.scriptOrFile);
 

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -3,6 +3,7 @@ package dev.jbang.cli;
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -12,7 +13,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -308,6 +308,15 @@ public class TestAlias extends BaseTest {
 	}
 
 	@Test
+	void testAddMissingScript() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("alias", "add", "--name=name");
+			AliasAdd add = (AliasAdd) pr.subcommand().subcommand().commandSpec().userObject();
+			add.doCall();
+		});
+	}
+
+	@Test
 	void testGetAliasNone() throws IOException {
 		Alias alias = Alias.get("dummy-alias!");
 		assertThat(alias, nullValue());
@@ -395,7 +404,7 @@ public class TestAlias extends BaseTest {
 	void testGetAliasLoop() throws IOException {
 		try {
 			Alias.get("eight");
-			Assert.fail();
+			fail();
 		} catch (RuntimeException ex) {
 			assertThat(ex.getMessage(), containsString("seven"));
 		}

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,6 +27,8 @@ import dev.jbang.*;
 import dev.jbang.source.RunContext;
 import dev.jbang.source.SourceSet;
 import dev.jbang.util.Util;
+
+import picocli.CommandLine;
 
 public class TestEdit extends BaseTest {
 
@@ -230,5 +233,14 @@ public class TestEdit extends BaseTest {
 
 					assertThat(f + " not found", java.toFile(), aReadableFile());
 				});
+	}
+
+	@Test
+	void testEditMissingScript() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("edit");
+			Edit edit = (Edit) pr.subcommand().commandSpec().userObject();
+			edit.doCall();
+		});
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.hamcrest.io.FileMatchers.anExistingFileOrDirectory;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
 import dev.jbang.Settings;
+
+import picocli.CommandLine;
 
 public class TestExport extends BaseTest {
 
@@ -140,5 +143,14 @@ public class TestExport extends BaseTest {
 				.map(Path::toFile)
 				.forEach(File::delete);
 
+	}
+
+	@Test
+	void testExportMissingScript() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("export", "local");
+			ExportLocal export = (ExportLocal) pr.subcommand().subcommand().commandSpec().userObject();
+			export.doCall();
+		});
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1998,4 +1998,22 @@ public class TestRun extends BaseTest {
 			assertThat(sw.toString(), not(containsString("mavencentral=")));
 		}
 	}
+
+	@Test
+	void testBuildMissingScript() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build");
+			Build build = (Build) pr.subcommand().commandSpec().userObject();
+			build.doCall();
+		});
+	}
+
+	@Test
+	void testRunMissingScript() {
+		assertThrows(IllegalArgumentException.class, () -> {
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run");
+			Run run = (Run) pr.subcommand().commandSpec().userObject();
+			run.doCall();
+		});
+	}
 }


### PR DESCRIPTION
Fixes NPE that would happen if you leave out a required script
parameter for commands like export and alias add.

Fixes #1375

