### PR TITLE
feat: add Java 19 support for native image

### DIFF
--- a/src/main/java/dev/jbang/net/GroovyManager.java
+++ b/src/main/java/dev/jbang/net/GroovyManager.java
@@ -15,7 +15,7 @@ import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
 
 public class GroovyManager {
-	public static final String DEFAULT_GROOVY_VERSION = "3.0.9";
+	public static final String DEFAULT_GROOVY_VERSION = "3.0.13";
 
 	public static String resolveInGroovyHome(String cmd, String requestedVersion) {
 		Path groovyHome = getGroovy(requestedVersion);

--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -14,7 +14,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "1.6.10";
+	public static final String DEFAULT_KOTLIN_VERSION = "1.7.20";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -31,6 +31,12 @@ public class NativeBuildStep implements Builder<Project> {
 		List<String> optionList = new ArrayList<>();
 		optionList.add(resolveInGraalVMHome("native-image", project.getJavaVersion()));
 
+		final int actualVersion = JavaUtil.javaVersion(project.getJavaVersion());
+		if (actualVersion == 19) {
+			optionList.add("--enable-preview");
+			optionList.add("--add-modules=jdk.incubator.concurrent");
+		}
+
 		optionList.add("-H:+ReportExceptionStackTraces");
 
 		optionList.add("--enable-https");


### PR DESCRIPTION
- Add `--enable-preview` and `--add-modules=jdk.incubator.concurrent` for Java 19 native build
- Update Kotlin default version to `1.7.20`
- Update Groovy default version to `3.0.13`