### PR TITLE
fix: typo in edit message

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -154,8 +154,8 @@ public class Init extends BaseCommand {
 					+ "' or edit it using 'jbang edit --open=[editor] "
 					+ renderedScriptOrFile + "' where [editor] is your editor or IDE, e.g. '"
 					+ Edit.knownEditors[new Random().nextInt(Edit.knownEditors.length)]
-					+ "'. If your IDE supports JBang, you can edit the directory instead: 'jbang edit . '"
-					+ ". See https://jbang.dev/ide");
+					+ "'. If your IDE supports JBang, you can edit the directory instead: 'jbang edit . "
+					+ renderedScriptOrFile + "'. See https://jbang.dev/ide");
 		}
 		return EXIT_OK;
 	}

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -155,7 +155,7 @@ public class Init extends BaseCommand {
 					+ renderedScriptOrFile + "' where [editor] is your editor or IDE, e.g. '"
 					+ Edit.knownEditors[new Random().nextInt(Edit.knownEditors.length)]
 					+ "'. If your IDE supports JBang, you can edit the directory instead: 'jbang edit . '"
-					+ renderedScriptOrFile + ". See https://jbang.dev/ide");
+					+ ". See https://jbang.dev/ide");
 		}
 		return EXIT_OK;
 	}


### PR DESCRIPTION
Hi 👋  Happy New 2024!

I've just created a new script with `jbang init -t cli scripts/process_entries.java`

And I get as output:
```
[jbang] File initialized. You can now run it with 'jbang scripts/process_entries.java' or edit it using 'jbang edit --open=[editor] scripts/process_entries.java' where [editor] is your editor or IDE, e.g. 'code'. If your IDE supports JBang, you can edit the directory instead: 'jbang edit . 'scripts/process_entries.java. See https://jbang.dev/ide
```

The part about the directory is unclear to me and I believe there is a typo, which should read instead:

```
If your IDE supports JBang, you can edit the directory instead: 'jbang edit . '. 
```

(without the name of the script repeated _outside_ of the single quote command).

Hope this helps?
Sorry if the message was intentional, but in that case I didn't understood it 🤔 