### PR TITLE
fix: Groovy compiler now runs correctly

### DIFF
--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -96,7 +96,7 @@ public class GroovySource extends Source {
 				if (project.getMainSource() instanceof GroovySource) {
 					processBuilder	.environment()
 									.put("JAVA_HOME",
-											JdkManager.getOrInstallJdk(project.getJavaVersion()).toString());
+											JdkManager.getOrInstallJdk(project.getJavaVersion()).getHome().toString());
 					processBuilder.environment().remove("GROOVY_HOME");
 				}
 				super.runCompiler(processBuilder);


### PR DESCRIPTION
The `JAVA_HOME` wasn't being set up correctly. This was a regression.

Fixes #1554

