### PR TITLE
fix: handle quotes better for compiler call

### DIFF
--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -133,7 +133,7 @@ public abstract class BaseBuilder implements Builder {
 		if (!Util.isBlankString(path)) {
 			optionList.addAll(Arrays.asList("-classpath", escapeOSArgument(path, shell)));
 		}
-		optionList.addAll(Arrays.asList("-d", esacpeOSArgument(compileDir.toAbsolutePath().toString(), shell)));
+		optionList.addAll(Arrays.asList("-d", escapeOSArgument(compileDir.toAbsolutePath().toString(), shell)));
 
 		// add source files to compile
 		optionList.addAll(prj	.getMainSourceSet()

--- a/src/main/java/dev/jbang/source/builders/BaseBuilder.java
+++ b/src/main/java/dev/jbang/source/builders/BaseBuilder.java
@@ -131,9 +131,9 @@ public abstract class BaseBuilder implements Builder {
 		optionList.addAll(prj.getMainSourceSet().getCompileOptions());
 		String path = prj.resolveClassPath().getClassPath();
 		if (!Util.isBlankString(path)) {
-			optionList.addAll(Arrays.asList("-classpath", path));
+			optionList.addAll(Arrays.asList("-classpath", escapeOSArgument(path, shell)));
 		}
-		optionList.addAll(Arrays.asList("-d", compileDir.toAbsolutePath().toString()));
+		optionList.addAll(Arrays.asList("-d", esacpeOSArgument(compileDir.toAbsolutePath().toString(), shell)));
 
 		// add source files to compile
 		optionList.addAll(prj	.getMainSourceSet()


### PR DESCRIPTION
trying to fix kotlinc.bat bad behavior  (or rather windows lack of safe default quoting)
as discussed in https://github.com/jbangdev/jbang/issues/1447#issuecomment-1236013251

needs testing cross all OS versions.