### PR TITLE
docs: fix typo in running.adoc

### DIFF
--- a/docs/modules/ROOT/pages/running.adoc
+++ b/docs/modules/ROOT/pages/running.adoc
@@ -19,7 +19,7 @@ endif::[]
 When using `--interactive` for java/jar scripts/apps jbang sets up a jshell function named `userMain`. `userMain` delegates to
 the main function that would have been called if not running in interactive. You can call it with arguments as follows `userMain(args)`.
 
-NOTE: One caveat about jshell is that it cannt access classes in default package. Thus you will need to add a package statement
+NOTE: One caveat about jshell is that it cannot access classes in default package. Thus you will need to add a package statement
 to your script/class to see it.
 
 == Flight Recorder


### PR DESCRIPTION
cannt -> cannot


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.

Details in https://github.com/zeke/semantic-pull-requests

If in doubt then open the pull-request and we'll help you - Thank you!
-->
