### PR TITLE
chore(deps): Update MIMA to 2.4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,6 +235,7 @@ compileJava9Java {
 shadowJar {
 	minimize() {
 		//exclude(dependency('org.slf4j:slf4j-api:.*'))
+		exclude(dependency('eu.maveniverse.maven.mima:context:.*'))
 		exclude(dependency('eu.maveniverse.maven.mima.runtime:standalone-static:.*'))
 		exclude(dependency('org.slf4j:jcl-over-slf4j:.*'))
 		exclude(dependency('org.slf4j:slf4j-nop:.*'))

--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,8 @@ dependencies {
 	implementation "org.slf4j:jcl-over-slf4j:1.7.30"
 	implementation "org.jboss:jandex:2.2.3.Final"
 
-	implementation "eu.maveniverse.maven.mima:context:2.4.3"
-	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.3"
+	implementation "eu.maveniverse.maven.mima:context:2.4.4"
+	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.4"
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.0"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.9.0"


### PR DESCRIPTION
https://github.com/maveniverse/mima/releases/tag/release-2.4.4

This version is now aligned with Maven 3.9.6.
