### PR TITLE
fix: allow uppercase group and artifactId names

### DIFF
--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -44,10 +44,10 @@ public class DependencyUtil {
 	}
 
 	public static final Pattern fullGavPattern = Pattern.compile(
-			"^(?<groupid>[a-z0-9_.-]*):(?<artifactid>[a-z0-9_.-]*):(?<version>[^:@]*)(:(?<classifier>[^@]*))?(@(?<type>.*))?$");
+			"^(?<groupid>[a-zA-Z0-9_.-]*):(?<artifactid>[a-zA-Z0-9_.-]*):(?<version>[^:@]*)(:(?<classifier>[^@]*))?(@(?<type>.*))?$");
 
 	public static final Pattern lenientGavPattern = Pattern.compile(
-			"^(?<groupid>[a-z0-9_.-]*):(?<artifactid>[a-z0-9_.-]*)(:(?<version>[^:@]*)(:(?<classifier>[^@]*))?)?(@(?<type>.*))?$");
+			"^(?<groupid>[a-zA-Z0-9_.-]*):(?<artifactid>[a-zA-Z0-9_.-]*)(:(?<version>[^:@]*)(:(?<classifier>[^@]*))?)?(@(?<type>.*))?$");
 
 	private DependencyUtil() {
 	}

--- a/src/test/java/dev/jbang/source/TestTagReader.java
+++ b/src/test/java/dev/jbang/source/TestTagReader.java
@@ -15,10 +15,10 @@ public class TestTagReader {
 	@Test
 	void testExtractDependencies() {
 		TagReader tr = new TagReader.Extended(
-				"//DEPS foo:bar, abc:def:123, https://github.com/jbangdev/jbang, something", null);
+				"//DEPS foo:bar, abc:DEF:123, https://github.com/jbangdev/jbang, something", null);
 
 		List<String> deps = tr.collectBinaryDependencies();
-		assertThat(deps, containsInAnyOrder("foo:bar", "abc:def:123", "https://github.com/jbangdev/jbang"));
+		assertThat(deps, containsInAnyOrder("foo:bar", "abc:DEF:123", "https://github.com/jbangdev/jbang"));
 
 		List<String> subs = tr.collectSourceDependencies();
 		assertThat(subs, containsInAnyOrder("something"));


### PR DESCRIPTION
Fixes #1652 

Updates the regex `dev.jbang.dependencies.DependencyUtil#lenientGavPattern` to accept uppercase `groupId` and `artifactId`.
