### PR TITLE
fix: looking for compiler executables on Windows

### DIFF
--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -301,10 +301,9 @@ public abstract class BaseBuilder implements Builder {
 
 	private static String resolveInEnv(String env, String cmd) {
 		if (System.getenv(env) != null) {
-			if (Util.isWindows()) {
-				cmd = cmd + ".exe";
-			}
-			return new File(System.getenv(env)).toPath().resolve("bin").resolve(cmd).toAbsolutePath().toString();
+			Path dir = Paths.get(System.getenv(env)).toAbsolutePath().resolve("bin");
+			Path cmdPath = Util.searchPath(cmd, dir.toString());
+			return cmdPath != null ? cmdPath.toString() : cmd;
 		} else {
 			return cmd;
 		}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1197,14 +1197,25 @@ public class Util {
 	/**
 	 * Searches the locations defined by PATH for the given executable
 	 * 
-	 * @param name The name of the executable to look for
+	 * @param cmd The name of the executable to look for
 	 * @return A Path to the executable, if found, null otherwise
 	 */
-	public static Path searchPath(String name) {
+	public static Path searchPath(String cmd) {
 		String envPath = System.getenv("PATH");
 		envPath = envPath != null ? envPath : "";
-		return Arrays	.stream(envPath.split(File.pathSeparator))
-						.map(dir -> Paths.get(dir).resolve(name))
+		return searchPath(cmd, envPath);
+	}
+
+	/**
+	 * Searches the locations defined by `paths` for the given executable
+	 *
+	 * @param cmd   The name of the executable to look for
+	 * @param paths A string containing the paths to search
+	 * @return A Path to the executable, if found, null otherwise
+	 */
+	public static Path searchPath(String cmd, String paths) {
+		return Arrays	.stream(paths.split(File.pathSeparator))
+						.map(dir -> Paths.get(dir).resolve(cmd))
 						.flatMap(Util::executables)
 						.filter(Util::isExecutable)
 						.findFirst()


### PR DESCRIPTION
We no longer assume the compiler executables will always be .exe when
running on Windows. In fact in the latest Graal versions the
`native-image` executable is a .cmd file.

Fixes #1394