### PR TITLE
fix: change kotlinc's extension to .bat on Windows

### DIFF
--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -19,10 +19,9 @@ public class KotlinManager {
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);
 		if (kotlinHome != null) {
-			if (Util.isWindows()) {
-				cmd = cmd + ".bat";
-			}
-			return kotlinHome.resolve("bin").resolve(cmd).toAbsolutePath().toString();
+			Path dir = kotlinHome.toAbsolutePath().resolve("bin");
+			Path cmdPath = Util.searchPath(cmd, dir.toString());
+			return cmdPath != null ? cmdPath.toString() : cmd;
 		}
 		return cmd;
 	}

--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -20,7 +20,7 @@ public class KotlinManager {
 		Path kotlinHome = getKotlin(requestedVersion);
 		if (kotlinHome != null) {
 			if (Util.isWindows()) {
-				cmd = cmd + ".exe";
+				cmd = cmd + ".bat";
 			}
 			return kotlinHome.resolve("bin").resolve(cmd).toAbsolutePath().toString();
 		}


### PR DESCRIPTION
fixes #1433 