### PR TITLE
refactor: extracted build state from `Project`

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -26,6 +26,7 @@ import dev.jbang.catalog.CatalogUtil;
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.net.JdkManager;
 import dev.jbang.net.JdkProvider;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.CommandBuffer;
@@ -117,7 +118,7 @@ class AppInstall extends BaseCommand {
 				&& !prj.getResourceRef().isURL()) {
 			scriptRef = prj.getResourceRef().getFile().toAbsolutePath().toString();
 		}
-		prj.builder().build();
+		prj.builder(BuildContext.forProject(prj)).build();
 		installScripts(name, scriptRef, benative);
 		Util.infoMsg("Command installed: " + name);
 		return true;

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -47,7 +47,6 @@ public abstract class BaseBuildCommand extends BaseCommand {
 								.mainClass(buildMixin.main)
 								.compileOptions(buildMixin.compileOptions)
 								.nativeImage(nativeMixin.nativeImage)
-								.nativeOptions(nativeMixin.nativeOptions)
-								.buildDir(buildDir);
+								.nativeOptions(nativeMixin.nativeOptions);
 	}
 }

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -2,6 +2,8 @@ package dev.jbang.cli;
 
 import java.io.IOException;
 
+import dev.jbang.source.BuildContext;
+import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 
 import picocli.CommandLine.Command;
@@ -15,7 +17,8 @@ public class Build extends BaseBuildCommand {
 		jdkProvidersMixin.initJdkProviders();
 
 		ProjectBuilder pb = createProjectBuilder();
-		pb.build(scriptMixin.scriptOrFile).builder().build();
+		Project prj = pb.build(scriptMixin.scriptOrFile);
+		prj.builder(BuildContext.forProject(prj, buildDir)).build();
 
 		return EXIT_OK;
 	}

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -21,6 +21,7 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import dev.jbang.Settings;
 import dev.jbang.dependencies.ArtifactInfo;
 import dev.jbang.dependencies.MavenCoordinate;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.JarUtil;
