### PR TITLE
fix: use the custom debug port when provided

### DIFF
--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -89,11 +89,11 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 			fallbackDebug.put("transport", "dt_socket");
 			fallbackDebug.put("server", "y");
 			fallbackDebug.put("suspend", "y");
-			fallbackDebug.putAll(debugString);
+			fallbackDebug.put("address", "4004");
 			// needed even though there is a fallbackvalue as user might have set some other
 			// key/value
 			// i.e. --debug=server=n
-			fallbackDebug.put("address", "4004");
+			fallbackDebug.putAll(debugString);
 			optionalArgs.add(
 					"-agentlib:jdwp=" + fallbackDebug	.entrySet()
 														.stream()

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -654,6 +654,26 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testDebugHostWithCustomPort() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--debug=5000", arg);
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		pb.mainClass("fakemain");
+		Project prj = pb.build(arg);
+
+		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
+
+		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
+		assertThat(result, containsString("helloworld.java"));
+		assertThat(result, containsString("classpath"));
+		assertThat(result, containsString("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5000"));
+		assertThat(result, not(containsString("  ")));
+	}
+
+	@Test
 	void testDependencies() throws IOException {
 
 		environmentVariables.clear("JAVA_HOME");


### PR DESCRIPTION
fixes #1689 

## Motivation

When a custom debug port is provided thanks to the parameter `--debug`, the port `4004` is still used.

## Modifications:

* Ensure that the default values including the port can be redefined by the end user
* Add a unit test to cover the use case