### PR TITLE
docs: update links to the Conventional Commits spec

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,9 @@ Please delete this text, and add description of the topic solved by this PR.
 
 To make releases as automated as possible we use conventional commits formats.
 Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
+See https://www.conventionalcommits.org/
 
-Details in https://github.com/zeke/semantic-pull-requests
+Details in https://github.com/Ezard/semantic-prs
 
 If in doubt then open the pull-request and we'll help you - Thank you!
 -->


### PR DESCRIPTION
The link in the template are outdated