### PR TITLE
feat: add support for --enable-preview

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 	id "com.github.breadmoirai.github-release" version "2.4.1"
 	id "io.toolebox.git-versioner" version "1.6.5"
 	id 'org.gradle.crypto.checksum' version '1.4.0'
-	id "com.diffplug.spotless" version "6.15.0"
+	id "com.diffplug.spotless" version "6.13.0" // can't go higher to still work with Java 8
 	id 'com.github.gmazzo.buildconfig' version "3.1.0"
 	id "com.dorongold.task-tree" version "2.1.1"
 	id "com.geoffgranum.gradle-conventional-changelog" version "0.3.1"

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -43,6 +43,8 @@ public class Alias extends CatalogItem {
 	public final String debug;
 	public final Boolean cds;
 	public final Boolean interactive;
+	@SerializedName(value = "enable-preview")
+	public final Boolean enablePreview;
 	@SerializedName(value = "enable-assertions")
 	public final Boolean enableAssertions;
 	@SerializedName(value = "enable-system-assertions")
@@ -69,6 +71,7 @@ public class Alias extends CatalogItem {
 
 	public Alias() {
 		this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+				null,
 				null, null, null, null, null, null, null);
 	}
 
@@ -92,6 +95,7 @@ public class Alias extends CatalogItem {
 			String debug,
 			Boolean cds,
 			Boolean interactive,
+			Boolean enablePreview,
 			Boolean enableAssertions,
 			Boolean enableSystemAssertions,
 			Map<String, String> manifestOptions,
@@ -118,6 +122,7 @@ public class Alias extends CatalogItem {
 		this.debug = debug;
 		this.cds = cds;
 		this.interactive = interactive;
+		this.enablePreview = enablePreview;
 		this.enableAssertions = enableAssertions;
 		this.enableSystemAssertions = enableSystemAssertions;
 		this.manifestOptions = manifestOptions;
@@ -209,6 +214,7 @@ public class Alias extends CatalogItem {
 			String debug = a1.debug != null ? a1.debug : a2.debug;
 			Boolean cds = a1.cds != null ? a1.cds : a2.cds;
 			Boolean inter = a1.interactive != null ? a1.interactive : a2.interactive;
+			Boolean ep = a1.enablePreview != null ? a1.enablePreview : a2.enablePreview;
 			Boolean ea = a1.enableAssertions != null ? a1.enableAssertions : a2.enableAssertions;
 			Boolean esa = a1.enableSystemAssertions != null ? a1.enableSystemAssertions : a2.enableSystemAssertions;
 			Map<String, String> mopts = a1.manifestOptions != null && !a1.manifestOptions.isEmpty() ? a1.manifestOptions
@@ -216,7 +222,8 @@ public class Alias extends CatalogItem {
 			List<JavaAgent> jags = a1.javaAgents != null && !a1.javaAgents.isEmpty() ? a1.javaAgents : a2.javaAgents;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
 			return new Alias(a2.scriptRef, desc, args, jopts, srcs, ress, deps, repos, cpaths, props, javaVersion,
-					mainClass, moduleName, copts, nimg, nopts, jfr, debug, cds, inter, ea, esa, mopts, jags, catalog);
+					mainClass, moduleName, copts, nimg, nopts, jfr, debug, cds, inter, ep, ea, esa, mopts, jags,
+					catalog);
 		} else {
 			return a1;
 		}
@@ -259,14 +266,16 @@ public class Alias extends CatalogItem {
 	public Alias withCatalog(Catalog catalog) {
 		return new Alias(scriptRef, description, arguments, runtimeOptions, sources, resources, dependencies,
 				repositories, classpaths, properties, javaVersion, mainClass, moduleName, compileOptions, nativeImage,
-				nativeOptions, jfr, debug, cds, interactive, enableAssertions, enableSystemAssertions, manifestOptions,
+				nativeOptions, jfr, debug, cds, interactive, enablePreview, enableAssertions, enableSystemAssertions,
+				manifestOptions,
 				javaAgents, catalog);
 	}
 
 	public Alias withScriptRef(String scriptRef) {
 		return new Alias(scriptRef, description, arguments, runtimeOptions, sources, resources, dependencies,
 				repositories, classpaths, properties, javaVersion, mainClass, moduleName, compileOptions, nativeImage,
-				nativeOptions, jfr, debug, cds, interactive, enableAssertions, enableSystemAssertions, manifestOptions,
+				nativeOptions, jfr, debug, cds, interactive, enablePreview, enableAssertions, enableSystemAssertions,
+				manifestOptions,
 				javaAgents, catalog);
 	}
 }

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -84,6 +84,9 @@ class AliasAdd extends BaseAliasCommand {
 	@CommandLine.Option(names = { "--name" }, description = "A name for the alias")
 	String name;
 
+	@CommandLine.Option(names = { "--enable-preview" }, description = "Activate Java preview features")
+	boolean enablePreviewRequested;
+
 	@CommandLine.Parameters(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
 	List<String> userParams;
 
@@ -111,6 +114,7 @@ class AliasAdd extends BaseAliasCommand {
 				dependencyInfoMixin.getProperties(), buildMixin.javaVersion, buildMixin.main, buildMixin.module,
 				buildMixin.compileOptions, nativeMixin.nativeImage, nativeMixin.nativeOptions,
 				runMixin.flightRecorderString, runMixin.debugString, runMixin.cds, runMixin.interactive,
+				enablePreviewRequested,
 				runMixin.enableAssertions, runMixin.enableSystemAssertions, buildMixin.manifestOptions,
 				createJavaAgents(), null);
 		if (catFile != null) {
@@ -136,7 +140,8 @@ class AliasAdd extends BaseAliasCommand {
 									.moduleName(buildMixin.module)
 									.compileOptions(buildMixin.compileOptions)
 									.nativeImage(nativeMixin.nativeImage)
-									.nativeOptions(nativeMixin.nativeOptions);
+									.nativeOptions(nativeMixin.nativeOptions)
+									.enablePreview(enablePreviewRequested);
 		Path cat = getCatalog(false);
 		if (cat != null) {
 			pb.catalog(cat.toFile());
@@ -245,6 +250,7 @@ class AliasList extends BaseAliasCommand {
 		public List<String> javaOptions;
 		public Map<String, String> properties;
 		public transient ResourceRef _catalogRef;
+		public Boolean enablePreview;
 	}
 
 	private static AliasOut getAliasOut(String catalogName, Catalog catalog, String name) {
@@ -269,6 +275,7 @@ class AliasList extends BaseAliasCommand {
 		out.javaOptions = alias.runtimeOptions;
 		out.properties = alias.properties;
 		out._catalogRef = alias.catalog.catalogRef;
+		out.enablePreview = alias.enablePreview;
 		return out;
 	}
 
@@ -290,6 +297,9 @@ class AliasList extends BaseAliasCommand {
 		}
 		if (alias.mainClass != null) {
 			out.println(prefix + ConsoleOutput.cyan("   Main Class: ") + alias.mainClass);
+		}
+		if (alias.enablePreview != null) {
+			out.println(prefix + ConsoleOutput.cyan("   Enable Preview: ") + alias.enablePreview);
 		}
 		if (alias.javaOptions != null) {
 			out.println(prefix + ConsoleOutput.cyan("   Java Options: ") + String.join(" ", alias.javaOptions));

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -30,6 +30,9 @@ public abstract class BaseBuildCommand extends BaseCommand {
 			"--build-dir" }, description = "Use given directory for build results")
 	Path buildDir;
 
+	@CommandLine.Option(names = { "--enable-preview" }, description = "Activate Java preview features")
+	boolean enablePreviewRequested;
+
 	PrintStream out = new PrintStream(new FileOutputStream(FileDescriptor.out));
 
 	protected ProjectBuilder createBaseProjectBuilder() {
@@ -48,7 +51,8 @@ public abstract class BaseBuildCommand extends BaseCommand {
 						.compileOptions(buildMixin.compileOptions)
 						.manifestOptions(buildMixin.manifestOptions)
 						.nativeImage(nativeMixin.nativeImage)
-						.nativeOptions(nativeMixin.nativeOptions);
+						.nativeOptions(nativeMixin.nativeOptions)
+						.enablePreview(enablePreviewRequested);
 
 		// NB: Do not put `.mainClass(buildMixin.main)` here
 	}

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -56,7 +56,7 @@ public class JBang extends BaseCommand {
 			"--version" }, versionHelp = true, description = "Display version info (use `jbang --verbose version` for more details)")
 	boolean versionRequested;
 
-	@CommandLine.Option(names = { "--preview" }, description = "Enable preview features")
+	@CommandLine.Option(names = { "--preview" }, description = "Enable jbang preview features")
 	void setPreview(boolean preview) {
 		Util.setPreview(preview);
 	}

--- a/src/main/java/dev/jbang/source/Project.java
+++ b/src/main/java/dev/jbang/source/Project.java
@@ -41,6 +41,7 @@ public class Project {
 	private String mainClass;
 	private String moduleName;
 	private boolean nativeImage;
+	private boolean enablePreviewRequested;
 
 	// Cached values
 	private String stableId;
@@ -48,6 +49,10 @@ public class Project {
 
 	public static final String ATTR_PREMAIN_CLASS = "Premain-Class";
 	public static final String ATTR_AGENT_CLASS = "Agent-Class";
+
+	public boolean enablePreview() {
+		return enablePreviewRequested || (mainSource != null && mainSource.enablePreview());
+	}
 
 	public enum BuildFile {
 		jbang("build.jbang");
@@ -181,6 +186,10 @@ public class Project {
 
 	public void setMainClass(String mainClass) {
 		this.mainClass = mainClass;
+	}
+
+	public void setEnablePreviewRequested(boolean enablePreview) {
+		this.enablePreviewRequested = enablePreview;
 	}
 
 	@Nonnull

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -53,6 +53,7 @@ public class ProjectBuilder {
 	private Boolean nativeImage;
 	private String javaVersion;
 	private Properties contextProperties;
+	private boolean enablePreview;
 
 	ProjectBuilder() {
 	}
@@ -158,6 +159,11 @@ public class ProjectBuilder {
 
 	public ProjectBuilder nativeImage(Boolean nativeImage) {
 		this.nativeImage = nativeImage;
+		return this;
+	}
+
+	public ProjectBuilder enablePreview(boolean enablePreviewRequested) {
+		this.enablePreview = enablePreviewRequested;
 		return this;
 	}
 
@@ -408,6 +414,7 @@ public class ProjectBuilder {
 		if (nativeImage != null) {
 			prj.setNativeImage(nativeImage);
 		}
+		prj.setEnablePreviewRequested(enablePreview);
 		return prj;
 	}
 
@@ -497,4 +504,5 @@ public class ProjectBuilder {
 	public static boolean isAlias(ResourceRef resourceRef) {
 		return resourceRef instanceof AliasResourceResolver.AliasedResourceRef;
 	}
+
 }

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -105,6 +105,10 @@ public abstract class Source {
 		return !tagReader.collectRawOptions("CDS").isEmpty();
 	}
 
+	public boolean enablePreview() {
+		return !tagReader.collectRawOptions("PREVIEW").isEmpty();
+	}
+
 	/**
 	 * Updates the given <code>Project</code> with all the information from this
 	 * <code>Source</code> when that source is the main file. It updates certain

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -70,6 +70,11 @@ public abstract class CompileBuildStep implements Builder<Project> {
 		Path compileDir = ctx.getCompileDir();
 		List<String> optionList = new ArrayList<>();
 		optionList.add(getCompilerBinary(requestedJavaVersion));
+		if (project.enablePreview()) {
+			optionList.add("--enable-preview");
+			optionList.add("-source");
+			optionList.add("" + JavaUtil.javaVersion(requestedJavaVersion));
+		}
 		optionList.addAll(project.getMainSourceSet().getCompileOptions());
 		String path = project.resolveClassPath().getClassPath();
 		if (!Util.isBlankString(path)) {

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -100,6 +100,10 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 			optionalArgs.add("-esa");
 		}
 
+		if (project.enablePreview()) {
+			optionalArgs.add("--enable-preview");
+		}
+
 		if (flightRecorderString != null) {
 			// TODO: find way to generate ~/.jbang/script.jfc to configure flightrecorder to
 			// have 0 ms thresholds

--- a/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JshCmdGenerator.java
@@ -60,6 +60,13 @@ public class JshCmdGenerator extends BaseCmdGenerator<JshCmdGenerator> {
 		// NB: See https://github.com/jbangdev/jbang/issues/992 for the reasons why we
 		// use the -J flags below
 
+		if (project.enablePreview()) {
+			// jshell does not seem to automaticall pass enable-preview to runtime/compiler
+			optionalArgs.add("--enable-preview");
+			optionalArgs.add("-J--enable-preview");
+			optionalArgs.add("-C--enable-preview");
+		}
+
 		optionalArgs.add("--execution=local");
 		optionalArgs.add("-J--add-modules=ALL-SYSTEM");
 

--- a/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
@@ -23,6 +23,10 @@ public class NativeCmdGenerator extends BaseCmdGenerator<NativeCmdGenerator> {
 	public String generate() throws IOException {
 		List<String> fullArgs = new ArrayList<>();
 
+		if (project.enablePreview()) {
+			fullArgs.add("--enable-preview");
+		}
+
 		Path image = ctx.getNativeImageFile();
 		if (Files.exists(image)) {
 			fullArgs.add(image.toString());

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1368,6 +1368,87 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testEnablePreviewInSource(@TempDir Path output) throws Exception {
+		String source = "//PREVIEW\nclass cds { }";
+		Path p = output.resolve("cds.java");
+		writeString(p, source);
+
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", p.toString());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		pb.mainClass("fakemain");
+		Project code = pb.build(p);
+
+		String commandLine = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
+		assertThat(commandLine, containsString("--enable-preview"));
+	}
+
+	@Test
+	void testEnablePreview() throws IOException {
+		File f = examplesTestFolder.resolve("resource.java").toFile();
+
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--enable-preview", "--main",
+													"fakemain",
+													f.getAbsolutePath());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		Project prj = pb.build(f.getAbsolutePath());
+
+		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
+
+		assertThat(line, containsString("--enable-preview"));
+	}
+
+	@Test
+	void testEnablePreviewJsh() throws IOException {
+		File f = examplesTestFolder.resolve("resource.java").toFile();
+
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--enable-preview", "-i", "--main",
+													"fakemain",
+													f.getAbsolutePath());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		Project prj = pb.build(f.getAbsolutePath());
+
+		BuildContext ctx = BuildContext.forProject(prj, null);
+		CmdGeneratorBuilder genb = prj.codeBuilder(ctx).build();
+
+		String cmdline = run.updateGeneratorForRun(genb).build().generate();
+
+		assertThat(cmdline, containsString("--enable-preview"));
+		assertThat(cmdline, containsString("-C--enable-preview"));
+		assertThat(cmdline, containsString("-J--enable-preview"));
+	}
+
+	@Test
+	void testEnablePreviewJava() throws IOException {
+		File f = examplesTestFolder.resolve("resource.java").toFile();
+
+		CommandLine.ParseResult pr = JBang	.getCommandLine()
+											.parseArgs("run", "--enable-preview", "--main",
+													"fakemain",
+													f.getAbsolutePath());
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		Project prj = pb.build(f.getAbsolutePath());
+
+		BuildContext ctx = BuildContext.forProject(prj, null);
+		CmdGeneratorBuilder genb = prj.codeBuilder(ctx).build();
+
+		String cmdline = run.updateGeneratorForRun(genb).build().generate();
+
+		assertThat(cmdline, containsString("--enable-preview"));
+		assertThat(cmdline, not(containsString("-C--enable-preview")));
+		assertThat(cmdline, not(containsString("-J--enable-preview")));
+	}
+
+	@Test
 	void testFilePresentB() throws IOException {
 		File f = examplesTestFolder.resolve("resource.java").toFile();
 

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -54,6 +54,28 @@ public class TestBuilder extends BaseTest {
 	}
 
 	@Test
+	void testEnablePreview() throws IOException {
+		Path foo = examplesTestFolder.resolve("helloworld.java").toAbsolutePath();
+		ProjectBuilder pb = Project.builder();
+		Project prj = pb.build(foo.toString());
+		prj.setEnablePreviewRequested(true);
+		BuildContext ctx = BuildContext.forProject(prj);
+
+		new JavaSource.JavaAppBuilder(prj, ctx) {
+			@Override
+			protected Builder<Project> getCompileBuildStep() {
+				return new JavaCompileBuildStep() {
+					@Override
+					protected void runCompiler(List<String> optionList) {
+						assertThat(optionList, hasItems(foo.toString(), "--enable-preview"));
+						// Skip the compiler
+					}
+				};
+			}
+		}.setFresh(true).build();
+	}
+
+	@Test
 	void testDualHelloworld(@TempDir File out1, @TempDir File out2) throws IOException {
 		Path foo = examplesTestFolder.resolve("helloworld.java").toAbsolutePath();
 		ProjectBuilder pb = Project.builder();


### PR DESCRIPTION
Why:

 * --enable-preview is a common flag to enable preview features in Java 9 and up
    but is hard to use with jbang as it is not passed on to the java,javac
    and jshell command when running a script.
 * workaround thus far been to pass -C=--enable-preview and -R=--enable-preview
    but that does not work for jshell

This change addreses the need by:

 * introducing `--enable-preview` flag to jbang which will pass it on to
    java, javac and jshell as appropriate
 * `//PREVIEW` in source files is possible
 * aliases can specify enable preview too.

Fixes #1622