### PR TITLE
only add -g for javac invocations.

### DIFF
--- a/itests/helloworld.kt
+++ b/itests/helloworld.kt
@@ -1,0 +1,11 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+// //DEPS <dependency1> <dependency2>
+//NATIVE_OPTIONS -O1
+//RUNTIME_OPTIONS -Dfoo=bar "-Dbar=aap noot mies"
+//MANIFEST foo bar=baz baz=${bazprop:nada}
+
+class helloworld {
+    fun main(vararg args: String) {
+        println("Hello " + if (args.length>0) args[0] else "World"));
+    }
+}

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -38,7 +38,6 @@ public abstract class CompileBuildStep implements Builder<Project> {
 		Path compileDir = project.getBuildDir();
 		List<String> optionList = new ArrayList<>();
 		optionList.add(getCompilerBinary(requestedJavaVersion));
-		optionList.add("-g");
 		optionList.addAll(project.getMainSourceSet().getCompileOptions());
 		String path = project.resolveClassPath().getClassPath();
 		if (!Util.isBlankString(path)) {

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -2,6 +2,7 @@ package dev.jbang.source.sources;
 
 import static dev.jbang.util.JavaUtil.resolveInJavaHome;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -10,6 +11,7 @@ import dev.jbang.source.AppBuilder;
 import dev.jbang.source.buildsteps.CompileBuildStep;
 import dev.jbang.source.buildsteps.IntegrationBuildStep;
 import dev.jbang.spi.IntegrationResult;
+import dev.jbang.util.Util;
 
 public class JavaSource extends Source {
 
@@ -27,7 +29,9 @@ public class JavaSource extends Source {
 
 	@Override
 	protected List<String> getCompileOptions() {
-		return tagReader.collectOptions("JAVAC_OPTIONS", "COMPILE_OPTIONS");
+		List<String> jopts = Collections.singletonList("-g");
+		List<String> opts = tagReader.collectOptions("JAVAC_OPTIONS", "COMPILE_OPTIONS");
+		return Util.join(jopts, opts);
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -48,7 +48,7 @@ public class KotlinSource extends Source {
 						.orElse(KotlinManager.DEFAULT_KOTLIN_VERSION);
 	}
 
-	private static class KotlinAppBuilder extends AppBuilder {
+	public static class KotlinAppBuilder extends AppBuilder {
 		public KotlinAppBuilder(Project project) {
 			super(project);
 		}
@@ -63,7 +63,7 @@ public class KotlinSource extends Source {
 			return new KotlinIntegrationBuildStep();
 		}
 
-		private class KotlinCompileBuildStep extends CompileBuildStep {
+		protected class KotlinCompileBuildStep extends CompileBuildStep {
 
 			public KotlinCompileBuildStep() {
 				super(KotlinAppBuilder.this.project);

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -25,6 +25,8 @@ import dev.jbang.catalog.CatalogUtil;
 import dev.jbang.source.buildsteps.JarBuildStep;
 import dev.jbang.source.buildsteps.NativeBuildStep;
 import dev.jbang.source.sources.JavaSource;
+import dev.jbang.source.sources.JavaSource.JavaAppBuilder.JavaCompileBuildStep;
+import dev.jbang.source.sources.KotlinSource;
 import dev.jbang.util.Util;
 
 public class TestBuilder extends BaseTest {
@@ -62,6 +64,26 @@ public class TestBuilder extends BaseTest {
 					@Override
 					protected void runCompiler(List<String> optionList) {
 						assertThat(optionList, hasItems(foo.toString(), "-g", "--foo", "--bar"));
+						// Skip the compiler
+					}
+				};
+			}
+		}.setFresh(true).build();
+	}
+
+	@Test
+	void testKotlinCompileOptions() throws IOException {
+		Path foo = examplesTestFolder.resolve("helloworld.kt").toAbsolutePath();
+		ProjectBuilder pb = ProjectBuilder.create().compileOptions(Arrays.asList("--foo", "--bar"));
+		Project prj = pb.build(foo.toString());
+
+		new KotlinSource.KotlinAppBuilder(prj) {
+			@Override
+			protected Builder<Project> getCompileBuildStep() {
+				return new KotlinCompileBuildStep() {
+					@Override
+					protected void runCompiler(List<String> optionList) {
+						assertThat(optionList, hasItems(foo.toString(), "--foo", "--bar"));
 						// Skip the compiler
 					}
 				};

--- a/src/test/java/dev/jbang/source/TestSource.java
+++ b/src/test/java/dev/jbang/source/TestSource.java
@@ -284,7 +284,7 @@ public class TestSource extends BaseTest {
 	void testExtractOptions() {
 		Source s = new JavaSource(example, null);
 
-		assertEquals(Arrays.asList("--verbose", "--enable-preview"), s.getCompileOptions());
+		assertEquals(Arrays.asList("-g", "--verbose", "--enable-preview"), s.getCompileOptions());
 		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
 		assertEquals(Arrays.asList("--enable-preview", "--enable-preview", "-Dvalue='this is space'"),
 				s.getRuntimeOptions());


### PR DESCRIPTION
Only add -g for javac invocations so kotlin scripts can be compiled.

fixes #1512


