### PR TITLE
fix: we don't blindly import JAR metadata anymore

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -6,7 +6,6 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 
 import dev.jbang.source.*;
-import dev.jbang.util.Util;
 
 import picocli.CommandLine;
 
@@ -49,7 +48,6 @@ public abstract class BaseBuildCommand extends BaseCommand {
 								.compileOptions(buildMixin.compileOptions)
 								.nativeImage(nativeMixin.nativeImage)
 								.nativeOptions(nativeMixin.nativeOptions)
-								.buildDir(buildDir)
-								.skipMetadataImport(Util.isFresh());
+								.buildDir(buildDir);
 	}
 }

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -93,8 +93,7 @@ abstract class BaseExportCommand extends BaseCommand {
 								.catalog(exportMixin.scriptMixin.catalog)
 								.javaVersion(exportMixin.buildMixin.javaVersion)
 								.mainClass(exportMixin.buildMixin.main)
-								.compileOptions(exportMixin.buildMixin.compileOptions)
-								.skipMetadataImport(Util.isFresh());
+								.compileOptions(exportMixin.buildMixin.compileOptions);
 	}
 }
 

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -22,7 +22,6 @@ import dev.jbang.net.JdkManager;
 import dev.jbang.net.JdkProvider;
 import dev.jbang.source.*;
 import dev.jbang.util.JavaUtil;
-import dev.jbang.util.Util;
 
 import picocli.CommandLine;
 
@@ -119,10 +118,6 @@ abstract class BaseInfoCommand extends BaseCommand {
 						resolvedDependencies = Arrays.asList(cp.split(CP_SEPARATOR));
 					}
 
-					// TODO remove if everything okay
-					// if (prj.isJar() && prj.getBuildJdk() > 0) {
-					// javaVersion = Integer.toString(prj.getBuildJdk());
-					// }
 					if (prj.getJavaVersion() != null) {
 						javaVersion = Integer.toString(JavaUtil.parseJavaVersion(prj.getJavaVersion()));
 					}
@@ -130,6 +125,12 @@ abstract class BaseInfoCommand extends BaseCommand {
 					List<String> opts = prj.getRuntimeOptions();
 					if (!opts.isEmpty()) {
 						runtimeOptions = opts;
+					}
+
+					if (prj.getJarFile() != null && Files.exists(prj.getJarFile())) {
+						Project jarProject = ProjectBuilder.create().build(prj.getJarFile());
+						mainClass = jarProject.getMainClass();
+						gav = jarProject.getGav().orElse(gav);
 					}
 				}
 			}
@@ -207,8 +208,7 @@ abstract class BaseInfoCommand extends BaseCommand {
 								.additionalResources(scriptMixin.resources)
 								.forceType(scriptMixin.forceType)
 								.catalog(scriptMixin.catalog)
-								.buildDir(buildDir)
-								.skipMetadataImport(Util.isFresh());
+								.buildDir(buildDir);
 	}
 
 }

