### PR TITLE
feat: mastodon url support

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -45,7 +45,6 @@ import javax.swing.*;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.parser.Parser;
 
 import com.google.gson.Gson;
 
@@ -504,11 +503,11 @@ public class Util {
 
 	/**
 	 * Swizzles the content retrieved from sites that are known to possibly embed
-	 * code (i.e. twitter and carbon)
+	 * code (i.e. mastodon and carbon)
 	 */
 	public static Path swizzleContent(String fileURL, Path filePath) throws IOException {
-		boolean twitter = fileURL.startsWith("https://mobile.twitter.com");
-		if (twitter || fileURL.startsWith("https://carbon.now.sh")) { // sites known
+		boolean mastodon = fileURL.matches("https://.*/@(\\w+)/([0-9]+)");
+		if (mastodon || fileURL.startsWith("https://carbon.now.sh")) { // sites known
 																		// to have
 																		// og:description
 																		// meta name or
@@ -517,22 +516,19 @@ public class Util {
 				Document doc = Jsoup.parse(filePath.toFile(), "UTF-8", fileURL);
 
 				String proposedString = null;
-				if (twitter) {
-					proposedString = doc.select("div[class=dir-ltr]").first().wholeText().trim();
-				} else {
-					proposedString = doc.select("meta[property=og:description],meta[name=og:description]")
-										.first()
-										.attr("content");
-				}
 
-				if (twitter) {
-					// remove fake quotes
-					// proposedString = proposedString.replace("\u201c", "");
-					// proposedString = proposedString.replace("\u201d", "");
-					// unescape properly
-					proposedString = Parser.unescapeEntities(proposedString, true);
+				proposedString = doc.select("meta[property=og:description],meta[name=og:description]")
+									.first()
+									.attr("content");
 
-				}
+				/*
+				 * if (twitter) { // remove fake quotes // proposedString =
+				 * proposedString.replace("\u201c", ""); // proposedString =
+				 * proposedString.replace("\u201d", ""); // unescape properly proposedString =
+				 * Parser.unescapeEntities(proposedString, true);
+				 * 
+				 * }
+				 */
 
 				if (proposedString != null) {
 					Matcher m = mainClassPattern.matcher(proposedString);

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1068,6 +1068,12 @@ public class TestRun extends BaseTest {
 		verifyHello("https://twitter.com/maxandersen/status/1266329490927616001", dir);
 	}
 
+	@Test
+	void testFetchFromMastdon(@TempDir Path dir) throws IOException {
+		verifyHello("https://mastodon.social/@maxandersen/109361828562755062", dir);
+		verifyHello("https://fosstodon.org/@jbangdev/109367735752497165", dir);
+	}
+
 	/*
 	 * carbon gist rate limited so it fails
 	 *


### PR DESCRIPTION
Twitter blocked no-javascript access but mastodon does not have this issue.

Thus this PR enables you to do this: 

`jbang https://fosstodon.org/@jbangdev/109367735752497165`

it will match any URL that matches `https://.*/@(\w+)/([0-9]+)` which afaics are fairly specific to mastodon style urls.