### PR TITLE
fix: allow to mark http url as trusted

### DIFF
--- a/src/main/java/dev/jbang/net/TrustedSources.java
+++ b/src/main/java/dev/jbang/net/TrustedSources.java
@@ -85,7 +85,7 @@ public class TrustedSources {
 			}
 
 			URI parsedTrustedSource;
-			if (trustedSource.startsWith("http://")) {
+			if (trustedSource.startsWith("https://")||trustedSource.startsWith("http://")) {
 				parsedTrustedSource = new URI(trustedSource);
 				if (!url.getScheme().equals(parsedTrustedSource.getScheme())) {
 					continue;

--- a/src/main/java/dev/jbang/net/TrustedSources.java
+++ b/src/main/java/dev/jbang/net/TrustedSources.java
@@ -85,7 +85,7 @@ public class TrustedSources {
 			}
 
 			URI parsedTrustedSource;
-			if (trustedSource.startsWith("https://")) {
+			if (trustedSource.startsWith("http://")) {
 				parsedTrustedSource = new URI(trustedSource);
 				if (!url.getScheme().equals(parsedTrustedSource.getScheme())) {
 					continue;

--- a/src/main/java/dev/jbang/net/TrustedSources.java
+++ b/src/main/java/dev/jbang/net/TrustedSources.java
@@ -85,7 +85,7 @@ public class TrustedSources {
 			}
 
 			URI parsedTrustedSource;
-			if (trustedSource.startsWith("https://")||trustedSource.startsWith("http://")) {
+			if (trustedSource.startsWith("https://") || trustedSource.startsWith("http://")) {
 				parsedTrustedSource = new URI(trustedSource);
 				if (!url.getScheme().equals(parsedTrustedSource.getScheme())) {
 					continue;


### PR DESCRIPTION
I have added http inside trustedSource.startsWith .

![image](https://github.com/jbangdev/jbang/assets/42388388/b1d5cf0a-6ea5-4e7c-91a3-9eec6a01c6b2)

