### PR TITLE
fix: properly detect existing JDK on Macs

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -57,7 +57,7 @@ unpack() {
 }
 
 javacInPath() {
-  [[ -x "$(command -v javac)" && ( $os != "mac" || $(/usr/libexec/java_home &> /dev/null) ) ]]
+  [[ -x "$(command -v javac)" ]] && ( [[ $os != "mac" ]] || /usr/libexec/java_home &> /dev/null )
 }
 
 abs_jbang_dir=$(dirname "$(resolve_symlink "$(absolute_path "$0")")")


### PR DESCRIPTION
Fixes #1385

