### PR TITLE
refactor: update release configuration

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Verify Changed files in docs
@@ -50,10 +50,10 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled }}
         with:
           limit-access-to-actor: true
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
       - name: install-java8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: temurin
@@ -103,13 +103,13 @@ jobs:
           powershell
           choco pack build/choco/jbang.nuspec
       - name: Archive build results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: ${{ runner.os }}-build-${{ github.sha }}
           path: build
       - name: Upload jbang.zip
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: always() && runner.os != 'Windows'
         with:
           name: jbang-${{ github.sha }}
@@ -125,11 +125,11 @@ jobs:
         java: [8,11,17,19]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: ${{ runner.os }}-build-${{ github.sha }}
           path: build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/install-tests.yml
+++ b/.github/workflows/install-tests.yml
@@ -6,7 +6,7 @@ jobs:
   macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Remove Java
       run: |
         sudo rm -rf /Library/Java/*

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -19,13 +19,17 @@ jobs:
       JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-      JRELEASER_VERSION: 0.9.0
+      JRELEASER_VERSION: 1.5.1
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: install-java11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: temurin
+          cache: gradle
       - name: build-gradle
         run: ./gradlew --no-daemon clean build -x test --build-cache --scan -s
       - name: version extract
@@ -35,15 +39,16 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
       - name: jreleaser publish
         continue-on-error: true
-        uses: jreleaser/release-action@v1
+        uses: jreleaser/release-action@v2
         env:
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:
           version: ${{ env.JRELEASER_VERSION }}
           arguments: publish
-      - name: JReleaser output
+          setup-java: false
+      - name: JReleaser publish output
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jreleaser-publish
           path: |
@@ -57,22 +62,23 @@ jobs:
         run: ./misc/updatespec.sh
       - name: jreleaser announce
         continue-on-error: true
-        uses: jreleaser/release-action@v1
+        uses: jreleaser/release-action@v2
         env:
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:
           version: ${{ env.JRELEASER_VERSION }}
           arguments: announce
-      - name: JReleaser output
+          setup-java: false
+      - name: JReleaser announce output
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jreleaser-announce
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
       - name: upload-choco
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: build-choco
           path: build/choco
@@ -82,7 +88,7 @@ jobs:
     name: publish-choco
     continue-on-error: true
     steps:
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: build-choco
           path: build/choco

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -19,19 +19,17 @@ jobs:
       JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
       JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-      JRELEASER_VERSION: 0.9.0
+      JRELEASER_VERSION: 1.5.1
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          fetch-depth: 0
       - name: install-java11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          distribution: temurin
+          cache: gradle
       - name: build-gradle
         run: ./gradlew --no-daemon clean build installDist --build-cache --scan -s
       - name: integration-test
@@ -48,9 +46,18 @@ jobs:
           RELEASE_VERSION=`cat build/tmp/version.txt`
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
       - name: Run JReleaser
-        uses: jreleaser/release-action@v1
+        uses: jreleaser/release-action@v2
         env: 
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:
           version: ${{ env.JRELEASER_VERSION }}
           arguments: release
+          setup-java: false
+      - name: JReleaser output
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jreleaser-release
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -5,13 +5,13 @@ project:
     Unleash the power of Java.
     Use `jbang` to run java, jar, jsh or kt file(s) with automatic dependency fetching
     and immediate compilation and execution.
-
-  website: https://jbang.dev
-  docsUrl: https://jbang.dev/documentation
+  links:
+    homepage: https://jbang.dev
+    documentation: https://jbang.dev/documentation
+    license: https://github.com/jbangdev/jbang/blob/main/LICENSE
   authors:
     - Max Rydahl Andersen
   license: MIT
-  licenseUrl: https://github.com/jbangdev/jbang/blob/main/LICENSE
   tags:
     - jbang
     - bash
@@ -21,8 +21,8 @@ project:
   java:
     groupId: dev.jbang
     version: 8
-  extraProperties:
-    inceptionYear: 2020
+  inceptionYear: 2020
+  stereotype: CLI
 
 release:
   github:
@@ -42,17 +42,17 @@ checksum:
   individual: true
 
 signing:
-  active: always
+  active: ALWAYS
   armored: true
 
 announce:
   twitter:
-    active: release
+    active: RELEASE
     status: 'JBang {{projectVersion}} has been released! {{releaseNotesUrl}}'
   sdkman:
-    active: release
+    active: RELEASE
   article:
-    active: release
+    active: RELEASE
     repository:
       name: jbang.dev
     files:
@@ -67,9 +67,10 @@ files:
 
 distributions:
   jbang:
-    executableExtension: cmd
+    executable:
+      windowsExtension: cmd
     docker:  ## not ready to release this way.
-      active: release
+      active: RELEASE
       continueOnError: true
       postCommands:
         - "VOLUME /scripts"
@@ -77,25 +78,25 @@ distributions:
       repository:
         name: jbang-action
     sdkman:
-      active: release
+      active: RELEASE
       continueOnError: true
     brew:
-      active: release
+      active: RELEASE
       continueOnError: true
       extraProperties:
         skipJava: true
     scoop:
-      active: release
+      active: RELEASE
       continueOnError: true
       bucket:
         name: 'scoop-bucket'
     chocolatey:
-      active: release
+      active: RELEASE
       continueOnError: true
       remoteBuild: true
       title: JBang
     snap:
-      active: release
+      active: RELEASE
       continueOnError: true
       remoteBuild: true
       base: core18


### PR DESCRIPTION
Update JReleaser configuration to 1.5.1
Update GH workflows with latest versions of several actions due to phase out of node 12 (see warnings on workflow executions).
