### PR TITLE
chore: `app setup` now tells user about `--force`

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -436,6 +436,7 @@ class AppSetup extends BaseCommand {
 			Util.infoMsg("Setting up JBang environment...");
 		} else if (chatty) {
 			Util.infoMsg("JBang environment is already set up.");
+			Util.infoMsg("(You can use --force to perform the setup anyway)");
 		}
 		if (Util.getShell() == Util.Shell.bash) {
 			if (changed) {


### PR DESCRIPTION
When the user runs `app setup` when, according to Jbang, the environment was already set up correctly a message will be shown that the user can add the `--force` flag to perform the setup anyway.

See #1524

