### PR TITLE
fix: avoid infinite recursion with **.java

### DIFF
--- a/itests/sources/yang.java
+++ b/itests/sources/yang.java
@@ -1,0 +1,1 @@
+//SOURCES **.java

--- a/itests/sources/ying.java
+++ b/itests/sources/ying.java
@@ -1,0 +1,1 @@
+//SOURCES yang.java

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -109,8 +109,10 @@ abstract class BaseInfoCommand extends BaseCommand {
 
 		public ScriptInfo(Source source) {
 			originalResource = source.getResourceRef().getOriginalResource();
-			backingResource = source.getResourceRef().getFile().toString();
-			init(source);
+			if (scripts.add(originalResource)) {
+				backingResource = source.getResourceRef().getFile().toString();
+				init(source);
+			}
 		}
 
 		private void init(Project prj) {

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -152,4 +152,18 @@ public class TestInfo extends BaseTest {
 		assertThat(info.mainClass, equalTo("helloworld"));
 		assertThat(info.resolvedDependencies, empty());
 	}
+
+	@Test
+	void testInfoStarSources() {
+		String src = examplesTestFolder.resolve("sources/ying.java").toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
+		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
+		BaseInfoCommand.ScriptInfo info = tools.getInfo();
+		assertThat(info.originalResource, equalTo(src));
+		// assertThat(info.applicationJar, equalTo(src));
+		assertThat(info.backingResource, equalTo(src));
+		// assertThat(info.javaVersion, not(nullValue()));
+		// assertThat(info.mainClass, equalTo("helloworld"));
+		assertThat(info.resolvedDependencies, empty());
+	}
 }


### PR DESCRIPTION
Fixes #1464, but i'm not sure this is the right fix.

uses Project to know if already processed sources, but feels wrong that only Info.java has to change.