### PR TITLE
feat: adding auto download for sources via edit and JBANG_DOWNLOAD_SOURCES=true

### DIFF
--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -119,6 +119,10 @@ And finally if the link you provide is to a specific branch of the project then 
 In case you prefer `jbang` to just fail-fast when dependencies cannot be found locally you can run `jbang` in offline mode using
 `jbang -o` or `jbang --offline`. In this mode `jbang` will simply fail if dependencies have not been cached already.
 
+== Downloading Sources
+
+JBang can download sources for your dependencies and make them available in your IDE. `jbang edit` will do it automatically but you can also enable it globally by setting environment variable `JBANG_DOWNLOAD_SOURCES` to `true`.
+
 == Repositories
 
 By default `jbang` uses https://repo1.maven.org/maven2/[maven central]. In past it used `jcenter` but with its imminent shutdown deemed best to use central.

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -32,4 +32,5 @@ public class DependencyInfoMixin {
 	public Map<String, String> getProperties() {
 		return properties;
 	}
+
 }

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -60,6 +60,9 @@ public class Edit extends BaseCommand {
 	public Integer doCall() throws IOException {
 		scriptMixin.validate();
 
+		// force download sources when editing
+		Util.setDownloadSources(true);
+
 		ProjectBuilder pb = createProjectBuilder();
 		final Project prj = pb.build(scriptMixin.scriptOrFile);
 

--- a/src/main/java/dev/jbang/dependencies/DependencyResolver.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyResolver.java
@@ -79,7 +79,7 @@ public class DependencyResolver {
 	public ModularClassPath resolve() {
 		ModularClassPath mcp = DependencyUtil.resolveDependencies(
 				new ArrayList<>(dependencies), new ArrayList<>(repositories),
-				Util.isOffline(), Util.isFresh(), !Util.isQuiet());
+				Util.isOffline(), Util.isFresh(), !Util.isQuiet(), Util.downloadSources());
 		if (artifacts.isEmpty()) {
 			return mcp;
 		} else {

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -55,7 +55,7 @@ public class DependencyUtil {
 	 * @return string with resolved classpath
 	 */
 	public static ModularClassPath resolveDependencies(List<String> deps, List<MavenRepo> repos,
-			boolean offline, boolean updateCache, boolean loggingEnabled) {
+			boolean offline, boolean updateCache, boolean loggingEnabled, boolean downloadSources) {
 
 		// if no dependencies were provided we stop here
 		if (deps.isEmpty()) {
@@ -107,6 +107,7 @@ public class DependencyUtil {
 																.offline(offline)
 																.forceCacheUpdate(updateCache)
 																.logging(loggingEnabled)
+																.downloadSources(downloadSources)
 																.build();
 			List<ArtifactInfo> artifacts = resolver.resolve(depIds);
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -63,6 +63,7 @@ public class Util {
 	public static final String JBANG_STDIN_NOTTY = "JBANG_STDIN_NOTTY";
 	public static final String JBANG_AUTH_BASIC_USERNAME = "JBANG_AUTH_BASIC_USERNAME";
 	public static final String JBANG_AUTH_BASIC_PASSWORD = "JBANG_AUTH_BASIC_PASSWORD";
+	private static final String JBANG_DOWNLOAD_SOURCES = "JBANG_DOWNLOAD_SOURCES";
 
 	public static final Pattern patternMainMethod = Pattern.compile(
 			"^.*(public\\s+static|static\\s+public)\\s+void\\s+main\\s*\\(.*",
@@ -76,7 +77,9 @@ public class Util {
 	private static boolean offline;
 	private static boolean fresh;
 	private static boolean preview;
+
 	private static Path cwd;
+	private static Boolean downloadSources;
 
 	public static void setVerbose(boolean verbose) {
 		Util.verbose = verbose;
@@ -105,6 +108,17 @@ public class Util {
 		if (offline) {
 			setFresh(false);
 		}
+	}
+
+	public static void setDownloadSources(boolean flag) {
+		downloadSources = flag;
+	}
+
+	public static boolean downloadSources() {
+		if (downloadSources == null) {
+			downloadSources = Boolean.valueOf(System.getenv(JBANG_DOWNLOAD_SOURCES));
+		}
+		return downloadSources;
 	}
 
 	public static boolean isOffline() {

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -137,7 +137,7 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Arrays.asList("com.offbytwo:docopt:0.6.0.20150202", "log4j:log4j:1.2+");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		// if returns 5 its because optional deps are included which they shouldn't
 		assertEquals(2, classpath.getClassPaths().size());
@@ -149,7 +149,7 @@ class DependencyResolverTest extends BaseTest {
 				"org.apache.commons:commons-text:1.8");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		// if returns with duplicates its because some dependencies are multiple times
 		// in the
@@ -170,7 +170,7 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Collections.singletonList("com.github.docker-java:docker-java:3.1.5");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		assertEquals(46, classpath.getClassPaths().size());
 	}
@@ -181,7 +181,8 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Arrays.asList("org.openjfx:javafx-graphics:11.0.2:mac", "com.offbytwo:docopt:0.6+");
 
 		ModularClassPath cp = new ModularClassPath(
-				DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false, true).getArtifacts()) {
+				DependencyUtil	.resolveDependencies(deps, Collections.emptyList(), false, false, true, false)
+								.getArtifacts()) {
 			@Override
 			protected boolean supportsModules(String requestedVersion) {
 				return true;
@@ -202,7 +203,7 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Arrays.asList("com.microsoft.azure:azure-bom:1.0.0.M1@pom", "com.microsoft.azure:azure");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		assertEquals(62, classpath.getArtifacts().size());
 	}
@@ -218,7 +219,7 @@ class DependencyResolverTest extends BaseTest {
 				"org.slf4j:slf4j-simple:1.7.30");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		Optional<ArtifactInfo> coord = classpath.getArtifacts()
 												.stream()
@@ -250,7 +251,7 @@ class DependencyResolverTest extends BaseTest {
 				"org.apache.camel:camel-core",
 				"org.apache.camel:camel-vertx",
 				"org.slf4j:slf4j-simple:1.7.30");
-		classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false, true);
+		classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false, true, false);
 
 		coord = classpath	.getArtifacts()
 							.stream()
@@ -265,7 +266,7 @@ class DependencyResolverTest extends BaseTest {
 		List<String> deps = Arrays.asList("org.infinispan:infinispan-commons:13.0.5.Final@test-jar");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		assertThat(classpath.getArtifacts(), hasSize(7));
 		ArtifactInfo ai = classpath.getArtifacts().get(0);

--- a/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
+++ b/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
@@ -25,7 +25,7 @@ public class TestArtifactInfo extends BaseTest {
 				"org.apache.commons:commons-text:1.8");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
-				true);
+				true, false);
 
 		DependencyCache.cache("wonka", classpath.getArtifacts());
 


### PR DESCRIPTION
adding option to have jbang download sources for dependencies.

approach is a bit a naive and will only work if all //DEPS resolves properly but simply
takes the resolved set and then one by one try resolve matching sources classifier.