### PR TITLE
[EXPERIMENT] Try out MIMA 3.0.0-alpha-1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,8 @@ dependencies {
 	implementation "org.slf4j:jcl-over-slf4j:1.7.30"
 	implementation "org.jboss:jandex:2.2.3.Final"
 
-	implementation "eu.maveniverse.maven.mima:context:2.4.3"
-	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.3"
+	implementation "eu.maveniverse.maven.mima:context:3.0.0-alpha-1"
+	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:3.0.0-alpha-1"
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.0"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.9.0"
@@ -235,6 +235,7 @@ compileJava9Java {
 shadowJar {
 	minimize() {
 		//exclude(dependency('org.slf4j:slf4j-api:.*'))
+		exclude(dependency('eu.maveniverse.maven.mima:context:.*'))
 		exclude(dependency('eu.maveniverse.maven.mima.runtime:standalone-static:.*'))
 		exclude(dependency('org.slf4j:jcl-over-slf4j:.*'))
 		exclude(dependency('org.slf4j:slf4j-nop:.*'))


### PR DESCRIPTION
This PR is **not for merge**. It's sole purpose is to get more funny GIFs  with floppies.

Note: maven and resolver alphas since their release has known bugs and issues, while most of them are fixed, these are latest alphas present in Central. But this release is still ok to fiddle against Central.

Trick: if you build this JBang, it will use the latest "jdk" HTTP/2 transport (and old "apache" transport is dropped).
