### PR TITLE
feat: treat empty catalog as jbanghub/jbang-catalog aliases

### DIFF
--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -2,7 +2,9 @@ package dev.jbang.catalog;
 
 import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -189,6 +191,8 @@ public class Alias extends CatalogItem {
 		String[] parts = name.split("@");
 		if (parts.length > 2 || parts[0].isEmpty()) {
 			throw new RuntimeException("Invalid alias name '" + name + "'");
+		} else if (parts.length == 1 && (name.endsWith("@"))) {
+			parts = new String[] { parts[0], Catalog.JBANG_DEFAULT_CATALOG };
 		}
 		Alias a2;
 		if (parts.length == 1) {
@@ -196,6 +200,11 @@ public class Alias extends CatalogItem {
 		} else {
 			if (parts[1].isEmpty()) {
 				throw new RuntimeException("Invalid alias name '" + name + "'");
+			}
+			// TODO: not happy I have to check for file existence if starts with /
+			// but how else can we also support dir locations?
+			if (parts[1].startsWith("/") && !Files.exists(Paths.get(parts[1]))) {
+				parts[1] = Catalog.JBANG_DEFAULT_CATALOG + parts[1];
 			}
 			a2 = fromCatalog(parts[1], parts[0]);
 		}

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -30,6 +30,7 @@ import dev.jbang.util.Util;
 public class Catalog {
 	public static final String JBANG_CATALOG_JSON = "jbang-catalog.json";
 	public static final String JBANG_IMPLICIT_CATALOG_JSON = "implicit-catalog.json";
+	public static final String JBANG_DEFAULT_CATALOG = "jbanghub";
 
 	static final Map<String, Catalog> catalogCache = new HashMap<>();
 

--- a/src/main/java/dev/jbang/catalog/CatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/CatalogRef.java
@@ -52,9 +52,11 @@ public class CatalogRef extends CatalogItem {
 		if (catalog != null) {
 			catalogRef = catalog.catalogs.get(catalogName);
 		}
-		if (catalogRef == null && Util.isValidPath(catalogName)) {
+		// check if local file matches first.
+		if (catalogRef == null && !catalogName.equals("")
+				&& Util.isValidPath(catalogName)) {
 			Path p = Util.getCwd().resolve(catalogName);
-			if (!p.getFileName().toString().equals(Catalog.JBANG_CATALOG_JSON)) {
+			if (p.getFileName() != null && !p.getFileName().toString().equals(Catalog.JBANG_CATALOG_JSON)) {
 				p = p.resolve(Catalog.JBANG_CATALOG_JSON);
 			}
 			if (Files.isRegularFile(p)) {

--- a/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
@@ -41,6 +41,9 @@ public class ImplicitCatalogRef {
 		if (Util.isURL(name)) {
 			return null;
 		}
+		if (name.startsWith("/")) {
+			name = Catalog.JBANG_DEFAULT_CATALOG + name;
+		}
 		String[] parts = name.split("~", 2);
 		String path;
 		if (parts.length == 2) {

--- a/src/test/java/dev/jbang/TestImplicitAlias.java
+++ b/src/test/java/dev/jbang/TestImplicitAlias.java
@@ -1,14 +1,18 @@
 package dev.jbang;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.Catalog;
 import dev.jbang.catalog.ImplicitCatalogRef;
 
 /**
@@ -19,16 +23,36 @@ public class TestImplicitAlias extends BaseTest {
 	@Test
 	public void testGitImplicitCatalog() {
 		assertThat(ImplicitCatalogRef.getImplicitCatalogUrl("jbangdev").get(),
-				Matchers.equalTo("https://github.com/jbangdev/jbang-catalog/blob/HEAD/jbang-catalog.json"));
+				equalTo("https://github.com/jbangdev/jbang-catalog/blob/HEAD/jbang-catalog.json"));
 		assertThat(ImplicitCatalogRef.getImplicitCatalogUrl("jbangdev/jbang-examples").get(),
-				Matchers.equalTo("https://github.com/jbangdev/jbang-examples/blob/HEAD/jbang-catalog.json"));
+				equalTo("https://github.com/jbangdev/jbang-examples/blob/HEAD/jbang-catalog.json"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { /* not sure this should be allowed "", */ "/", "/sqlline", "jbanghub/sqlline" })
+	public void testGitImplicitCatalogHub(String catalog) {
+		String cref = ImplicitCatalogRef.getImplicitCatalogUrl(catalog).get();
+		assertThat(cref,
+				startsWith("https://github.com/jbanghub/"));
+
+		Catalog c = Catalog.getByName(catalog);
+		assertThat(c.catalogRef.getOriginalResource(),
+				startsWith("https://github.com/jbanghub/"));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "sqlline@", "sqlline@/", "sqlline@/sqlline", "sqlline@jbanghub/sqlline" })
+	public void testImplicitHub(String alias) {
+		Alias a = Alias.get(alias);
+		assertThat(a.scriptRef, containsString("sqlline:sqlline"));
+		assertThat(a.catalog.baseRef, containsString("jbanghub"));
 	}
 
 	@Test
 	public void testImplictURLAlias() {
 
 		Alias url = Alias.get("tree@xam.dk");
-		assertThat(url.scriptRef, Matchers.equalTo("tree/main.java"));
+		assertThat(url.scriptRef, equalTo("tree/main.java"));
 
 	}
 
@@ -36,7 +60,7 @@ public class TestImplicitAlias extends BaseTest {
 	public void testImplictExplicitURLAlias() {
 
 		Alias url = Alias.get("tree@https://xam.dk");
-		assertThat(url.scriptRef, Matchers.equalTo("tree/main.java"));
+		assertThat(url.scriptRef, equalTo("tree/main.java"));
 
 	}
 
@@ -56,7 +80,7 @@ public class TestImplicitAlias extends BaseTest {
 
 		Alias alias = Alias.get(url);
 
-		assertThat(alias.scriptRef, Matchers.equalTo("helloworld.java"));
+		assertThat(alias.scriptRef, equalTo("helloworld.java"));
 
 	}
 }


### PR DESCRIPTION
prototype for https://github.com/jbangdev/jbang/discussions/1733

lets you do:

`jbang sqlline@/sqlline`

and

`jbang h2@/`

basically treating "empty catalog" as a referring to "jbanghub"