### PR TITLE
fix: ensure cache jdks directory exists before creating link

### DIFF
--- a/src/main/java/dev/jbang/net/JdkManager.java
+++ b/src/main/java/dev/jbang/net/JdkManager.java
@@ -211,6 +211,7 @@ public class JdkManager {
 		if (ver.isPresent()) {
 			Integer linkedJdkVersion = ver.get();
 			if (linkedJdkVersion == version) {
+				Util.mkdirs(jdkPath.getParent());
 				Util.createLink(jdkPath, linkedJdkPath);
 				Util.infoMsg("JDK " + version + " has been linked to: " + linkedJdkPath);
 			} else {


### PR DESCRIPTION
After installing jbang through sdkman ==> `sdk install jbang`. I wanted jbang to use an already installed jdk version from sdk, so I ran the command `jbang jdk install 17 $(sdk home java 17.0.5-tem)`

I got the following error :

> [jbang] java.nio.file.NoSuchFileException: /home/john/.jbang/cache/jdks/17
[jbang] Creation of symbolic link failed.
[jbang] Now try creating a hard link instead of symbolic.
[jbang] Creation of hard link failed. Script must be on the same drive as $JBANG_CACHE_DIR (typically under $HOME) for hardlink creation to work. Or call the command with admin rights.
[jbang] [ERROR] java.nio.file.NoSuchFileException: /home/john/.jbang/cache/jdks/17 -> /home/john/.sdkman/candidates/java/17.0.5-tem
[jbang] Run with --verbose for more details 

Jbang is trying to create a symbolic link, whereas the cache jdks folder (`~/.jbang/cache/jdks`) doesn't exist.

This fix ensures the cache jdks directory exists before trying to create the symbolic link. 