### PR TITLE
fix: don't add `Class-Path` by default to JARs

### DIFF
--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -208,18 +208,6 @@ public abstract class BaseBuilder implements Builder {
 
 		ss.getManifestAttributes().forEach((k, v) -> manifest.getMainAttributes().putValue(k, v));
 
-		if (ss.getMainSource().isAgent()) {
-			String bootClasspath = ctx.resolveClassPath(ss).getManifestPath();
-			if (!bootClasspath.isEmpty()) {
-				manifest.getMainAttributes().put(new Attributes.Name(ATTR_BOOT_CLASS_PATH), bootClasspath);
-			}
-		} else {
-			String classpath = ctx.resolveClassPath(ss).getManifestPath();
-			if (!classpath.isEmpty()) {
-				manifest.getMainAttributes().put(Attributes.Name.CLASS_PATH, classpath);
-			}
-		}
-
 		// When persistent JVM args are set they are appended to any runtime
 		// options set on the Source (that way persistent args can override
 		// options set on the Source)


### PR DESCRIPTION
We used to add absolute paths for all dependencies to the MANIFEST.MF
file inside the JAR files Jbang creates. But this is actually not
according to spec, paths may only be relative, but it often just
worked fine. Except that Graal's `native-image` transpiler doesn't
lke that at all. So now we don't generate those `Class-Path` entries
anymore by default, only when using `export local` and `export portable`
will the `Class-Path` be set.

Fixes #1396

