### PR TITLE
fix: make integrations work again

### DIFF
--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -67,6 +67,7 @@ public abstract class Source {
 		return new TagReader.Extended(contents, replaceProperties);
 	}
 
+	@Nonnull
 	public Stream<String> getTags() {
 		return tagReader.getTags();
 	}

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -36,6 +36,7 @@ import dev.jbang.dependencies.ArtifactInfo;
 import dev.jbang.dependencies.MavenRepo;
 import dev.jbang.source.Project;
 import dev.jbang.source.Source;
+import dev.jbang.util.JavaUtil;
 import dev.jbang.util.PathTypeAdapter;
 import dev.jbang.util.Util;
 
@@ -89,8 +90,9 @@ public class IntegrationManager {
 						comments,
 						prj.isNativeImage());
 				IntegrationResult ir = requestedJavaVersion == null
-						? runIntegrationEmbedded(input, integrationCl)
-						: runIntegrationExternal(input, requestedJavaVersion);
+						|| JavaUtil.satisfiesRequestedVersion(requestedJavaVersion, JavaUtil.determineJavaVersion())
+								? runIntegrationEmbedded(input, integrationCl)
+								: runIntegrationExternal(input, requestedJavaVersion);
 				result = result.merged(ir);
 			}
 		} catch (ClassNotFoundException e) {

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -92,7 +92,7 @@ public class IntegrationManager {
 				IntegrationResult ir = requestedJavaVersion == null
 						|| JavaUtil.satisfiesRequestedVersion(requestedJavaVersion, JavaUtil.determineJavaVersion())
 								? runIntegrationEmbedded(input, integrationCl)
-								: runIntegrationExternal(input, requestedJavaVersion);
+								: runIntegrationExternal(input, prj.getProperties(), requestedJavaVersion);
 				result = result.merged(ir);
 			}
 		} catch (ClassNotFoundException e) {
@@ -209,13 +209,18 @@ public class IntegrationManager {
 		return new IntegrationResult(nativeImage, mainClass, javaArgs);
 	}
 
-	private static IntegrationResult runIntegrationExternal(IntegrationInput input, String requestedJavaVersion)
+	private static IntegrationResult runIntegrationExternal(IntegrationInput input,
+			Map<String, String> properties,
+			String requestedJavaVersion)
 			throws Exception {
 		Gson parser = gsonb.create();
 		Util.infoMsg("Running external post build for " + input.integrationClassName);
 
 		List<String> args = new ArrayList<>();
 		args.add(resolveInJavaHome("java", requestedJavaVersion)); // TODO
+		for (Map.Entry<String, String> entry : properties.entrySet()) {
+			args.add("-D" + entry.getKey() + "=" + entry.getValue());
+		}
 		args.add("-cp");
 		args.add(Util.getJarLocation().toString());
 		args.add("dev.jbang.spi.IntegrationManager");

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -74,7 +74,7 @@ public class IntegrationManager {
 			}
 		}
 
-		List<String> comments = source.getTags().collect(Collectors.toList());
+		List<String> comments = source.getTags().map(s -> "//" + s).collect(Collectors.toList());
 		ClassLoader old = Thread.currentThread().getContextClassLoader();
 		PrintStream oldout = System.out;
 		try {


### PR DESCRIPTION
- properly passing tags to the integrations again
- fixed that the integrations were running externally in too many cases where the current JVM was matching but wasn't used.
- passing properties to external integrations