@@ -82,11 +83,13 @@ abstract class BaseExportCommand extends BaseCommand {
 	public Integer doCall() throws IOException {
 		exportMixin.validate();
 		ProjectBuilder pb = createProjectBuilder(exportMixin);
-		Project prj = pb.build(exportMixin.scriptMixin.scriptOrFile).builder().build();
-		return apply(prj, pb);
+		Project prj = pb.build(exportMixin.scriptMixin.scriptOrFile);
+		BuildContext ctx = BuildContext.forProject(prj);
+		prj.builder(ctx).build();
+		return apply(prj, ctx);
 	}
 
-	abstract int apply(Project prj, ProjectBuilder pb) throws IOException;
+	abstract int apply(Project prj, BuildContext ctx) throws IOException;
 
 	protected ProjectBuilder createProjectBuilder(ExportMixin exportMixin) {
 		return ProjectBuilder
@@ -118,9 +121,9 @@ abstract class BaseExportCommand extends BaseCommand {
 class ExportLocal extends BaseExportCommand {
 
 	@Override
-	int apply(Project prj, ProjectBuilder pb) throws IOException {
+	int apply(Project prj, BuildContext ctx) throws IOException {
 		// Copy the JAR
-		Path source = prj.getJarFile();
+		Path source = ctx.getJarFile();
 		Path outputPath = getJarOutputPath();
 		if (outputPath.toFile().exists()) {
 			if (exportMixin.force) {
@@ -155,9 +158,9 @@ class ExportPortable extends BaseExportCommand {
 	public static final String LIB = "lib";
 
 	@Override
-	int apply(Project prj, ProjectBuilder pb) throws IOException {
+	int apply(Project prj, BuildContext ctx) throws IOException {
 		// Copy the JAR
-		Path source = prj.getJarFile();
+		Path source = ctx.getJarFile();
 		Path outputPath = getJarOutputPath();
 		if (outputPath.toFile().exists()) {
 			if (exportMixin.force) {
@@ -205,14 +208,14 @@ class ExportMavenPublish extends BaseExportCommand {
 	String version;
 
 	@Override
-	int apply(Project prj, ProjectBuilder pb) throws IOException {
+	int apply(Project prj, BuildContext ctx) throws IOException {
 		Path outputPath = exportMixin.outputFile;
 
 		if (outputPath == null) {
 			outputPath = Settings.getLocalMavenRepo();
 		}
 		// Copy the JAR
-		Path source = prj.getJarFile();
+		Path source = ctx.getJarFile();
 
 		if (!outputPath.toFile().isDirectory()) {
 			if (outputPath.toFile().exists()) {
@@ -306,9 +309,9 @@ class ExportMavenPublish extends BaseExportCommand {
 class ExportNative extends BaseExportCommand {
 
 	@Override
-	int apply(Project prj, ProjectBuilder pb) throws IOException {
+	int apply(Project prj, BuildContext ctx) throws IOException {
 		// Copy the native binary
-		Path source = prj.getNativeImageFile();
+		Path source = ctx.getNativeImageFile();
 		Path outputPath = getNativeOutputPath();
 		if (outputPath.toFile().exists()) {
 			if (exportMixin.force) {
@@ -345,9 +348,9 @@ class ExportNative extends BaseExportCommand {
 class ExportFatjar extends BaseExportCommand {
 
 	@Override
-	int apply(Project prj, ProjectBuilder pb) throws IOException {
+	int apply(Project prj, BuildContext ctx) throws IOException {
 		// Copy the native binary
-		Path source = prj.getJarFile();
+		Path source = ctx.getJarFile();
 		Path outputPath = getFatjarOutputPath();
 		if (outputPath.toFile().exists()) {
 			if (exportMixin.force) {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -9,6 +9,7 @@ import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.source.Source;
@@ -102,7 +103,8 @@ public class Run extends BaseBuildCommand {
 			}
 		}
 
-		prj.builder().build();
+		BuildContext ctx = BuildContext.forProject(prj, buildDir);
+		prj.builder(ctx).build();
 
 		if (Boolean.TRUE.equals(nativeMixin.nativeImage)
 				&& (scriptMixin.forceType == Source.Type.jshell || prj.isJShell())) {
@@ -110,7 +112,7 @@ public class Run extends BaseBuildCommand {
 			pb.nativeImage(false);
 		}
 
-		String cmdline = prj.cmdGenerator().generate();
+		String cmdline = prj.cmdGenerator(ctx).generate();
 		debug("run: " + cmdline);
 		out.println(cmdline);
 
@@ -133,8 +135,7 @@ public class Run extends BaseBuildCommand {
 				String javaAgentOptions = agentOption.getValue();
 				ProjectBuilder apb = super.createProjectBuilder();
 				Project aprj = apb.build(javaAgent);
-				aprj.addRuntimeOption("-javaagent:" + aprj.getJarFile()
-						+ (javaAgentOptions != null ? "=" + javaAgentOptions : ""));
+				aprj.addRuntimeOption("-javaagent:$JAR$" + (javaAgentOptions != null ? "=" + javaAgentOptions : ""));
 				pb.addJavaAgent(aprj);
 			}
 		}

--- a/src/main/java/dev/jbang/source/BuildContext.java
+++ b/src/main/java/dev/jbang/source/BuildContext.java
@@ -1,0 +1,82 @@
+package dev.jbang.source;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.annotation.Nonnull;
+
+import dev.jbang.Cache;
+import dev.jbang.Settings;
+import dev.jbang.util.Util;
+
+public class BuildContext {
+	private final Project project;
+	private final Path buildDir;
+
+	public static BuildContext forProject(Project project) {
+		return forProject(project, null);
+	}
+
+	public static BuildContext forProject(Project project, Path buildDirOverride) {
+		if (buildDirOverride != null) {
+			return new BuildContext(project, buildDirOverride);
+		} else {
+			return new BuildContext(project, getBuildDir(project));
+		}
+	}
+
+	@Nonnull
+	private static Path getBuildDir(Project project) {
+		Path baseDir = Settings.getCacheDir(Cache.CacheClass.jars);
+		return baseDir.resolve(
+				project.getResourceRef().getFile().getFileName() + "." + project.getMainSourceSet().getStableId());
+	}
+
+	private BuildContext(Project project, Path buildDir) {
+		this.project = project;
+		this.buildDir = buildDir;
+	}
+
+	public BuildContext forSubProject(Project subProject, String subProjectTypeName) {
+		return forProject(subProject, buildDir.resolve(subProjectTypeName));
+	}
+
+	public Path getJarFile() {
+		if (project.isJShell()) {
+			return null;
+		} else if (project.isJar()) {
+			return project.getResourceRef().getFile();
+		} else {
+			return getBasePath(".jar");
+		}
+	}
+
+	public Path getNativeImageFile() {
+		if (project.isJShell()) {
+			return null;
+		}
+		if (Util.isWindows()) {
+			return getBasePath(".exe");
+		} else {
+			return getBasePath(".bin");
+		}
+	}
+
+	public Path getCompileDir() {
+		return buildDir.resolve("classes");
+	}
+
+	@Nonnull
+	private Path getBasePath(String extension) {
+		return buildDir.resolve(
+				Util.sourceBase(project.getResourceRef().getFile().getFileName().toString()) + extension);
+	}
+
+	/**
+	 * Determines if the associated jar is up-to-date, returns false if it needs to
+	 * be rebuilt
+	 */
+	public boolean isUpToDate() {
+		return getJarFile() != null && Files.exists(getJarFile()) && project.resolveClassPath().isValid();
+	}
+}

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -82,7 +82,7 @@ public abstract class Source {
 
 	protected abstract List<String> getRuntimeOptions();
 
-	public abstract Builder<Project> getBuilder(Project prj);
+	public abstract Builder<Project> getBuilder(Project prj, BuildContext ctx);
 
 	public ResourceRef getResourceRef() {
 		return resourceRef;
@@ -105,26 +105,16 @@ public abstract class Source {
 	}
 
 	/**
-	 * Creates and returns a new <code>Project</code> that has been initialized with
-	 * all relevant information from this <code>Source</code>. Uses a default
-	 * resolver that only knows about resources so this can not be used for
-	 * compiling code (see <code>ProjectBuilder.forResource()</code> for that).
+	 * Updates the given <code>Project</code> with all the information from this
+	 * <code>Source</code> when that source is the main file. It updates certain
+	 * things at the project level and then calls <code>updateProject()</code> which
+	 * will update things at the <code>SourceSet</code> level.
 	 *
-	 * @return A <code>Project</code>
-	 */
-	public Project createProject() {
-		return createProject(ResourceResolver.forResources());
-	}
-
-	/**
-	 * Creates and returns a new <code>Project</code> that has been initialized with
-	 * all relevant information from this <code>Source</code>.
-	 *
+	 * @param prj      The <code>Project</code> to update
 	 * @param resolver The resolver to use for dependent (re)sources
 	 * @return A <code>Project</code>
 	 */
-	public Project createProject(ResourceResolver resolver) {
-		Project prj = new Project(this);
+	public Project updateProjectMain(Project prj, ResourceResolver resolver) {
 		prj.setDescription(tagReader.getDescription().orElse(null));
 		prj.setGav(tagReader.getGav().orElse(null));
 		return updateProject(prj, resolver);

--- a/src/main/java/dev/jbang/source/buildsteps/IntegrationBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/IntegrationBuildStep.java
@@ -21,6 +21,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.Type;
 
 import dev.jbang.cli.ExitException;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Builder;
 import dev.jbang.source.Project;
 import dev.jbang.spi.IntegrationManager;
@@ -35,6 +36,7 @@ import dev.jbang.util.Util;
  */
 public abstract class IntegrationBuildStep implements Builder<IntegrationResult> {
 	private final Project project;
+	private final BuildContext ctx;
 
 	public static final Type STRINGARRAYTYPE = Type.create(DotName.createSimple("[Ljava.lang.String;"),
 			Type.Kind.ARRAY);
@@ -42,15 +44,16 @@ public abstract class IntegrationBuildStep implements Builder<IntegrationResult>
 	public static final Type INSTRUMENTATIONTYPE = Type.create(
 			DotName.createSimple("java.lang.instrument.Instrumentation"), Type.Kind.CLASS);
 
-	public IntegrationBuildStep(Project project) {
+	public IntegrationBuildStep(Project project, BuildContext ctx) {
 		this.project = project;
+		this.ctx = ctx;
 	}
 
 	@Override
 	public IntegrationResult build() throws IOException {
 		// todo: setting properties to avoid loosing properties in integration call.
-		Path compileDir = project.getBuildDir();
-		Path pomPath = CompileBuildStep.getPomPath(project);
+		Path compileDir = ctx.getCompileDir();
+		Path pomPath = CompileBuildStep.getPomPath(project, ctx);
 		Properties old = System.getProperties();
 		Properties temp = new Properties(System.getProperties());
 		for (Map.Entry<String, String> entry : project.getProperties().entrySet()) {

--- a/src/main/java/dev/jbang/source/buildsteps/JarBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/JarBuildStep.java
@@ -10,6 +10,7 @@ import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
 import dev.jbang.source.AppBuilder;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Builder;
 import dev.jbang.source.Project;
 import dev.jbang.util.CommandBuffer;
@@ -23,18 +24,20 @@ import dev.jbang.util.Util;
  */
 public class JarBuildStep implements Builder<Project> {
 	private final Project project;
+	private final BuildContext ctx;
 
 	public static final String ATTR_BUILD_JDK = "Build-Jdk";
 	public static final String ATTR_JBANG_JAVA_OPTIONS = "JBang-Java-Options";
 	public static final String ATTR_BOOT_CLASS_PATH = "Boot-Class-Path";
 
-	public JarBuildStep(Project project) {
+	public JarBuildStep(Project project, BuildContext ctx) {
 		this.project = project;
+		this.ctx = ctx;
 	}
 
 	@Override
 	public Project build() throws IOException {
-		createJar(project, project.getBuildDir(), project.getJarFile());
+		createJar(project, ctx.getCompileDir(), ctx.getJarFile());
 		return project;
 	}
 

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import dev.jbang.cli.ExitException;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Builder;
 import dev.jbang.source.Project;
 import dev.jbang.util.CommandBuffer;
@@ -22,9 +23,11 @@ import dev.jbang.util.Util;
  */
 public class NativeBuildStep implements Builder<Project> {
 	private final Project project;
+	private final BuildContext ctx;
 
-	public NativeBuildStep(Project project) {
+	public NativeBuildStep(Project project, BuildContext ctx) {
 		this.project = project;
+		this.ctx = ctx;
 	}
 
 	public Project build() throws IOException {
@@ -41,7 +44,7 @@ public class NativeBuildStep implements Builder<Project> {
 		}
 
 		optionList.add("-jar");
-		optionList.add(project.getJarFile().toString());
+		optionList.add(ctx.getJarFile().toString());
 
 		optionList.add(getNativeImageOutputName().toString());
 
@@ -56,7 +59,7 @@ public class NativeBuildStep implements Builder<Project> {
 	 * `.exe` to the name!
 	 */
 	private Path getNativeImageOutputName() {
-		Path image = project.getNativeImageFile();
+		Path image = ctx.getNativeImageFile();
 		if (Util.isWindows()) {
 			// NB: On Windows the compiler always adds `.exe` to the name!
 			// So we remove the extension from the name before returning it

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -16,7 +16,6 @@ import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
 
 public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
-	private final Project project;
 
 	private boolean assertions;
 	private boolean systemAssertions;
@@ -43,13 +42,8 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 		return this;
 	}
 
-	public JarCmdGenerator(Project prj) {
-		this.project = prj;
-	}
-
-	@Override
-	protected Project getProject() {
-		return project;
+	public JarCmdGenerator(Project prj, BuildContext ctx) {
+		super(prj, ctx);
 	}
 
 	@Override
@@ -91,11 +85,11 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 			Util.verboseMsg("Flight recording enabled with:" + jfropt);
 		}
 
-		if (project.getJarFile() != null) {
+		if (ctx.getJarFile() != null) {
 			if (Util.isBlankString(classpath)) {
-				classpath = project.getJarFile().toAbsolutePath().toString();
+				classpath = ctx.getJarFile().toAbsolutePath().toString();
 			} else {
-				classpath = project.getJarFile().toAbsolutePath() + Settings.CP_SEPARATOR + classpath.trim();
+				classpath = ctx.getJarFile().toAbsolutePath() + Settings.CP_SEPARATOR + classpath.trim();
 			}
 		}
 		if (!Util.isBlankString(classpath)) {
@@ -104,7 +98,7 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 		}
 
 		if (classDataSharing || project.enableCDS()) {
-			Path cdsJsa = project.getJarFile().toAbsolutePath();
+			Path cdsJsa = ctx.getJarFile().toAbsolutePath();
 			if (Files.exists(cdsJsa)) {
 				Util.verboseMsg("CDS: Using shared archive classes from " + cdsJsa);
 				optionalArgs.add("-XX:SharedArchiveFile=" + cdsJsa);

--- a/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
@@ -17,7 +17,6 @@ import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
 
 public class JshCmdGenerator extends BaseCmdGenerator<JshCmdGenerator> {
-	private final Project project;
 	private boolean interactive;
 
 	public JshCmdGenerator interactive(boolean interactive) {
@@ -25,13 +24,8 @@ public class JshCmdGenerator extends BaseCmdGenerator<JshCmdGenerator> {
 		return this;
 	}
 
-	public JshCmdGenerator(Project project) {
-		this.project = project;
-	}
-
-	@Override
-	protected Project getProject() {
-		return project;
+	public JshCmdGenerator(Project prj, BuildContext ctx) {
+		super(prj, ctx);
 	}
 
 	@Override
@@ -42,7 +36,7 @@ public class JshCmdGenerator extends BaseCmdGenerator<JshCmdGenerator> {
 
 		List<String> optionalArgs = new ArrayList<>();
 
-		String requestedJavaVersion = getProject().getJavaVersion();
+		String requestedJavaVersion = project.getJavaVersion();
 		String javacmd;
 		javacmd = JavaUtil.resolveInJavaHome("jshell", requestedJavaVersion);
 

--- a/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
@@ -6,29 +6,24 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.CmdGenerator;
 import dev.jbang.source.Project;
 import dev.jbang.util.Util;
 
 public class NativeCmdGenerator extends BaseCmdGenerator<NativeCmdGenerator> {
-	private final Project project;
 	private final CmdGenerator fallback;
 
-	public NativeCmdGenerator(Project prj, CmdGenerator fallback) {
-		this.project = prj;
+	public NativeCmdGenerator(Project prj, BuildContext ctx, CmdGenerator fallback) {
+		super(prj, ctx);
 		this.fallback = fallback;
-	}
-
-	@Override
-	protected Project getProject() {
-		return project;
 	}
 
 	@Override
 	public String generate() throws IOException {
 		List<String> fullArgs = new ArrayList<>();
 
-		Path image = project.getNativeImageFile();
+		Path image = ctx.getNativeImageFile();
 		if (Files.exists(image)) {
 			fullArgs.add(image.toString());
 		} else {

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -61,13 +61,13 @@ public class GroovySource extends Source {
 	}
 
 	@Override
-	public Builder<Project> getBuilder(Project prj) {
-		return new GroovyAppBuilder(prj);
+	public Builder<Project> getBuilder(Project prj, BuildContext ctx) {
+		return new GroovyAppBuilder(prj, ctx);
 	}
 
 	private static class GroovyAppBuilder extends AppBuilder {
-		public GroovyAppBuilder(Project project) {
-			super(project);
+		public GroovyAppBuilder(Project project, BuildContext ctx) {
+			super(project, ctx);
 		}
 
 		@Override
@@ -83,7 +83,7 @@ public class GroovySource extends Source {
 		private class GroovyCompileBuildStep extends CompileBuildStep {
 
 			public GroovyCompileBuildStep() {
-				super(GroovyAppBuilder.this.project);
+				super(GroovyAppBuilder.this.project, GroovyAppBuilder.this.ctx);
 			}
 
 			@Override
@@ -105,7 +105,7 @@ public class GroovySource extends Source {
 
 		private class GroovyIntegrationBuildStep extends IntegrationBuildStep {
 			public GroovyIntegrationBuildStep() {
-				super(GroovyAppBuilder.this.project);
+				super(GroovyAppBuilder.this.project, GroovyAppBuilder.this.ctx);
 			}
 
 			@Override

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -45,13 +45,13 @@ public class JavaSource extends Source {
 	}
 
 	@Override
-	public Builder<Project> getBuilder(Project prj) {
-		return new JavaAppBuilder(prj);
+	public Builder<Project> getBuilder(Project prj, BuildContext ctx) {
+		return new JavaAppBuilder(prj, ctx);
 	}
 
 	public static class JavaAppBuilder extends AppBuilder {
-		public JavaAppBuilder(Project project) {
-			super(project);
+		public JavaAppBuilder(Project project, BuildContext ctx) {
+			super(project, ctx);
 		}
 
 		@Override
@@ -67,7 +67,7 @@ public class JavaSource extends Source {
 		public class JavaCompileBuildStep extends CompileBuildStep {
 
 			public JavaCompileBuildStep() {
-				super(JavaAppBuilder.this.project);
+				super(JavaAppBuilder.this.project, JavaAppBuilder.this.ctx);
 			}
 
 			@Override
@@ -78,7 +78,7 @@ public class JavaSource extends Source {
 
 		public class JavaIntegrationBuildStep extends IntegrationBuildStep {
 			public JavaIntegrationBuildStep() {
-				super(JavaAppBuilder.this.project);
+				super(JavaAppBuilder.this.project, JavaAppBuilder.this.ctx);
 			}
 
 			@Override

--- a/src/main/java/dev/jbang/source/sources/JshSource.java
+++ b/src/main/java/dev/jbang/source/sources/JshSource.java
@@ -14,7 +14,7 @@ public class JshSource extends JavaSource {
 	}
 
 	@Override
-	public Builder<Project> getBuilder(Project prj) {
+	public Builder<Project> getBuilder(Project prj, BuildContext ctx) {
 		return () -> prj;
 	}
 }

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -37,8 +37,8 @@ public class KotlinSource extends Source {
 	}
 
 	@Override
-	public Builder<Project> getBuilder(Project prj) {
-		return new KotlinAppBuilder(prj);
+	public Builder<Project> getBuilder(Project prj, BuildContext ctx) {
+		return new KotlinAppBuilder(prj, ctx);
 	}
 
 	public String getKotlinVersion() {
@@ -49,8 +49,8 @@ public class KotlinSource extends Source {
 	}
 
 	public static class KotlinAppBuilder extends AppBuilder {
-		public KotlinAppBuilder(Project project) {
-			super(project);
+		public KotlinAppBuilder(Project project, BuildContext ctx) {
+			super(project, ctx);
 		}
 
 		@Override
@@ -66,7 +66,7 @@ public class KotlinSource extends Source {
 		protected class KotlinCompileBuildStep extends CompileBuildStep {
 
 			public KotlinCompileBuildStep() {
-				super(KotlinAppBuilder.this.project);
+				super(KotlinAppBuilder.this.project, KotlinAppBuilder.this.ctx);
 			}
 
 			@Override
@@ -77,7 +77,7 @@ public class KotlinSource extends Source {
 
 		private class KotlinIntegrationBuildStep extends IntegrationBuildStep {
 			public KotlinIntegrationBuildStep() {
-				super(KotlinAppBuilder.this.project);
+				super(KotlinAppBuilder.this.project, KotlinAppBuilder.this.ctx);
 			}
 
 			@Override

--- a/src/test/java/dev/jbang/cli/TestExternalDeps.java
+++ b/src/test/java/dev/jbang/cli/TestExternalDeps.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.Util;
@@ -47,9 +48,11 @@ class TestExternalDeps extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
-		Project prj = pb.build(f.getPath()).builder().build();
+		Project prj = pb.build(f.getPath());
+		BuildContext ctx = BuildContext.forProject(prj);
+		prj.builder(ctx).build();
 
-		String result = prj.cmdGenerator().generate();
+		String result = prj.cmdGenerator(ctx).generate();
 
 		assertThat(result, containsString("pico"));
 
@@ -70,9 +73,11 @@ class TestExternalDeps extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
-		Project prj = pb.build(f.getPath()).builder().build();
+		Project prj = pb.build(f.getPath());
+		BuildContext ctx = BuildContext.forProject(prj);
+		prj.builder(ctx).build();
 
-		String result = prj.cmdGenerator().generate();
+		String result = prj.cmdGenerator(ctx).generate();
 
 		assertThat(result, matchesPattern(".*com[/\\\\]github[/\\\\]jbangdev[/\\\\]jbang.*"));
 

--- a/src/test/java/dev/jbang/dependencies/TestGrape.java
+++ b/src/test/java/dev/jbang/dependencies/TestGrape.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
 import dev.jbang.source.Project;
+import dev.jbang.source.ProjectBuilder;
 import dev.jbang.source.Source;
 import dev.jbang.source.sources.JavaSource;
 
@@ -32,7 +33,7 @@ public class TestGrape extends BaseTest {
 				"})\n";
 
 		Source src = new JavaSource(grabBlock, null);
-		Project prj = src.createProject();
+		Project prj = ProjectBuilder.create().build(src);
 		List<String> deps = prj.getMainSourceSet().getDependencies();
 
 		assertThat(deps, hasItem("org.hibernate:hibernate-core:5.4.10.Final"));

--- a/src/test/java/dev/jbang/source/TestProject.java
+++ b/src/test/java/dev/jbang/source/TestProject.java
@@ -15,8 +15,8 @@ public class TestProject extends BaseTest {
 		Source source = new JavaSource("//CDS\nclass m { }", null);
 		Source source2 = new JavaSource("class m { }", null);
 
-		Project prj = source.createProject();
-		Project prj2 = source2.createProject();
+		Project prj = ProjectBuilder.create().build(source);
+		Project prj2 = ProjectBuilder.create().build(source2);
 
 		assertTrue(prj.enableCDS());
 		assertFalse(prj2.enableCDS());

--- a/src/test/java/dev/jbang/source/TestSameSourceInDifferentPaths.java
+++ b/src/test/java/dev/jbang/source/TestSameSourceInDifferentPaths.java
@@ -68,7 +68,7 @@ public class TestSameSourceInDifferentPaths extends BaseTest {
 		TestSource.createTmpFileWithContent(mainPath.getParent(), "model", "C.java", classModelC);
 		TestSource.createTmpFileWithContent(BPath.getParent(), "model", "C.java", classPersonModelC);
 		Source source = Source.forResource(mainPath.toString(), null);
-		Project prj = source.createProject();
+		Project prj = ProjectBuilder.create().build(source);
 		assertEquals(4, prj.getMainSourceSet().getSources().size());
 	}
 

--- a/src/test/java/dev/jbang/source/TestSource.java
+++ b/src/test/java/dev/jbang/source/TestSource.java
@@ -154,7 +154,7 @@ public class TestSource extends BaseTest {
 	@Test
 	void testCommentsDoesNotGetPickedUp() {
 		Source source = new JavaSource(exampleCommandsWithComments, null);
-		Project prj = source.createProject();
+		Project prj = ProjectBuilder.create().build(source);
 
 		assertEquals(prj.getJavaVersion(), "14+");
 
@@ -167,7 +167,7 @@ public class TestSource extends BaseTest {
 	void testFindDependencies() {
 		Source src = new JavaSource(example,
 				it -> PropertiesValueResolver.replaceProperties(it, new Properties()));
-		Project prj = src.createProject();
+		Project prj = ProjectBuilder.create().build(src);
 
 		List<String> deps = prj.getMainSourceSet().getDependencies();
 		assertEquals(2, deps.size());
@@ -184,7 +184,7 @@ public class TestSource extends BaseTest {
 		p.put("log4j.version", "1.2.9");
 
 		Source src = new JavaSource(example, it -> PropertiesValueResolver.replaceProperties(it, p));
-		Project prj = src.createProject();
+		Project prj = ProjectBuilder.create().build(src);
 
 		List<String> dependencies = prj.getMainSourceSet().getDependencies();
 		assertEquals(2, dependencies.size());
@@ -302,7 +302,7 @@ public class TestSource extends BaseTest {
 	@Test
 	void testGav() {
 		Source src = new JavaSource(example, null);
-		String gav = src.createProject().getGav().get();
+		String gav = ProjectBuilder.create().build(src).getGav().get();
 		assertEquals("org.example:classpath", gav);
 	}
 

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -106,7 +106,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
 		Source script = Source.forResourceRef(resourceRef, null);
-		Project prj = script.createProject();
+		Project prj = ProjectBuilder.create().build(script);
 		List<ResourceRef> sources = prj.getMainSourceSet().getSources();
 		assertEquals(5, sources.size());
 		TreeSet<String> fileNames = new TreeSet<>();
@@ -142,7 +142,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
 		Source source = Source.forResourceRef(resourceRef, null);
-		Assertions.assertThrows(ResourceNotFoundException.class, source::createProject);
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> ProjectBuilder.create().build(source));
 	}
 
 }

--- a/src/test/java/dev/jbang/source/TestSourcesMutualDependency.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMutualDependency.java
@@ -40,7 +40,7 @@ public class TestSourcesMutualDependency extends BaseTest {
 		TestSource.createTmpFileWithContent("", "B.java", classB);
 		String scriptURL = mainPath.toString();
 		Source source = Source.forResource(scriptURL, null);
-		Project prj = source.createProject();
+		Project prj = ProjectBuilder.create().build(source);
 		assertEquals(3, prj.getMainSourceSet().getSources().size());
 	}
 

--- a/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
@@ -79,7 +79,7 @@ class TestSourcesRecursivelyMultipleFiles extends BaseTest {
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
 		Source script = Source.forResourceRef(resourceRef, null);
-		Project prj = script.createProject();
+		Project prj = ProjectBuilder.create().build(script);
 		List<ResourceRef> sources = prj.getMainSourceSet().getSources();
 		assertEquals(5, sources.size());
 		TreeSet<String> fileNames = new TreeSet<>();


### PR DESCRIPTION
The `Project` class now does not contain any build-related code anymore, this has all been moved to `BuildContext`. So a `Builder` can be given a `Project` and a `BuildContext` where the former represents all the inputs that go into the build and the latter represents all the outputs (and any temporary/intermediate state).
