### PR TITLE
fix: no longer throws exception for certain config values

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -48,7 +48,7 @@ public class Edit extends BaseCommand {
 	public boolean live;
 
 	@CommandLine.Option(names = {
-			"--open" }, arity = "0..1", defaultValue = "${JBANG_EDITOR:-${jbang.edit.open:-}}", fallbackValue = "${JBANG_EDITOR:-${jbang.edit.open:-}}", description = "Opens editor/IDE on the temporary project.", preprocessor = StrictParameterPreprocessor.class)
+			"--open" }, arity = "0..1", defaultValue = "${JBANG_EDITOR:-${default.edit.open:-}}", fallbackValue = "${JBANG_EDITOR:-${default.edit.open:-}}", description = "Opens editor/IDE on the temporary project.", preprocessor = StrictParameterPreprocessor.class)
 	public Optional<String> editor;
 
 	@CommandLine.Option(names = { "--no-open" })

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 import dev.jbang.Configuration;
 import dev.jbang.util.Util;
@@ -213,10 +214,13 @@ public class JBang extends BaseCommand {
 	}
 
 	static class ConfigurationResourceBundle extends ResourceBundle {
+
+		private static final String PREFIX = "default.";
+
 		@Override
 		protected Object handleGetObject(String propkey) {
-			if (propkey.startsWith("jbang.")) {
-				String key = propkey.substring(6);
+			if (propkey.startsWith(PREFIX)) {
+				String key = propkey.substring(PREFIX.length());
 				return Configuration.instance().get(key);
 			} else {
 				return null;
@@ -225,7 +229,12 @@ public class JBang extends BaseCommand {
 
 		@Override
 		public Enumeration<String> getKeys() {
-			return Collections.enumeration(Configuration.instance().keySet());
+			return Collections.enumeration(Configuration.instance()
+														.flatten()
+														.keySet()
+														.stream()
+														.map(k -> "default." + k)
+														.collect(Collectors.toSet()));
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/RunMixin.java
+++ b/src/main/java/dev/jbang/cli/RunMixin.java
@@ -12,11 +12,11 @@ public class RunMixin {
 	public List<String> javaRuntimeOptions;
 
 	@CommandLine.Option(names = {
-			"--jfr" }, fallbackValue = "${jbang.run.jfr}", parameterConsumer = Run.KeyValueFallbackConsumer.class, arity = "0..1", description = "Launch with Java Flight Recorder enabled.")
+			"--jfr" }, fallbackValue = "${default.run.jfr}", parameterConsumer = Run.KeyValueFallbackConsumer.class, arity = "0..1", description = "Launch with Java Flight Recorder enabled.")
 	public String flightRecorderString;
 
 	@CommandLine.Option(names = { "-d",
-			"--debug" }, fallbackValue = "${jbang.run.debug}", parameterConsumer = Run.DebugFallbackConsumer.class, arity = "0..1", description = "Launch with java debug enabled on specified port (default: ${FALLBACK-VALUE}) ")
+			"--debug" }, fallbackValue = "${default.run.debug}", parameterConsumer = Run.DebugFallbackConsumer.class, arity = "0..1", description = "Launch with java debug enabled on specified port (default: ${FALLBACK-VALUE}) ")
 	public String debugString;
 
 	// should take arguments for package/classes when picocli fixes its flag

--- a/src/main/resources/jbang.properties
+++ b/src/main/resources/jbang.properties
@@ -1,6 +1,6 @@
+format=text
 init.template=hello
+jdkproviders=current,default,javahome,path,jbang
 run.debug=4004
 run.jfr=filename={baseName}.jfr
 wrapper.install.dir=.
-format=text
-jdkproviders=current,default,javahome,path,jbang


### PR DESCRIPTION
The way config values were being turned into a resource bundle te be used in PicoCli's default values was conflicting with PicoCli's resource string for usage/help. We now make sure our names don't conflict with those that PicoCli uses.

Fixes #1614
