### PR TITLE
fix: all default values can be set by config

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -14,22 +14,27 @@ endif::[]
 
 toc::[]
 
-JBang try and have decent defaults, for the cases where they do not fit you can use `jbang config` to setup better defaults.
+JBang tries to have decent defaults, for the cases where they do not fit you can use `jbang config` to set up better defaults.
 
-Example, the default editor for `jbang edit` is calculated but sometimes you want it to be one specific editor. Instead of writing `jbang edit --open=code hello.java` to say it is `code` you want open with, you can use `jbang config set edit.open=code`. When you have done that then `jbang edit hello.java` is all that is needed - JBang will now use `code` as the default editor.
+Example, the default editor for `jbang edit` is automatically determined, but sometimes you want it to be one specific editor. Instead of writing `jbang edit --open=code hello.java` to say it is `code` you want open with, you can use `jbang config set edit.open=code`. When you have done that then `jbang edit hello.java` is all that is needed - JBang will now use `code` as the default editor.
 
 == Configure default value for every argument
 
 If you noticed it what JBang configuration does is to map a configuration key to a command line argument. Meaning any command and its command line arguments can be given default values to change the default behavior of jbang. i.e. `edit.open` is the `--open` argument to `edit` command.
 
-You can see all the available keys by running `jbang config list --show-available` and if you want to see the current default values use `jbang config list`.
+Basically any option can be set by taking the full name of the command, which for example is `run` for `jbang run` and `app.list` for `jbang app list`, together with the name of the option without any dashes. So the option `--format` for `jbang app list` becomes `app.list.format`, and `--jdk-providers` for `build` becomes `build.jdkproviders`.
+
+You can see all the available keys by running `jbang config list --show-available` and if you want to see the current values use `jbang config list`.
+
+Additionally, any option can be set by simply using its name, this is especially useful when there are several commands that all have the same option, and you want ot set them all. So if we take the example above where we set the `app.list.format`, we can also simply use `jbang config set format json`. But that will affect _all_ commands that have a format option, like `alias list`, `catalog list`, `jdk list` and others.
+
+In the case that you set both a simple value, like `format`, and a fully named value, like `app.list.format`, the most specific one takes precedence.
 
 == Local vs Global configuration
 
-JBang has a built-in default value and any config setting will by default be set on a global scope. Meaning it will apply to any `jbang` run. The default location for this is at `~/.jbang/jbang.properties`.
+JBang has built-in default values and any config setting will by default be set on a global scope. Meaning it will apply to any `jbang` run. The default location for this is at `~/.jbang/jbang.properties`.
 
-If you want to have local settings that only apply within a certain diretory tree simply go that directory and run `jbang config set --file=. edit.open idea`. Then JBang stores settings in a local `jbang.properties`
-wihch will override any global setting.
+If you want to have local settings that only apply within a certain directory tree simply go into that directory and run, for example, `jbang config set --file=. edit.open idea`. Then JBang will store that setting in a local `jbang.properties` file which will override any global setting.
 
 To see which keys are configured where and in what order run `jbang config list --show-origin` and you will get something like:
 

--- a/src/main/java/dev/jbang/cli/FormatMixin.java
+++ b/src/main/java/dev/jbang/cli/FormatMixin.java
@@ -9,6 +9,6 @@ public class FormatMixin {
 	}
 
 	@CommandLine.Option(names = {
-			"--format" }, description = "Specify output format ('text' or 'json')", defaultValue = "text")
+			"--format" }, description = "Specify output format ('text' or 'json')")
 	protected Format format;
 }

