### PR TITLE
fix: we now only add `-g` flag to Java source types

### DIFF
--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -26,6 +26,7 @@ import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.*;
 import dev.jbang.source.buildsteps.JarBuildStep;
 import dev.jbang.source.resolvers.*;
+import dev.jbang.source.sources.JavaSource;
 import dev.jbang.util.JavaUtil;
 import dev.jbang.util.ModuleUtil;
 import dev.jbang.util.PropertiesValueResolver;
@@ -464,7 +465,9 @@ public class ProjectBuilder {
 		prj.setGav(src.tagReader.getGav().orElse(null));
 		prj.setMainClass(src.tagReader.getMain().orElse(null));
 		prj.setModuleName(src.tagReader.getModule().orElse(null));
-		prj.getMainSourceSet().addCompileOption("-g");
+		if (prj.getMainSource() instanceof JavaSource) {
+			prj.getMainSourceSet().addCompileOption("-g");
+		}
 		return updateProject(src, prj, resolver);
 	}
 

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -23,6 +23,10 @@ public class GroovySource extends Source {
 		super(script, replaceProperties);
 	}
 
+	public GroovySource(String script, Function<String, String> replaceProperties) {
+		super(script, replaceProperties);
+	}
+
 	@Override
 	protected List<String> getCompileOptions() {
 		return tagReader.collectOptions("COMPILE_OPTIONS");

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -19,6 +19,10 @@ public class KotlinSource extends Source {
 		super(script, replaceProperties);
 	}
 
+	public KotlinSource(String script, Function<String, String> replaceProperties) {
+		super(script, replaceProperties);
+	}
+
 	@Override
 	protected List<String> getCompileOptions() {
 		return tagReader.collectOptions("COMPILE_OPTIONS");

--- a/src/test/java/dev/jbang/source/TestSource.java
+++ b/src/test/java/dev/jbang/source/TestSource.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import dev.jbang.BaseTest;
 import dev.jbang.net.TrustedSources;
+import dev.jbang.source.sources.GroovySource;
 import dev.jbang.source.sources.JavaSource;
+import dev.jbang.source.sources.KotlinSource;
 import dev.jbang.util.PropertiesValueResolver;
 
 public class TestSource extends BaseTest {
@@ -150,6 +152,28 @@ public class TestSource extends BaseTest {
 			"//COMPILE_OPTIONS commons-codec:commons-codec:1.15 // <.>\n" +
 			"public class test {" +
 			"}";
+
+	String groovyExample = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
+			"//DEPS info.picocli:picocli:4.6.3\n" +
+			"\n" +
+			"//RUNTIME_OPTIONS --enable-preview \"-Dvalue='this is space'\"\n" +
+			"//JAVA_OPTIONS --enable-preview\n" +
+			"//COMPILE_OPTIONS --enable-preview\n" +
+			"//NATIVE_OPTIONS -O1\n" +
+			"\n" +
+			"println(\"Hello World\");\n";
+
+	String kotlinExample = "///usr/bin/env jbang \"$0\" \"$@\" ; exit $?\n" +
+			"//DEPS info.picocli:picocli:4.6.3\n" +
+			"\n" +
+			"//RUNTIME_OPTIONS --enable-preview \"-Dvalue='this is space'\"\n" +
+			"//JAVA_OPTIONS --enable-preview\n" +
+			"//COMPILE_OPTIONS --enable-preview\n" +
+			"//NATIVE_OPTIONS -O1\n" +
+			"\n" +
+			"public fun main() {\n" +
+			"    println(\"Hello World\");\n" +
+			"}\n";
 
 	@Test
 	void testCommentsDoesNotGetPickedUp() {
@@ -281,10 +305,31 @@ public class TestSource extends BaseTest {
 	}
 
 	@Test
-	void testExtractOptions() {
+	void testExtractJavaOptions() {
 		Source s = new JavaSource(example, null);
 
 		assertEquals(Arrays.asList("--verbose", "--enable-preview"), s.getCompileOptions());
+		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
+		assertEquals(Arrays.asList("--enable-preview", "--enable-preview", "-Dvalue='this is space'"),
+				s.getRuntimeOptions());
+
+	}
+
+	@Test
+	void testExtractGroovyOptions() {
+		Source s = new GroovySource(groovyExample, null);
+
+		assertEquals(Arrays.asList("--enable-preview"), s.getCompileOptions());
+		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
+		assertEquals(Arrays.asList("-Dgroovy.grape.enable=false", "--enable-preview", "--enable-preview",
+				"-Dvalue='this is space'"), s.getRuntimeOptions());
+	}
+
+	@Test
+	void testExtractKotlinOptions() {
+		Source s = new KotlinSource(kotlinExample, null);
+
+		assertEquals(Arrays.asList("--enable-preview"), s.getCompileOptions());
 		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
 		assertEquals(Arrays.asList("--enable-preview", "--enable-preview", "-Dvalue='this is space'"),
 				s.getRuntimeOptions());


### PR DESCRIPTION
Before it would get added to Groovy and Kotlin as well.

Fixes #1656
