### PR TITLE
fix: apply auth from global settings to repositories and use ~/.m2/se…

### DIFF
--- a/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
+++ b/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
@@ -155,11 +155,13 @@ public class ArtifactResolver {
 		settings = newEffectiveSettings();
 		session = newSession(system, settings);
 		configureSession(session, settings);
+		List<RemoteRepository> partialRepos;
 		if (builder.repositories != null) {
-			repositories = builder.repositories.stream().map(this::toRemoteRepo).collect(Collectors.toList());
+			partialRepos = builder.repositories.stream().map(this::toRemoteRepo).collect(Collectors.toList());
 		} else {
-			repositories = newRepositories();
+			partialRepos = newRepositories();
 		}
+		repositories = system.newResolutionRepositories(session, partialRepos);
 	}
 
 	public List<ArtifactInfo> resolve(List<String> depIds) {
@@ -302,6 +304,7 @@ public class ArtifactResolver {
 		return new RemoteRepository.Builder(repo.getId(), "default", repo.getUrl())
 																					.setPolicy(getUpdatePolicy())
 																					.build();
+
 	}
 
 	private static Dependency toDependency(Artifact artifact) {
@@ -354,13 +357,13 @@ public class ArtifactResolver {
 			// find the settings
 			Path settingsFile = settingsXml;
 			if (settingsFile == null) {
-				Path userSettings = Paths.get(System.getProperty("user.home"), ".m2", "settings.xml");
-				if (Files.exists(userSettings)) {
-					settingsFile = userSettings.toAbsolutePath();
+				Path globalSettings = Paths.get(System.getProperty("user.home"), ".m2", "settings.xml");
+				if (Files.exists(globalSettings)) {
+					settingsFile = globalSettings.toAbsolutePath();
 				}
 			}
 			if (settingsFile != null) {
-				settingsBuilderRequest.setUserSettingsFile(settingsFile.toFile());
+				settingsBuilderRequest.setGlobalSettingsFile(settingsFile.toFile());
 			}
 		}
 


### PR DESCRIPTION
…ttings.xml as global rather than user settings

fixes #1504 

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