--- a/src/main/java/dev/jbang/source/AppBuilder.java
+++ b/src/main/java/dev/jbang/source/AppBuilder.java
@@ -55,16 +55,20 @@ public abstract class AppBuilder implements Builder<Project> {
 		} else if (nativeBuildRequired) {
 			Util.verboseMsg("Building as native build required.");
 		} else if (Files.isReadable(outjar)) {
+			Project jarProject = ProjectBuilder.create().build(outjar);
 			// We already have a Jar, check if we can still use it
 			if (!project.isUpToDate()) {
 				Util.verboseMsg("Building as previous build jar found but it or its dependencies not up-to-date.");
 			} else if (JavaUtil.javaVersion(requestedJavaVersion) < JavaUtil.minRequestedVersion(
-					project.getJavaVersion())) {
+					jarProject.getJavaVersion())) {
 				Util.verboseMsg(
 						String.format(
 								"Building as requested Java version %s < than the java version used during last build %s",
 								requestedJavaVersion, project.getJavaVersion()));
 			} else {
+				if (project.getMainClass() == null) {
+					project.setMainClass(jarProject.getMainClass());
+				}
 				Util.verboseMsg("No build required. Reusing jar from " + project.getJarFile());
 				buildRequired = false;
 			}

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -63,7 +63,6 @@ public class ProjectBuilder {
 	private String debugString;
 	private Boolean classDataSharing;
 	private Path buildDir;
-	private boolean skipMetadataImport;
 
 	public static ProjectBuilder create() {
 		return new ProjectBuilder();
@@ -235,11 +234,6 @@ public class ProjectBuilder {
 		return this;
 	}
 
-	public ProjectBuilder skipMetadataImport(boolean skipMetadataImport) {
-		this.skipMetadataImport = skipMetadataImport;
-		return this;
-	}
-
 	private Properties getContextProperties() {
 		if (contextProperties == null) {
 			contextProperties = getContextProperties(properties);
@@ -359,20 +353,11 @@ public class ProjectBuilder {
 			}
 		}
 
-		if (!skipMetadataImport) {
-			return importJarMetadata(updateProject(prj));
-		} else {
-			return updateProject(prj);
-		}
+		return updateProject(prj);
 	}
 
 	private Project createSourceProject(ResourceRef resourceRef) {
-		Project prj = createSource(resourceRef).createProject(getResourceResolver());
-		if (!skipMetadataImport) {
-			return importJarMetadata(updateProject(prj));
-		} else {
-			return updateProject(prj);
-		}
+		return updateProject(createSource(resourceRef).createProject(getResourceResolver()));
 	}
 
 	private Source createSource(ResourceRef resourceRef) {
@@ -383,7 +368,6 @@ public class ProjectBuilder {
 
 	private Project importJarMetadata(Project prj) {
 		ResourceRef resourceRef = prj.getResourceRef();
-		prj.setCacheDir(buildDir);
 		Path jar = prj.getJarFile();
 		if (jar != null && Files.exists(jar)) {
 			try (JarFile jf = new JarFile(jar.toFile())) {
@@ -411,12 +395,6 @@ public class ProjectBuilder {
 						Util.verboseMsg("Unable to read the JAR's pom.xml file", e);
 					}
 				}
-
-				// TODO should be removed
-				// String val = attrs.getValue(BaseBuilder.ATTR_JBANG_JAVA_OPTIONS);
-				// if (val != null) {
-				// prj.addRuntimeOptions(Project.quotedStringToList(val));
-				// }
 
 				String ver = attrs.getValue(JarBuildStep.ATTR_BUILD_JDK);
 				if (ver != null) {
@@ -494,6 +472,7 @@ public class ProjectBuilder {
 		if (nativeImage != null) {
 			prj.setNativeImage(nativeImage);
 		}
+		prj.setCacheDir(buildDir);
 		prj.setCmdGeneratorFactory(() -> createCmdGenerator(prj));
 		return prj;
 	}

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -48,7 +48,6 @@ public class TestInfo extends BaseTest {
 		assertThat(info.applicationJar, allOf(
 				containsString("quote.java."),
 				endsWith(".jar")));
-		assertThat(Integer.parseInt(info.javaVersion), greaterThan(0));
 		assertThat(info.mainClass, equalTo("quote"));
 		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
 				hasSize(equalTo(1)),


### PR DESCRIPTION
We added a way to skip importing metadata into a Project if a JAR was available locally, but that was still causing problems in certain situations. For example if you would compile with Java 19 and then uninstall Java 19 leaving an earlier version, let's say Java 11, jbang would try to download Java 19 just to run the code, even though nothing in the source indicated that was necessary. In that case it's much more convenient to simply recompile the code with Java 11. The solution now is to not import the metadata into the Project anymore, but to make it an explicit action of reading the information and let the code that does the reading decide what to do with it.

