### PR TITLE
fix: Fixed NPE dealing with jdk providers

### DIFF
--- a/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
+++ b/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
@@ -13,7 +13,7 @@ public class JdkProvidersMixin {
 	List<String> jdkProviders;
 
 	protected void initJdkProviders() {
-		if (!jdkProviders.isEmpty()) {
+		if (jdkProviders != null && !jdkProviders.isEmpty()) {
 			JdkManager.initProvidersByName(jdkProviders);
 		}
 	}


### PR DESCRIPTION
The underlying issue was that classpath resources were not being properly duplicated to the file system, resulting in them never being updated. This meant that newer config option were left empty.
