### PR TITLE
fix: now actually passing native options to `nativeimage`

### DIFF
--- a/itests/helloworld.java
+++ b/itests/helloworld.java
@@ -1,5 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
+//NATIVE_OPTIONS -O1
 //RUNTIME_OPTIONS -Dfoo=bar "-Dbar=aap noot mies"
 //MANIFEST foo bar=baz baz=${bazprop:nada}
 

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -32,8 +32,8 @@ public class NativeBuildStep implements Builder<Project> {
 		optionList.add(resolveInGraalVMHome("native-image", project.getJavaVersion()));
 
 		optionList.add("-H:+ReportExceptionStackTraces");
-
 		optionList.add("--enable-https");
+		optionList.addAll(project.getMainSourceSet().getNativeOptions());
 
 		String classpath = project.resolveClassPath().getClassPath();
 		if (!Util.isBlankString(classpath)) {

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -459,6 +459,35 @@ public class TestBuilder extends BaseTest {
 			assertThat(attrs.getValue("bar"), equalTo("baz"));
 			assertThat(attrs.getValue("baz"), equalTo("algo"));
 		}
+	}
 
+	@Test
+	void testNative() throws IOException {
+		Path foo = examplesTestFolder.resolve("helloworld.java").toAbsolutePath();
+		ProjectBuilder pb = ProjectBuilder.create().nativeImage(true);
+		Project prj = pb.build(foo.toString());
+
+		new JavaSource.JavaAppBuilder(prj) {
+			@Override
+			protected Builder<Project> getCompileBuildStep() {
+				return new JavaCompileBuildStep() {
+					@Override
+					protected void runCompiler(List<String> optionList) {
+						// Skip the compiler
+					}
+				};
+			}
+
+			@Override
+			protected Builder<Project> getNativeBuildStep() {
+				return new NativeBuildStep(prj) {
+					@Override
+					protected void runNativeBuilder(List<String> optionList) throws IOException {
+						// Skip the native image builder
+						assertThat(optionList, hasItem("-O1"));
+					}
+				};
+			}
+		}.setFresh(true).build();
 	}
 }


### PR DESCRIPTION
This is a fix for PR #1494 which implemented all the necessary API and UI elements.... but didn't actually pass the options to the native image builder :roll_eyes: 