### PR TITLE
feat: honor JBANG_DOWNLOAD_VERSION in bootstrap setup

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -144,11 +144,15 @@ elif [ -f "$abs_jbang_dir/.jbang/jbang.jar" ]; then
   jarPath=$abs_jbang_dir/.jbang/jbang.jar
 else
   if [[ ! -f "$JBDIR/bin/jbang.jar" || ! -f "$JBDIR/bin/jbang" ]]; then
-    echo "Downloading JBang..." 1>&2
+    echo "Downloading JBang $JBANG_DOWNLOAD_VERSION..." 1>&2
     mkdir -p "$TDIR/urls"
-    jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar"
+    if [ -z "$JBANG_DOWNLOAD_VERSION" ]; then
+      jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar";
+    else
+      jburl="https://github.com/jbangdev/jbang/releases/download/v$JBANG_DOWNLOAD_VERSION/jbang.tar";
+    fi
     download $jburl "$TDIR/urls/jbang.tar"
-    if [ $retval -ne 0 ]; then echo "Error downloading JBang" 1>&2; exit $retval; fi
+    if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
     echo "Installing JBang..." 1>&2
     rm -rf "$TDIR/urls/jbang"
     tar xf "$TDIR/urls/jbang.tar" -C "$TDIR/urls"

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -70,9 +70,9 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
     if (-not (Test-Path env:JBANG_DOWNLOAD_VERSION)) {
         $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
     } else {
-        $jburl="https://github.com/jbangdev/jbang/releases/download/v$JBANG_DOWNLOAD_VERSION/jbang.zip";
+        $jburl="https://github.com/jbangdev/jbang/releases/download/v$env:JBANG_DOWNLOAD_VERSION/jbang.zip";
     }
-    [Console]::Error.WriteLine("Downloading JBang $JBANG_DOWNLOAD_VERSION...")
+    [Console]::Error.WriteLine("Downloading JBang $env:JBANG_DOWNLOAD_VERSION...")
     try { Invoke-WebRequest "$jburl" -OutFile "$TDIR\urls\jbang.zip"; $ok=$? } catch {
       $ok=$false
       $err=$_

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -66,9 +66,13 @@ if (Test-Path "$PSScriptRoot\jbang.jar") {
   $jarPath="$PSScriptRoot\.jbang\jbang.jar"
 } else {
   if (-not (Test-Path "$JBDIR\bin\jbang.jar") -or -not (Test-Path "$JBDIR\bin\jbang.ps1")) {
-    [Console]::Error.WriteLine("Downloading JBang...")
     New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
-    $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
+    if (-not (Test-Path env:JBANG_DOWNLOAD_VERSION)) {
+        $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
+    } else {
+        $jburl="https://github.com/jbangdev/jbang/releases/download/v$JBANG_DOWNLOAD_VERSION/jbang.zip";
+    }
+    [Console]::Error.WriteLine("Downloading JBang $JBANG_DOWNLOAD_VERSION...")
     try { Invoke-WebRequest "$jburl" -OutFile "$TDIR\urls\jbang.zip"; $ok=$? } catch {
       $ok=$false
       $err=$_


### PR DESCRIPTION
allows to do:

`curl -Ls https://sh.jbang.dev | JBANG_DOWNLOAD_VERSION=0.99.2 bash -s - app setup`

Similar for Windows but haven't tested it - thus marking this draft for now.