### PR TITLE
fix: info tools again generates info for nested sources

### DIFF
--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -109,6 +109,8 @@ abstract class BaseInfoCommand extends BaseCommand {
 		}
 
 		public ScriptInfo(Source source) {
+			originalResource = source.getResourceRef().getOriginalResource();
+			backingResource = source.getResourceRef().getFile().toString();
 			init(source);
 		}
 

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -111,6 +111,7 @@ public class TestInfo extends BaseTest {
 	@Test
 	void testInfoClasspathNested() {
 		String src = examplesTestFolder.resolve("sources.java").toString();
+		String quote = examplesTestFolder.resolve("quote.java").toString();
 		JBang jbang = new JBang();
 		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
@@ -125,6 +126,9 @@ public class TestInfo extends BaseTest {
 		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
 				hasSize(equalTo(1)),
 				everyItem(containsString("picocli"))));
+		assertThat(info.sources, hasSize(equalTo(1)));
+		assertThat(info.sources.get(0).originalResource, equalTo(quote));
+		assertThat(info.sources.get(0).backingResource, equalTo(quote));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #1425

Tests didn't check for this, now they do.