### PR TITLE
fix: fixed filename extraction from URL

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1066,7 +1066,12 @@ public class Util {
 				if (isBlankString(fileName)) {
 					// extracts file name from URL if nothing found
 					int p = fileURL.indexOf("?");
-					fileName = fileURL.substring(fileURL.lastIndexOf("/") + 1, p > 0 ? p : fileURL.length());
+					// Strip parameters from the URL (if any)
+					String simpleUrl = (p > 0) ? fileURL.substring(0, p) : fileURL;
+					while (simpleUrl.endsWith("/")) {
+						simpleUrl = simpleUrl.substring(0, simpleUrl.length() - 1);
+					}
+					fileName = simpleUrl.substring(simpleUrl.lastIndexOf("/") + 1);
 				}
 			}
 		} else {

--- a/src/test/java/dev/jbang/util/TestUtilDownloads.java
+++ b/src/test/java/dev/jbang/util/TestUtilDownloads.java
@@ -404,6 +404,22 @@ public class TestUtilDownloads extends BaseTest {
 		});
 	}
 
+	@Test
+	void testReqUrlWithParams(WireMockRuntimeInfo wmri) throws IOException {
+		stubFor(get(urlEqualTo("/test.txt?path=foo/bar"))
+															.andMatching(withoutHeader("If-None-Match"))
+															.andMatching(withoutHeader("If-Modified-Since"))
+															.willReturn(aResponse()
+																					.withHeader("Content-Type",
+																							"text/plain")
+																					.withBody("test")));
+
+		String url = wmri.getHttpBaseUrl() + "/test.txt?path=foo/bar";
+		Path file = Util.downloadAndCacheFile(url);
+		assertThat(file.toFile(), anExistingFile());
+		assertThat(Util.readString(file), is("test"));
+	}
+
 	private static ValueMatcher<Request> withoutHeader(String hdr) {
 		return req -> MatchResult.of(!req.containsHeader(hdr));
 	}


### PR DESCRIPTION
If the URL contained slashes in the parameter part of the URL, the filename extraction would fail.

Fixes #1740
