### PR TITLE
test: updated docker-compose file for testing proxies

### DIFF
--- a/misc/proxy/config/tinyproxy.conf
+++ b/misc/proxy/config/tinyproxy.conf
@@ -1,0 +1,5 @@
+# Uncomment if you want to test proxy authentication
+#BasicAuth test test
+
+Port 8888
+

--- a/misc/proxy/docker-compose.yml
+++ b/misc/proxy/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     networks:
       - no-internet
       - internet
+    volumes:
+      - ./config:/etc/tinyproxy
     restart: unless-stopped
 
   jbang:


### PR DESCRIPTION
We can now test with proxies that require authentication.