--- a/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
+++ b/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
@@ -9,7 +9,7 @@ import picocli.CommandLine;
 public class JdkProvidersMixin {
 
 	@CommandLine.Option(names = {
-			"--jdk-providers" }, description = "Use the given providers to check for installed JDKs", split = ",", defaultValue = JdkManager.PROVIDERS_DEFAULT_STR, hidden = true)
+			"--jdk-providers" }, description = "Use the given providers to check for installed JDKs", split = ",", hidden = true)
 	List<String> jdkProviders;
 
 	protected void initJdkProviders() {

--- a/src/main/java/dev/jbang/net/JdkManager.java
+++ b/src/main/java/dev/jbang/net/JdkManager.java
@@ -38,7 +38,6 @@ public class JdkManager {
 	public static final String[] PROVIDERS_ALL = new String[] { "current", "default", "javahome", "path", "jbang",
 			"sdkman", "scoop" };
 	public static final String[] PROVIDERS_DEFAULT = new String[] { "current", "default", "javahome", "path", "jbang" };
-	public static final String PROVIDERS_DEFAULT_STR = "current,default,javahome,path,jbang";
 
 	public static void initProvidersByName(String... providerNames) {
 		initProvidersByName(Arrays.asList(providerNames));

--- a/src/main/resources/jbang.properties
+++ b/src/main/resources/jbang.properties
@@ -2,3 +2,5 @@ init.template=hello
 run.debug=4004
 run.jfr=filename={baseName}.jfr
 wrapper.install.dir=.
+format=text
+jdkproviders=current,default,javahome,path,jbang

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -101,8 +101,7 @@ public class TestAlias extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias alias = Alias.get("name");
 		assertThat(alias.scriptRef, is("test.java"));
@@ -114,22 +113,23 @@ public class TestAlias extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add",
-				"-f", cwd.toString(),
-				"--name=name", testFile.toString(),
-				"--description", "desc",
-				"--deps", "deps",
-				"--repos", "repos",
-				"--cp", "cps",
-				"--runtime-option", "jopts",
-				"-D", "prop=val",
-				"--main", "mainclass",
-				"--compile-option", "copts",
-				"--native",
-				"--native-option", "nopts",
-				"--java", "999",
-				"aap", "noot", "mies");
+		JBang	.getCommandLine()
+				.execute("alias", "add",
+						"-f", cwd.toString(),
+						"--name=name",
+						"--description", "desc",
+						"--deps", "deps",
+						"--repos", "repos",
+						"--cp", "cps",
+						"--runtime-option", "jopts",
+						"-D", "prop=val",
+						"--main", "mainclass",
+						"--compile-option", "copts",
+						"--native",
+						"--native-option", "nopts",
+						"--java", "999",
+						testFile.toString(),
+						"aap", "noot", "mies");
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Alias alias = Alias.get("name");
@@ -164,20 +164,21 @@ public class TestAlias extends BaseTest {
 		Path catFile = Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON);
 		Files.write(catFile, "".getBytes());
 		assertThat(Files.size(catFile), is(0L));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add",
-				"--name=name", testFile.toString(),
-				"--description", "desc",
-				"--deps", "deps",
-				"--repos", "repos",
-				"--cp", "cps",
-				"--runtime-option", "jopts",
-				"-D", "prop=val",
-				"--main", "mainclass",
-				"--compile-option", "copts",
-				"--native-option", "nopts",
-				"--java", "999",
-				"aap", "noot", "mies");
+		JBang	.getCommandLine()
+				.execute("alias", "add",
+						"--name=name",
+						"--description", "desc",
+						"--deps", "deps",
+						"--repos", "repos",
+						"--cp", "cps",
+						"--runtime-option", "jopts",
+						"-D", "prop=val",
+						"--main", "mainclass",
+						"--compile-option", "copts",
+						"--native-option", "nopts",
+						"--java", "999",
+						testFile.toString(),
+						"aap", "noot", "mies");
 		assertThat(Files.size(catFile), not(is(0L)));
 		Alias alias = Alias.get("name");
 		assertThat(alias.scriptRef, is("test.java"));
@@ -210,8 +211,7 @@ public class TestAlias extends BaseTest {
 		Path testFile = sub.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias name = Alias.get("name");
 		assertThat(name.scriptRef, is(Paths.get("sub/test.java").toString()));
@@ -224,8 +224,7 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, ("// Test file \n" +
 				"//DESCRIPTION Description of the script inside the script").getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias name = Alias.get("name");
 		assertThat(name.scriptRef, is("test.java"));
@@ -239,9 +238,9 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, ("// Test file \n" +
 				"//DESCRIPTION Description of the script inside the script").getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name",
-				"-d", "Description of the script in arguments", testFile.toString());
+		JBang	.getCommandLine()
+				.execute("alias", "add", "-f", cwd.toString(), "--name=name",
+						"-d", "Description of the script in arguments", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias name = Alias.get("name");
 		assertThat(name.scriptRef, is("test.java"));
@@ -258,8 +257,7 @@ public class TestAlias extends BaseTest {
 				"//DESCRIPTION description second tag\n" +
 				"//DESCRIPTION description third tag").getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias name = Alias.get("name");
 		assertThat(name.scriptRef, is("test.java"));
@@ -273,8 +271,7 @@ public class TestAlias extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, ("// Test file \n").getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias name = Alias.get("name");
 		assertThat(name.scriptRef, is("test.java"));
@@ -291,8 +288,7 @@ public class TestAlias extends BaseTest {
 		Path hiddenJBangPath = Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR);
 		Files.createDirectory(hiddenJBangPath);
 		Files.createFile(Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR, Catalog.JBANG_CATALOG_JSON));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
 		Catalog catalog = Catalog.get(hiddenJBangPath);
 		Alias name = catalog.aliases.get("name");
@@ -304,8 +300,7 @@ public class TestAlias extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		Alias one = Alias.get("one");
 		Alias name = Alias.get("name");
 		assertThat(one.scriptRef, is("http://dummy"));

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -16,8 +16,6 @@ import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.catalog.CatalogUtil;
 
-import picocli.CommandLine;
-
 public class TestCatalog extends BaseTest {
 
 	static final String testCatalog = "{\n" +
@@ -59,8 +57,7 @@ public class TestCatalog extends BaseTest {
 
 	@Test
 	void testAddInvalidName() throws IOException {
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("catalog", "add", "--name=invalid!", "dummy");
+		JBang.getCommandLine().execute("catalog", "add", "--name=invalid!", "dummy");
 	}
 
 	@Test
@@ -72,8 +69,7 @@ public class TestCatalog extends BaseTest {
 
 	@Test
 	void testUpdate() throws IOException {
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("catalog", "update");
+		JBang.getCommandLine().execute("catalog", "update");
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestConfig.java
+++ b/src/test/java/dev/jbang/cli/TestConfig.java
@@ -33,7 +33,7 @@ public class TestConfig extends BaseTest {
 	static Path testConfigFileSub = null;
 
 	@BeforeEach
-	void init() throws IOException {
+	void initEach() throws IOException {
 		configFile = jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS);
 		testConfigFile = cwdDir.resolve(Configuration.JBANG_CONFIG_PROPS);
 		Files.write(testConfigFile, testConfig.getBytes());
@@ -49,7 +49,9 @@ public class TestConfig extends BaseTest {
 		ExecutionResult result = checkedRun(null, "config", "list");
 		assertThat(result.exitCode, equalTo(SUCCESS_EXIT));
 		assertThat(result.normalizedOut(),
-				equalTo("init.template = hello\n" +
+				equalTo("format = text\n" +
+						"init.template = hello\n" +
+						"jdkproviders = current,default,javahome,path,jbang\n" +
 						"one = footop\n" +
 						"run.debug = 4004\n" +
 						"run.jfr = filename={baseName}.jfr\n" +
@@ -114,5 +116,28 @@ public class TestConfig extends BaseTest {
 	void testUnsetBuiltin() throws IOException {
 		ExecutionResult result = checkedRun(null, "config", "unset", "run.debug");
 		assertThat(result.normalizedErr(), containsString("Cannot remove built-in option"));
+	}
+
+	@Test
+	void testCommandDefaultValueDefault() {
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
+		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
+		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.text));
+	}
+
+	@Test
+	void testCommandDefaultValueSpecificOverride() {
+		Configuration.instance().put("app.list.format", "json");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
+		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
+		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.json));
+	}
+
+	@Test
+	void testCommandDefaultValueGlobalOverride() {
+		Configuration.instance().put("format", "json");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
+		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
+		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.json));
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -39,9 +39,8 @@ public class TestInfo extends BaseTest {
 	@Test
 	void testInfoToolsBuilt() {
 		String src = examplesTestFolder.resolve("quote.java").toString();
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("build", src);
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		JBang.getCommandLine().execute("build", src);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -18,8 +18,7 @@ public class TestInfo extends BaseTest {
 	@Test
 	void testInfoToolsSimple() {
 		String src = examplesTestFolder.resolve("quote.java").toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));
@@ -56,11 +55,11 @@ public class TestInfo extends BaseTest {
 	@Test
 	void testInfoToolsWithDeps() {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools",
-				"--deps", "info.picocli:picocli:4.6.3,commons-io:commons-io:2.8.0",
-				"--deps", "org.apache.commons:commons-lang3:3.12.0",
-				src);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("info", "tools",
+													"--deps", "info.picocli:picocli:4.6.3,commons-io:commons-io:2.8.0",
+													"--deps", "org.apache.commons:commons-lang3:3.12.0",
+													src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));
@@ -81,8 +80,7 @@ public class TestInfo extends BaseTest {
 	void testInfoToolsWithClasspath() {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String jar = examplesTestFolder.resolve("hellojar.jar").toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", "--cp", jar, src);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", "--cp", jar, src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));
@@ -101,8 +99,7 @@ public class TestInfo extends BaseTest {
 	void testInfoClasspathNested() {
 		String src = examplesTestFolder.resolve("sources.java").toString();
 		String quote = examplesTestFolder.resolve("quote.java").toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));
@@ -125,8 +122,7 @@ public class TestInfo extends BaseTest {
 	@Test
 	void testInfoJShell() {
 		String src = examplesTestFolder.resolve("basic.jsh").toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("info", "tools", src);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
 		assertThat(info.originalResource, equalTo(src));

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -85,11 +85,11 @@ public class TestRun extends BaseTest {
 
 	void testHelloWorld(boolean first) throws IOException {
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
 		String extracp = examplesTestFolder.resolve("hellojar.jar").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
-				"--cp", extracp, arg);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
+													"--cp", extracp, arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -162,9 +162,8 @@ public class TestRun extends BaseTest {
 	void testHelloWorldShell() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.jsh").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -189,9 +188,8 @@ public class TestRun extends BaseTest {
 	void testNestedDeps() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("ec.jsh").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "-s", arg, "-c", "Collector2.class");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "-s", arg, "-c", "Collector2.class");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -229,10 +227,8 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testMarkdown() throws IOException {
-
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("readme.md").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -255,9 +251,8 @@ public class TestRun extends BaseTest {
 															Util.readString(examplesTestFolder.resolve("readme.md")))));
 
 		wms.start();
-		JBang jbang = new JBang();
 		String arg = "http://localhost:" + wms.port() + "/readme.md";
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -273,8 +268,7 @@ public class TestRun extends BaseTest {
 	void testEmptyInteractiveShell(@TempDir File dir) throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "a");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "a");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		File empty = new File(dir, "empty.jsh");
@@ -299,9 +293,8 @@ public class TestRun extends BaseTest {
 	void testForceShell() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("hellojsh").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--jsh", arg, "helloworld");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--jsh", arg, "helloworld");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -359,9 +352,7 @@ public class TestRun extends BaseTest {
 			TrustedSources.instance().add(jar, tdir.resolve("test.trust").toFile());
 
 			environmentVariables.clear("JAVA_HOME");
-			JBang jbang = new JBang();
-
-			CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
+			CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", jar);
 			Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 			ProjectBuilder pb = run.createProjectBuilder();
@@ -381,13 +372,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testHelloWorldGAVWithNoMain() throws IOException {
-
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
-
 		String jar = "info.picocli:picocli-codegen:4.6.3";
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -445,12 +433,9 @@ public class TestRun extends BaseTest {
 		Files.write(jbangTempDir.toPath().resolve(Catalog.JBANG_CATALOG_JSON), aliases.getBytes());
 
 		environmentVariables.clear("JAVA_HOME");
-
-		JBang jbang = new JBang();
-
 		String jar = "qcli";
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -474,13 +459,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testHelloWorldGAVWithAMain() throws IOException {
-
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
-
 		String jar = "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r";
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -498,14 +480,12 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testHelloWorldGAVWithExplicitMainClass() throws IOException {
-
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
-
 		String jar = "info.picocli:picocli-codegen:4.6.3";
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--main",
-				"picocli.codegen.aot.graalvm.ReflectionConfigGenerator", jar);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--main",
+													"picocli.codegen.aot.graalvm.ReflectionConfigGenerator", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -556,14 +536,12 @@ public class TestRun extends BaseTest {
 	}
 
 	void testGAVWithExtraDeps() throws IOException {
-
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
-
 		String jar = "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r";
 		String extracp = examplesTestFolder.resolve("hellojar.jar").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
-				"--cp", extracp, jar);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
+													"--cp", extracp, jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -582,10 +560,10 @@ public class TestRun extends BaseTest {
 	void testHelloWorldShellNoExit() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.jsh").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--interactive", arg,
-				"blah");
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--interactive", arg,
+													"blah");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -652,9 +630,8 @@ public class TestRun extends BaseTest {
 	void testDependencies() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("classpath_example.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -677,9 +654,8 @@ public class TestRun extends BaseTest {
 	void testDependenciesInteractive() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("classpath_example.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--interactive", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--interactive", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -701,11 +677,11 @@ public class TestRun extends BaseTest {
 	void testProperties() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("classpath_example.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang)	.setStopAtPositional(true)
-															.parseArgs("run", "-Dwonka=panda", "-Dquoted=see this",
-																	arg, "-Dafter=wonka");
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.setStopAtPositional(true)
+											.parseArgs("run", "-Dwonka=panda", "-Dquoted=see this",
+													arg, "-Dafter=wonka");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assertThat(run.userParams.size(), is(1));
@@ -743,8 +719,7 @@ public class TestRun extends BaseTest {
 		MatcherAssert.assertThat(Util.readString(pre.getResourceRef().getFile()),
 				containsString("Logger.getLogger(classpath_example.class);"));
 
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", url);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -761,8 +736,7 @@ public class TestRun extends BaseTest {
 	@Test
 	public void testMetaCharacters() throws IOException {
 		String url = examplesTestFolder.resolve("classpath_example.java").toFile().toURI().toString();
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", url, " ~!@#$%^&*()-+\\:;'`<>?/,.{}[]\"");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", url, " ~!@#$%^&*()-+\\:;'`<>?/,.{}[]\"");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -963,9 +937,8 @@ public class TestRun extends BaseTest {
 
 		Util.writeString(f.toPath(), base);
 
-		JBang jbang = new JBang();
 		String arg = f.getAbsolutePath();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -1156,9 +1129,8 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testCDSNotPresent() {
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assert (run.cds == null);
@@ -1207,9 +1179,8 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testNoCDSPresent() {
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", arg, "--no-cds");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--no-cds", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assert (run.cds != null);
@@ -1231,12 +1202,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testAgent(@TempDir Path output) throws IOException {
-
-		JBang jbang = new JBang();
 		Path p = output.resolve("Agent.java");
 		writeString(p, agent);
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build", p.toFile().getAbsolutePath());
 		Build build = (Build) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = build.createProjectBuilder();
@@ -1261,12 +1230,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testpreAgent(@TempDir Path output) throws IOException {
-
-		JBang jbang = new JBang();
 		Path p = output.resolve("Agent.java");
 		writeString(p, preagent);
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build", p.toFile().getAbsolutePath());
 		Build build = (Build) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = build.createProjectBuilder();
@@ -1308,10 +1275,11 @@ public class TestRun extends BaseTest {
 		Path mainfile = output.toPath().resolve("main.java");
 		Util.writeString(mainfile, base.replace("dualclass", "main"));
 
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				"--javaagent=" + agentfile.toAbsolutePath() + "=optionA",
-				"--javaagent=org.jboss.byteman:byteman:4.0.13", mainfile.toAbsolutePath().toString());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													"--javaagent=" + agentfile.toAbsolutePath() + "=optionA",
+													"--javaagent=org.jboss.byteman:byteman:4.0.13",
+													mainfile.toAbsolutePath().toString());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assertThat(run.javaAgentSlots.containsKey(agentfile.toAbsolutePath().toString()), is(true));
@@ -1336,8 +1304,7 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaAgentParsing() {
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--javaagent=xyz.jar", "wonka.java");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--javaagent=xyz.jar", "wonka.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assertThat(run.javaAgentSlots, hasKey("xyz.jar"));
@@ -1345,9 +1312,9 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaAgentViaGAV() {
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				"--javaagent=org.jboss.byteman:byteman:4.0.13", "wonka.java");
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													"--javaagent=org.jboss.byteman:byteman:4.0.13", "wonka.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assertThat(run.javaAgentSlots, hasKey("org.jboss.byteman:byteman:4.0.13"));
@@ -1355,10 +1322,9 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testAssertions() throws IOException {
-		JBang jbang = new JBang();
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--ea", f.getAbsolutePath());
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--ea", f.getAbsolutePath());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1374,12 +1340,12 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testSystemAssertions() throws IOException {
-		JBang jbang = new JBang();
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--enablesystemassertions", "--main",
-				"fakemain",
-				f.getAbsolutePath());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--enablesystemassertions", "--main",
+													"fakemain",
+													f.getAbsolutePath());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1575,11 +1541,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testMultiSourcesNonPublic(@TempDir Path output) throws IOException {
-		JBang jbang = new JBang();
 		Path p = output.resolve("script");
 		writeString(p, script);
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1605,11 +1570,10 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testMultiSourcesNonPublicAmbigious(@TempDir Path output) throws IOException {
-		JBang jbang = new JBang();
 		Path p = output.resolve("script");
 		writeString(p, ambigiousScript);
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", p.toFile().getAbsolutePath());
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build", p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1624,12 +1588,12 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testMultiSourcesNonPublicMakeNonAmbigious(@TempDir Path output) throws IOException {
-		JBang jbang = new JBang();
 		Path p = output.resolve("script");
 		writeString(p, ambigiousScript);
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("build", "-m", "Three",
-				p.toFile().getAbsolutePath());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("build", "-m", "Three",
+													p.toFile().getAbsolutePath());
 		Build run = (Build) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1891,9 +1855,8 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJVMOpts() throws IOException {
-		JBang jbang = new JBang();
 		String arg = new File(examplesTestFolder.toFile(), "helloworld.java").getAbsolutePath();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--runtime-option=--show-version", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--runtime-option=--show-version", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1908,13 +1871,12 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaFXViaFileDeps() throws IOException {
-		JBang jbang = new JBang();
-
 		Path fileref = examplesTestFolder.resolve("SankeyPlotTestWithDeps.java").toAbsolutePath();
 
 		// todo fix so --deps can use system properties
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				fileref.toString());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													fileref.toString());
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -1930,16 +1892,15 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaFXViaCommandLineDeps() throws IOException {
-		JBang jbang = new JBang();
-
 		Path fileref = examplesTestFolder.resolve("SankeyPlotTest.java").toAbsolutePath();
 
 		// todo fix so --deps can use system properties
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				"--deps", "org.openjfx:javafx-graphics:17:mac",
-				"--deps", "org.openjfx:javafx-controls:17:mac",
-				"--deps", "eu.hansolo.fx:charts:RELEASE",
-				fileref.toString());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													"--deps", "org.openjfx:javafx-graphics:17:mac",
+													"--deps", "org.openjfx:javafx-controls:17:mac",
+													"--deps", "eu.hansolo.fx:charts:RELEASE",
+													fileref.toString());
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -1955,15 +1916,14 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaFXViaCommandLineDepsUsingCommas() throws IOException {
-		JBang jbang = new JBang();
-
 		Path fileref = examplesTestFolder.resolve("SankeyPlotTest.java").toAbsolutePath();
 
 		// todo fix so --deps can use system properties
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				"--deps",
-				"org.openjfx:javafx-graphics:17:mac,org.openjfx:javafx-controls:17:mac,eu.hansolo.fx:charts:RELEASE",
-				fileref.toString());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													"--deps",
+													"org.openjfx:javafx-graphics:17:mac,org.openjfx:javafx-controls:17:mac,eu.hansolo.fx:charts:RELEASE",
+													fileref.toString());
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -1979,18 +1939,16 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testJavaFXMagicPropertyViaCommandline() throws IOException {
-
-		JBang jbang = new JBang();
-
 		Path fileref = examplesTestFolder.resolve("SankeyPlotTest.java").toAbsolutePath();
 
 		// todo fix so --deps can use system properties
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run",
-				"--java", "11",
-				"--deps", "org.openjfx:javafx-graphics:17:${os.detected.jfxname}",
-				"--deps", "org.openjfx:javafx-controls:17:${os.detected.jfxname}",
-				"--deps", "eu.hansolo.fx:charts:RELEASE",
-				fileref.toString());
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run",
+													"--java", "11",
+													"--deps", "org.openjfx:javafx-graphics:17:${os.detected.jfxname}",
+													"--deps", "org.openjfx:javafx-controls:17:${os.detected.jfxname}",
+													"--deps", "eu.hansolo.fx:charts:RELEASE",
+													fileref.toString());
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -2015,13 +1973,12 @@ public class TestRun extends BaseTest {
 				"}\n";
 
 		File f = new File(output, "test.java");
-
 		Util.writeString(f.toPath(), base);
 
-		JBang jbang = new JBang();
 		String arg = f.getAbsolutePath();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--repos", "http://dummyrepo", "--deps",
-				"dummygroup:dummyart:0.1", arg);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--repos", "http://dummyrepo", "--deps",
+													"dummygroup:dummyart:0.1", arg);
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -2044,9 +2001,9 @@ public class TestRun extends BaseTest {
 	void testGAVCliReposAndDepsSingleRepo(@TempDir File output) throws IOException {
 		String jar = "info.picocli:picocli-codegen:4.6.3";
 
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--repos", "http://dummyrepo", "--deps",
-				"dummygroup:dummyart:0.1", jar);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--repos", "http://dummyrepo", "--deps",
+													"dummygroup:dummyart:0.1", jar);
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
@@ -2067,10 +2024,10 @@ public class TestRun extends BaseTest {
 	void testGAVCliReposAndDepsTwoRepos(@TempDir File output) throws IOException {
 		String jar = "info.picocli:picocli-codegen:4.6.3";
 
-		JBang jbang = new JBang();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--repos", "mavencentral", "--repos",
-				"http://dummyrepo", "--deps",
-				"dummygroup:dummyart:0.1", jar);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--repos", "mavencentral", "--repos",
+													"http://dummyrepo", "--deps",
+													"dummygroup:dummyart:0.1", jar);
 
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -324,12 +324,12 @@ public class TestRun extends BaseTest {
 	void testHelloWorldJar() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 
 		String jar = examplesTestFolder.resolve("hellojar.jar").toAbsolutePath().toString();
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
-				"--cp", "dummy.jar", jar);
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--deps", "info.picocli:picocli:4.6.3",
+													"--cp", "dummy.jar", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -408,11 +408,10 @@ public class TestRun extends BaseTest {
 	void testHelloWorldGAVInteractiveWithNoMain() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");
-		JBang jbang = new JBang();
 
 		String jar = "info.picocli:picocli-codegen:4.6.3";
 
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", jar, "-i");
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "-i", jar);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();
@@ -1167,9 +1166,8 @@ public class TestRun extends BaseTest {
 
 	@Test
 	void testCDSPresentOnCli() throws IOException {
-		JBang jbang = new JBang();
 		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
-		CommandLine.ParseResult pr = new CommandLine(jbang).parseArgs("run", "--cds", arg);
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--cds", arg);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		ProjectBuilder pb = run.createProjectBuilder();

--- a/src/test/java/dev/jbang/cli/TestTemplate.java
+++ b/src/test/java/dev/jbang/cli/TestTemplate.java
@@ -24,8 +24,6 @@ import dev.jbang.catalog.Template;
 import dev.jbang.catalog.TemplateProperty;
 import dev.jbang.util.Util;
 
-import picocli.CommandLine;
-
 public class TestTemplate extends BaseTest {
 
 	static final String templates = "{\n" +
@@ -92,8 +90,7 @@ public class TestTemplate extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("name");
@@ -108,9 +105,9 @@ public class TestTemplate extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(), "--name=name",
-				"-d", "Description of the template", testFile.toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=name",
+						"-d", "Description of the template", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("name");
@@ -125,8 +122,7 @@ public class TestTemplate extends BaseTest {
 		Path hiddenJBangPath = Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR);
 		Files.createDirectory(hiddenJBangPath);
 		Files.createFile(Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR, Catalog.JBANG_CATALOG_JSON));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		JBang.getCommandLine().execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
 		Catalog catalog = Catalog.get(hiddenJBangPath);
 		Template name = catalog.templates.get("name");
@@ -140,9 +136,9 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(), "--name=name",
-				testFile.toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=name",
+						testFile.toString());
 		Template one = Template.get("one");
 		Template name = Template.get("name");
 		assertThat(one.fileRefs, aMapWithSize(3));
@@ -232,9 +228,9 @@ public class TestTemplate extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(), "--name=template-with-single-property",
-				"-d", "Description of the template", "-P", "new-test-key", testFile.toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=template-with-single-property",
+						"-d", "Description of the template", "-P", "new-test-key", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("template-with-single-property");
@@ -248,11 +244,11 @@ public class TestTemplate extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(),
-				"--name=template-with-single-complex-property",
-				"-d", "Description of the template", "-P",
-				"new-test-key:This is a description for the property key:3.14", testFile.toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(),
+						"--name=template-with-single-complex-property",
+						"-d", "Description of the template", "-P",
+						"new-test-key:This is a description for the property key:3.14", testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("template-with-single-complex-property");
@@ -267,13 +263,13 @@ public class TestTemplate extends BaseTest {
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
-		JBang jbang = new JBang();
-		new CommandLine(jbang).execute("template", "add", "-f", cwd.toString(),
-				"--name=template-with-complex-properties",
-				"-d", "Description of the template", "-P",
-				"new-test-key:This is a description for the property key:3.14", "--property",
-				"second-test-key:This is another description for the second property key:Non-Blocker",
-				testFile.toString());
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(),
+						"--name=template-with-complex-properties",
+						"-d", "Description of the template", "-P",
+						"new-test-key:This is a description for the property key:3.14", "--property",
+						"second-test-key:This is another description for the second property key:Non-Blocker",
+						testFile.toString());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("template-with-complex-properties");


### PR DESCRIPTION
Some default values were not settable by config, an oversight.
Also added the possibility to globally set default values for all commands that support the same option.

Fixes #1576
