### PR TITLE
fix: handle debug output messing up jbangdev

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -221,6 +221,11 @@ export JBANG_STDIN_NOTTY=$([ -t 0 ] && echo "false" || echo "true")
 output=$(CLICOLOR_FORCE=1 "${JAVA_EXEC}" ${JBANG_JAVA_OPTIONS} -classpath "${jarPath}" dev.jbang.Main "$@")
 err=$?
 if [ $err -eq 255 ]; then
+  nl=$'\n'
+  if [[ $output =~ $nl  ]]; then
+    ## keep the last output line to avoid being polluted by the potential verbosity of the JVM
+    output=$(echo "$output" | tail -1)
+  fi
   eval "exec $output"
 elif [ -n "$output" ]; then
   echo "$output"


### PR DESCRIPTION
fixes #1572 

## Motivation

The verbosity of the JVM may prevent the debug mode from working properly with an error of type `jbang: line 230: exec: Listening: not found`

## Modifications:

* Keep the last line of the output to avoid being affected by the verbosity of the JVM.

## Result:

```
$ export JBANG_JAVA_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005" 
$ jbang hello.java Max!
Listening for transport dt_socket at address: 5005
Hello Max!
```

**NB:** This fix doesn't cover Windows OS