### PR TITLE
fix: make sure we set main class in module jars

### DIFF
--- a/src/main/java/dev/jbang/source/AppBuilder.java
+++ b/src/main/java/dev/jbang/source/AppBuilder.java
@@ -61,7 +61,9 @@ public abstract class AppBuilder implements Builder<CmdGeneratorBuilder> {
 			Project jarProject = Project.builder().build(outjar);
 			// We already have a Jar, check if we can still use it
 			if (!ctx.isUpToDate()) {
-				Util.verboseMsg("Building as previous build jar found but it or its dependencies not up-to-date.");
+				Util.verboseMsg("Building as previously built jar found but it or its dependencies not up-to-date.");
+			} else if (jarProject.getJavaVersion() == null) {
+				Util.verboseMsg("Building as previously built jar found but it has incomplete meta data.");
 			} else if (JavaUtil.javaVersion(requestedJavaVersion) < JavaUtil.minRequestedVersion(
 					jarProject.getJavaVersion())) {
 				Util.verboseMsg(

--- a/src/main/java/dev/jbang/source/buildsteps/JarBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/JarBuildStep.java
@@ -1,11 +1,9 @@
 package dev.jbang.source.buildsteps;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -13,10 +11,8 @@ import dev.jbang.source.AppBuilder;
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.Builder;
 import dev.jbang.source.Project;
-import dev.jbang.util.CommandBuffer;
 import dev.jbang.util.JarUtil;
 import dev.jbang.util.JavaUtil;
-import dev.jbang.util.Util;
 
 /**
  * This class takes a <code>Project</code> and the result from a previous
@@ -42,40 +38,28 @@ public class JarBuildStep implements Builder<Project> {
 	}
 
 	public static void createJar(Project prj, Path compileDir, Path jarFile) throws IOException {
-		String mainclass = prj.getMainClass();
 		Manifest manifest = new Manifest();
 		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
-		if (mainclass != null) {
-			manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, mainclass);
-		}
 
 		prj.getManifestAttributes().forEach((k, v) -> manifest.getMainAttributes().putValue(k, v));
 
-		// When persistent JVM args are set they are appended to any runtime
-		// options set on the Source (that way persistent args can override
-		// options set on the Source)
-		List<String> rtArgs = prj.getRuntimeOptions();
-		String runtimeOpts = CommandBuffer.of(rtArgs).asCommandLine(Util.Shell.bash);
-		// TODO should be removed
-		// if (!runtimeOpts.isEmpty()) {
-		// manifest.getMainAttributes()
-		// .putValue(ATTR_JBANG_JAVA_OPTIONS, runtimeOpts);
-		// }
 		int buildJdk = JavaUtil.javaVersion(prj.getJavaVersion());
 		if (buildJdk > 0) {
 			String val = buildJdk >= 9 ? Integer.toString(buildJdk) : "1." + buildJdk;
 			manifest.getMainAttributes().putValue(ATTR_BUILD_JDK, val);
 		}
 
-		FileOutputStream target = new FileOutputStream(jarFile.toFile());
-		JarUtil.jar(target, compileDir.toFile().listFiles(), null, null, manifest);
-		target.close();
+		JarUtil.createJar(jarFile, compileDir, manifest, prj.getMainClass(), prj.getJavaVersion());
 
 		if (AppBuilder.keepClasses()) {
 			// In the case the "keep classes" option is specified we write
 			// an extra copy if the manifest to its proper location.
 			// This file is never used but is there so the user can take
 			// a look at it and know what its contents are
+			String mainclass = prj.getMainClass();
+			if (mainclass != null) {
+				manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, mainclass);
+			}
 			Path mf = compileDir.resolve("META-INF/MANIFEST.MF");
 			try (OutputStream os = Files.newOutputStream(mf)) {
 				manifest.write(os);

--- a/src/main/java/dev/jbang/util/JarUtil.java
+++ b/src/main/java/dev/jbang/util/JarUtil.java
@@ -1,200 +1,85 @@
 package dev.jbang.util;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import static dev.jbang.util.JavaUtil.resolveInJavaHome;
+
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.jar.JarOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.jar.Manifest;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+
+import dev.jbang.cli.ExitException;
 
 public final class JarUtil {
 	private JarUtil() {
 	}
 
-	/**
-	 * <P>
-	 * This function will create a Jar archive containing the src file/directory.
-	 * The archive will be written to the specified OutputStream.
-	 * </P>
-	 *
-	 * <P>
-	 * This is a shortcut for<br>
-	 * <code>jar(out, new File[] { src }, null, null, null);</code>
-	 * </P>
-	 *
-	 * @param out The output stream to which the generated Jar archive is written.
-	 * @param src The file or directory to jar up. Directories will be processed
-	 *            recursively.
-	 * @throws IOException
-	 */
-	public static void jar(OutputStream out, File src) throws IOException {
-		jar(out, new File[] { src }, null, null, null);
-	}
-
-	/**
-	 * <P>
-	 * This function will create a Jar archive containing the src file/directory.
-	 * The archive will be written to the specified OutputStream.
-	 * </P>
-	 *
-	 * <P>
-	 * This is a shortcut for<br>
-	 * <code>jar(out, src, null, null, null);</code>
-	 * </P>
-	 *
-	 * @param out The output stream to which the generated Jar archive is written.
-	 * @param src The file or directory to jar up. Directories will be processed
-	 *            recursively.
-	 * @throws IOException
-	 */
-	public static void jar(OutputStream out, File[] src) throws IOException {
-		jar(out, src, null, null, null);
-	}
-
-	/**
-	 * <P>
-	 * This function will create a Jar archive containing the src file/directory.
-	 * The archive will be written to the specified OutputStream. Directories are
-	 * processed recursively, applying the specified filter if it exists.
-	 *
-	 * <P>
-	 * This is a shortcut for<br>
-	 * <code>jar(out, src, filter, null, null);</code>
-	 * </P>
-	 *
-	 * @param out    The output stream to which the generated Jar archive is
-	 *               written.
-	 * @param src    The file or directory to jar up. Directories will be processed
-	 *               recursively.
-	 * @param filter The filter to use while processing directories. Only those
-	 *               files matching will be included in the jar archive. If null,
-	 *               then all files are included.
-	 * @throws IOException
-	 */
-	public static void jar(OutputStream out, File[] src, FileFilter filter)
+	public static void createJar(Path jar, Path src, Manifest manifest, String mainClass, String requestedJavaVersion)
 			throws IOException {
-		jar(out, src, filter, null, null);
+		runJarCommand(jar, "c", src, manifest, mainClass, requestedJavaVersion);
 	}
 
-	/**
-	 * <P>
-	 * This function will create a Jar archive containing the src file/directory.
-	 * The archive will be written to the specified OutputStream. Directories are
-	 * processed recursively, applying the specified filter if it exists.
-	 *
-	 * @param out    The output stream to which the generated Jar archive is
-	 *               written.
-	 * @param src    The file or directory to jar up. Directories will be processed
-	 *               recursively.
-	 * @param filter The filter to use while processing directories. Only those
-	 *               files matching will be included in the jar archive. If null,
-	 *               then all files are included.
-	 * @param prefix The name of an arbitrary directory that will precede all
-	 *               entries in the jar archive. If null, then no prefix will be
-	 *               used.
-	 * @param man    The manifest to use for the Jar archive. If null, then no
-	 *               manifest will be included.
-	 * @throws IOException
-	 */
-	public static void jar(OutputStream out, File[] src, FileFilter filter,
-			String prefix, Manifest man) throws IOException {
-
-		for (File file : src) {
-			if (!file.exists()) {
-				throw new FileNotFoundException(file.toString());
-			}
-		}
-
-		JarOutputStream jout;
-		if (man == null) {
-			// noinspection resource
-			jout = new JarOutputStream(out);
-		} else {
-			// noinspection resource
-			jout = new JarOutputStream(out, man);
-		}
-		if (prefix != null && prefix.length() > 0 && !prefix.equals("/")) {
-			// strip leading '/'
-			if (prefix.charAt(0) == '/') {
-				prefix = prefix.substring(1);
-			}
-			// ensure trailing '/'
-			if (prefix.charAt(prefix.length() - 1) != '/') {
-				prefix = prefix + "/";
-			}
-		} else {
-			prefix = "";
-		}
-		JarInfo info = new JarInfo(jout, filter);
-		for (File file : src) {
-			jar(file, prefix, info);
-		}
-		jout.close();
-	}
-
-	/**
-	 * This simple convenience class is used by the jar method to reduce the number
-	 * of arguments needed. It holds all non-changing attributes needed for the
-	 * recursive jar method.
-	 */
-	private static class JarInfo {
-		public JarOutputStream out;
-		public FileFilter filter;
-		public byte[] buffer;
-
-		public JarInfo(JarOutputStream out, FileFilter filter) {
-			this.out = out;
-			this.filter = filter;
-			buffer = new byte[1024];
-		}
-	}
-
-	/**
-	 * This recursive method writes all matching files and directories to the jar
-	 * output stream.
-	 */
-	private static void jar(File src, String prefix, JarInfo info)
+	public static void updateJar(Path jar, Manifest manifest, String mainClass, String requestedJavaVersion)
 			throws IOException {
+		runJarCommand(jar, "u", null, manifest, mainClass, requestedJavaVersion);
+	}
 
-		JarOutputStream jout = info.out;
-		if (src.isDirectory()) {
-			// create / init the zip entry
-			prefix = prefix + src.getName() + "/";
-			ZipEntry entry = new ZipEntry(prefix);
-			entry.setTime(src.lastModified());
-			entry.setMethod(ZipOutputStream.STORED);
-			entry.setSize(0L);
-			entry.setCrc(0L);
-			jout.putNextEntry(entry);
-			jout.closeEntry();
+	private static void runJarCommand(Path jar, String action, Path src, Manifest manifest, String mainClass,
+			String requestedJavaVersion) throws IOException {
+		assert (action.equals("c") || action.equals("u"));
+		List<String> optionList = new ArrayList<>();
+		Path tmpManifest = null;
+		try {
+			action += "f";
+			optionList.add(jar.toString());
 
-			// process the sub-directories
-			File[] files = src.listFiles(info.filter);
-			for (File file : files) {
-				jar(file, prefix, info);
-			}
-		} else if (src.isFile()) {
-			// get the required info objects
-			byte[] buffer = info.buffer;
-
-			// create / init the zip entry
-			ZipEntry entry = new ZipEntry(prefix + src.getName());
-			entry.setTime(src.lastModified());
-			jout.putNextEntry(entry);
-
-			// dump the file
-			try (FileInputStream in = new FileInputStream(src)) {
-				int len;
-				while ((len = in.read(buffer, 0, buffer.length)) != -1) {
-					jout.write(buffer, 0, len);
+			if (manifest != null) {
+				tmpManifest = Files.createTempFile("jbang-manifest", "mf");
+				try (OutputStream out = Files.newOutputStream(tmpManifest)) {
+					manifest.write(out);
 				}
+				action += "m";
+				optionList.add(tmpManifest.toString());
 			}
-			jout.closeEntry();
 
+			if (mainClass != null) {
+				action += "e";
+				optionList.add(mainClass);
+			}
+
+			optionList.add(0, action);
+
+			if (src != null) {
+				optionList.add("-C");
+				optionList.add(src.toAbsolutePath().toString());
+				optionList.add(".");
+			}
+			runJarCommand(optionList, requestedJavaVersion);
+		} finally {
+			if (tmpManifest != null) {
+				Util.deletePath(tmpManifest, true);
+			}
+		}
+	}
+
+	private static void runJarCommand(List<String> arguments, String requestedJavaVersion) throws IOException {
+		arguments.add(0, resolveInJavaHome("jar", requestedJavaVersion));
+		Util.verboseMsg("Jar: " + String.join(" ", arguments));
+		// no inheritIO as jar complains unnecessarily about duplicate manifest entries.
+		ProcessBuilder pb = new ProcessBuilder(arguments);
+		if (Util.isVerbose()) {
+			pb.inheritIO();
+		}
+		Process process = pb.start();
+		try {
+			process.waitFor();
+		} catch (InterruptedException e) {
+			throw new ExitException(1, e);
+		}
+		if (process.exitValue() != 0) {
+			throw new ExitException(1, "Error creating/updating jar");
 		}
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -779,7 +779,7 @@ public class TestRun extends BaseTest {
 
 		try (JarFile jf = new JarFile(out.toFile())) {
 
-			assertThat(Collections.list(jf.entries()), IsCollectionWithSize.hasSize(5));
+			assertThat(Collections.list(jf.entries()), IsCollectionWithSize.hasSize(6));
 
 			assertThat(jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS), equalTo("wonkabear"));
 


### PR DESCRIPTION
We had to switch back to using the external `jar` command to create or update JARs because there doesn't seem to be an easy way to set the main class for Java modules without it.


