### PR TITLE
feat: Hide .project/.classpath from virtual project in VS Code

### DIFF
--- a/src/main/resources/settings.qute.json
+++ b/src/main/resources/settings.qute.json
@@ -5,6 +5,8 @@
     "files.exclude": {
         "bin/":true,
         ".eclipse/":true,
+        ".project":true,
+        ".classpath":true,
         "build.gradle":true
     }
 }


### PR DESCRIPTION
Hide .project/.classpath from virtual project in VS Code (when running `jbang edit`), as they're unnecessary noise