### PR TITLE
fix: Fixes the "The system cannot find the path specified" (#1520)

### DIFF
--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -51,7 +51,7 @@ if "!JAVA_EXEC!"=="" (
     rem Check if we installed a JDK before
     if not exist "%TDIR%\jdks\%javaVersion%" (
       rem If not, download and install it
-      echo powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 jdk install %JBANG_DEFAULT_JAVA_VERSION%"
+      powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 jdk install %JBANG_DEFAULT_JAVA_VERSION%"
       if !ERRORLEVEL! NEQ 0 ( exit /b %ERRORLEVEL% )
       rem Set the current JDK
       "!JAVA_EXEC!" -classpath "%jarPath%" dev.jbang.Main jdk default "%javaVersion%"


### PR DESCRIPTION
Tested the change by:

1. Downloaded 101.0 zip on Windows Sandbox
2. Extracted the zip
3. Modified jbang.cmd:

Before:

```
echo powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 jdk install %JBANG_DEFAULT_JAVA_VERSION%"
```

After:

```
powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 jdk install %JBANG_DEFAULT_JAVA_VERSION%"
```

4. Run jbang

![image](https://user-images.githubusercontent.com/143570/204715627-4ea8569e-74ef-4745-a654-4d3e9592e3bd.png)