### PR TITLE
fix: check manifest exist before reading from it

### DIFF
--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -365,9 +365,16 @@ public class ProjectBuilder {
 					prj.setModuleName(moduleName);
 				}
 
-				Attributes attrs = jf.getManifest().getMainAttributes();
-				if (attrs.containsKey(Attributes.Name.MAIN_CLASS)) {
-					prj.setMainClass(attrs.getValue(Attributes.Name.MAIN_CLASS));
+				if (jf.getManifest() != null) {
+					Attributes attrs = jf.getManifest().getMainAttributes();
+					if (attrs.containsKey(Attributes.Name.MAIN_CLASS)) {
+						prj.setMainClass(attrs.getValue(Attributes.Name.MAIN_CLASS));
+					}
+					String ver = attrs.getValue(JarBuildStep.ATTR_BUILD_JDK);
+					if (ver != null) {
+						// buildJdk = JavaUtil.parseJavaVersion(ver);
+						prj.setJavaVersion(JavaUtil.parseJavaVersion(ver) + "+");
+					}
 				}
 
 				Optional<JarEntry> pom = jf.stream().filter(e -> e.getName().endsWith("/pom.xml")).findFirst();
@@ -390,11 +397,6 @@ public class ProjectBuilder {
 					}
 				}
 
-				String ver = attrs.getValue(JarBuildStep.ATTR_BUILD_JDK);
-				if (ver != null) {
-					// buildJdk = JavaUtil.parseJavaVersion(ver);
-					prj.setJavaVersion(JavaUtil.parseJavaVersion(ver) + "+");
-				}
 			} catch (IOException e) {
 				Util.warnMsg("Problem reading manifest from " + jar);
 			}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -2406,4 +2406,24 @@ public class TestRun extends BaseTest {
 		assertThat(result.err, containsString("foo%{" + arg + "}bar"));
 		assertThat(result.err, not(containsString("foo%%{" + arg + "}bar")));
 	}
+
+	@Test
+	void testHelloWorldGAVWithModulesButNoManifest() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		String jar = "org.graalvm.python:python-launcher:23.1.0";
+
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", jar);
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		Project code = pb.build(jar);
+
+		// assertThat(code.getResourceRef().getFile().toString(),
+		// matchesPattern(".*jbang_tests_maven.*codegen-4.6.3.jar"));
+
+		ExitException e = Assertions.assertThrows(ExitException.class,
+				() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
+
+		assertThat(e.getMessage(), startsWith("no main class"));
+	}
 }


### PR DESCRIPTION
Fixes #1684 

for the specific case of having module info but NO manifest then it fails.

this fixes that.