### PR TITLE
Catalog command improvements

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -20,6 +20,12 @@ Scenario: add catalog and remove
 Scenario: add catalog twice with same name
   When command('jbang catalog add --global --name tc jbang-catalog.json')
   Then command('jbang catalog add --global --name tc jbang-catalog.json')
+  Then match err contains "A catalog with name 'tc' already exists, use '--force' to add anyway"
+  Then match exit == 2
+
+Scenario: force add catalog twice with same name
+  When command('jbang catalog add --global --name tc jbang-catalog.json')
+  Then command('jbang catalog add --global --name tc --force jbang-catalog.json')
   Then match exit == 0
 
 Scenario: add catalog twice with different name

--- a/src/main/java/dev/jbang/Configuration.java
+++ b/src/main/java/dev/jbang/Configuration.java
@@ -276,9 +276,9 @@ public class Configuration {
 	 */
 	public static Configuration getMerged() {
 		Set<Path> configFiles = new LinkedHashSet<>();
-		Util.findNearestFileWith(null, JBANG_CONFIG_PROPS, cfgFile -> {
+		Util.findNearestWith(null, JBANG_CONFIG_PROPS, cfgFile -> {
 			configFiles.add(cfgFile);
-			return false;
+			return null;
 		});
 
 		Configuration result = defaults();

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -260,7 +260,8 @@ public class Alias extends CatalogItem {
 	}
 
 	static Catalog findNearestCatalogWithAlias(Path dir, String aliasName) {
-		return Catalog.findNearestCatalogWith(dir, catalog -> catalog.aliases.containsKey(aliasName));
+		return Catalog.findNearestCatalogWith(dir, true, true,
+				catalog -> catalog.aliases.containsKey(aliasName) ? catalog : null);
 	}
 
 	/**

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -140,7 +140,7 @@ public class Catalog {
 	 * @return An Aliases object
 	 */
 	public static Catalog getByName(String catalogName) {
-		CatalogRef catalogRef = CatalogRef.get(simplifyName(catalogName));
+		CatalogRef catalogRef = CatalogRef.get(simplifyRef(catalogName));
 		if (catalogRef != null) {
 			return getByRef(catalogRef.catalogRef);
 		} else {
@@ -450,16 +450,20 @@ public class Catalog {
 		}
 	}
 
-	public static String simplifyName(String catalog) {
-		if (!Util.isURL(catalog) && !isValidCatalogReference(catalog)) {
-			if (catalog.endsWith("/" + JBANG_CATALOG_REPO)) {
-				return catalog.substring(0, catalog.length() - 14);
-			} else {
-				return catalog.replace("/" + JBANG_CATALOG_REPO + "~", "~");
+	public static String simplifyRef(String catalogRefString) {
+		if (Util.isURL(catalogRefString)) {
+			ImplicitCatalogRef ref = ImplicitCatalogRef.extract(catalogRefString);
+			if (ref != null) {
+				return ref.toString();
 			}
-		} else {
-			return catalog;
+		} else if (!isValidCatalogReference(catalogRefString)) {
+			if (catalogRefString.endsWith("/" + JBANG_CATALOG_REPO)) {
+				return catalogRefString.substring(0, catalogRefString.length() - 14);
+			} else {
+				return catalogRefString.replace("/" + JBANG_CATALOG_REPO + "~", "~");
+			}
 		}
+		return catalogRefString;
 	}
 
 	public static boolean isValidName(String name) {

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -245,10 +245,12 @@ public class Catalog {
 			try {
 				String subCatName = e.getKey();
 				CatalogRef ref = e.getValue();
-				Catalog cat = getByRef(ref.catalogRef);
-				result.aliases.putAll(expandNames(cat.aliases, subCatName));
-				result.templates.putAll(expandNames(cat.templates, subCatName));
-				result.catalogs.putAll(expandNames(cat.catalogs, subCatName));
+				if (!Boolean.TRUE.equals(ref.importItems)) { // No need to add already imported items
+					Catalog cat = getByRef(ref.catalogRef);
+					result.aliases.putAll(expandNames(cat.aliases, subCatName));
+					result.templates.putAll(expandNames(cat.templates, subCatName));
+					result.catalogs.putAll(expandNames(cat.catalogs, subCatName));
+				}
 			} catch (Exception ex) {
 				Util.warnMsg(
 						"Unable to read catalog " + e.getValue().catalogRef + " (referenced from " + catalog.catalogRef

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -282,11 +282,7 @@ public class Catalog {
 		if (catalog == null) {
 			catalog = accept.apply(getBuiltin());
 		}
-		if (catalog != null) {
-			return catalog;
-		} else {
-			return Catalog.empty();
-		}
+		return catalog;
 	}
 
 	static Catalog findImportedCatalogsWith(Catalog catalog, Function<Catalog, Catalog> accept) {
@@ -323,18 +319,6 @@ public class Catalog {
 			catalog = catalogCache.get(catalogPath.toString());
 		}
 		return catalog;
-	}
-
-	// Looks up a sub-catalog in a given catalog and returns
-	// its name if it was found, otherwise `null`
-	public static String findCatalogName(Catalog catalog, Catalog subCatalog) {
-		return catalog.catalogs	.entrySet()
-								.stream()
-								.filter(e -> e.getValue().importItems != Boolean.TRUE
-										&& subCatalog.catalogRef.getOriginalResource().equals(e.getValue().catalogRef))
-								.map(Map.Entry::getKey)
-								.findAny()
-								.orElse(null);
 	}
 
 	// This returns the built-in Catalog that can be found in the resources

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -232,41 +232,11 @@ public class Catalog {
 
 		Catalog result = Catalog.empty();
 		for (Catalog catalog : catalogs) {
-			merge(catalog, result);
+			result.aliases.putAll(catalog.aliases);
+			result.templates.putAll(catalog.templates);
+			result.catalogs.putAll(catalog.catalogs);
 		}
 
-		return result;
-	}
-
-	private static void merge(Catalog catalog, Catalog result) {
-		// Merge the aliases and templates of the catalog refs
-		// into the current catalog
-		for (Map.Entry<String, CatalogRef> e : catalog.catalogs.entrySet()) {
-			try {
-				String subCatName = e.getKey();
-				CatalogRef ref = e.getValue();
-				if (!Boolean.TRUE.equals(ref.importItems)) { // No need to add already imported items
-					Catalog cat = getByRef(ref.catalogRef);
-					result.aliases.putAll(expandNames(cat.aliases, subCatName));
-					result.templates.putAll(expandNames(cat.templates, subCatName));
-					result.catalogs.putAll(expandNames(cat.catalogs, subCatName));
-				}
-			} catch (Exception ex) {
-				Util.warnMsg(
-						"Unable to read catalog " + e.getValue().catalogRef + " (referenced from " + catalog.catalogRef
-								+ ")");
-			}
-		}
-		result.aliases.putAll(catalog.aliases);
-		result.templates.putAll(catalog.templates);
-		result.catalogs.putAll(catalog.catalogs);
-	}
-
-	private static <T extends CatalogItem> Map<String, T> expandNames(Map<String, T> map, String subCatName) {
-		Map<String, T> result = new HashMap<>();
-		for (Map.Entry<String, T> e : map.entrySet()) {
-			result.put(e.getKey() + "@" + subCatName, e.getValue());
-		}
 		return result;
 	}
 

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -250,6 +250,7 @@ public class Catalog {
 				Catalog cat = getByRef(ref.catalogRef);
 				result.aliases.putAll(cat.aliases);
 				result.templates.putAll(cat.templates);
+				result.catalogs.putAll(cat.catalogs);
 			} catch (Exception ex) {
 				Util.warnMsg(
 						"Unable to read catalog " + ref.catalogRef + " (referenced from " + catalog.catalogRef + ")");
@@ -301,21 +302,16 @@ public class Catalog {
 		return catalog;
 	}
 
-	// Returns the implicit name for a Catalog if that Catalog was found in
-	// the list of implicit catalogs
-	public static String findImplicitName(Catalog catalog) {
-		Path file = Settings.getUserImplicitCatalogFile();
-		if (Files.isRegularFile(file) && Files.isReadable(file)) {
-			Catalog implicit = get(file);
-			return implicit.catalogs.entrySet()
-									.stream()
-									.filter(e -> catalog.catalogRef	.getOriginalResource()
+	// Looks up a sub-catalog in a given catalog and returns
+	// its name if it was found, otherwise `null`
+	public static String findCatalogName(Catalog catalog, Catalog subCatalog) {
+		return catalog.catalogs	.entrySet()
+								.stream()
+								.filter(e -> subCatalog.catalogRef	.getOriginalResource()
 																	.equals(e.getValue().catalogRef))
-									.map(Map.Entry::getKey)
-									.findAny()
-									.orElse(null);
-		}
-		return null;
+								.map(Map.Entry::getKey)
+								.findAny()
+								.orElse(null);
 	}
 
 	// This returns the built-in Catalog that can be found in the resources

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -242,14 +242,14 @@ public class CatalogUtil {
 	 *
 	 * @param name The name of the new alias
 	 */
-	public static Path addNearestCatalogRef(String name, String catalogRef, String description) {
+	public static Path addNearestCatalogRef(String name, String catalogRef, String description, Boolean importItems) {
 		Path catalogFile = Catalog.getCatalogFile(null);
-		addCatalogRef(catalogFile, name, catalogRef, description);
+		addCatalogRef(catalogFile, name, catalogRef, description, importItems);
 		return catalogFile;
 	}
 
 	public static CatalogRef addCatalogRef(Path catalogFile, String name, String catalogRef,
-			String description) {
+			String description, Boolean importItems) {
 		Path cwd = Util.getCwd();
 		catalogFile = cwd.resolve(catalogFile);
 		Catalog catalog = Catalog.get(catalogFile);
@@ -259,7 +259,7 @@ public class CatalogUtil {
 				catalogRef = cat.toAbsolutePath().toString();
 			}
 			if (!Util.isAbsoluteRef(catalogRef)) {
-				Optional<String> url = ImplicitCatalogRef.getImplicitCatalogUrl(catalogRef);
+				Optional<String> url = ImplicitCatalogRef.resolveImplicitCatalogUrl(catalogRef);
 				if (url.isPresent()) {
 					catalogRef = url.get();
 				}
@@ -267,7 +267,7 @@ public class CatalogUtil {
 		} catch (InvalidPathException ex) {
 			// Ignore
 		}
-		CatalogRef ref = new CatalogRef(catalogRef, description, catalog);
+		CatalogRef ref = new CatalogRef(catalogRef, description, importItems, catalog);
 		catalog.catalogs.put(name, ref);
 		try {
 			catalog.write();
@@ -323,5 +323,10 @@ public class CatalogUtil {
 
 	public static boolean isValidName(String name) {
 		return validNamePattern.matcher(name).matches();
+	}
+
+	public static String catalogRef(String atName) {
+		String[] parts = atName.split("@", 2);
+		return parts.length == 2 ? parts[1] : null;
 	}
 }

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -79,7 +79,11 @@ public class CatalogUtil {
 	public static void removeNearestAlias(String name) {
 		Catalog catalog = Alias.findNearestCatalogWithAlias(Util.getCwd(), name);
 		if (catalog != null) {
-			removeAlias(catalog, name);
+			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
+				Util.warnMsg("Unable to remove alias " + name + " because it is imported from a remote catalog");
+			} else {
+				removeAlias(catalog, name);
+			}
 		}
 	}
 
@@ -169,7 +173,11 @@ public class CatalogUtil {
 	public static void removeNearestTemplate(String name) {
 		Catalog catalog = Template.findNearestCatalogWithTemplate(Util.getCwd(), name);
 		if (catalog != null) {
-			removeTemplate(catalog, name);
+			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
+				Util.warnMsg("Unable to remove template " + name + " because it is imported from a remote catalog");
+			} else {
+				removeTemplate(catalog, name);
+			}
 		}
 	}
 
@@ -204,7 +212,11 @@ public class CatalogUtil {
 	public static void removeNearestCatalogRef(String name) {
 		Catalog catalog = CatalogRef.findNearestCatalogWithCatalogRef(Util.getCwd(), name);
 		if (catalog != null) {
-			removeCatalogRef(catalog, name);
+			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
+				Util.warnMsg("Unable to remove catalog ref " + name + " because it is imported from a remote catalog");
+			} else {
+				removeCatalogRef(catalog, name);
+			}
 		}
 	}
 

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -25,6 +25,19 @@ public class CatalogUtil {
 	private static final Pattern validNamePattern = Pattern.compile("[" + validNameChars + "]+");
 
 	/**
+	 * Determines if an alias with the given name exists in the given catalog
+	 *
+	 * @param catalogFile Path to catalog file
+	 * @param name        The name of alias
+	 */
+	public static boolean hasAlias(Path catalogFile, String name) {
+		Path cwd = Util.getCwd();
+		catalogFile = cwd.resolve(catalogFile);
+		Catalog catalog = Catalog.get(catalogFile);
+		return catalog.aliases.containsKey(name);
+	}
+
+	/**
 	 * Adds a new alias to the nearest catalog
 	 * 
 	 * @param name The name of the new alias
@@ -40,6 +53,7 @@ public class CatalogUtil {
 	 * 
 	 * @param catalogFile Path to catalog file
 	 * @param name        The name of the new alias
+	 * @param alias       The alias to add
 	 */
 	public static Alias addAlias(Path catalogFile, String name, Alias alias) {
 		Path cwd = Util.getCwd();
@@ -89,6 +103,19 @@ public class CatalogUtil {
 				Util.warnMsg("Unable to remove alias: " + ex.getMessage());
 			}
 		}
+	}
+
+	/**
+	 * Determines if a template with the given name exists in the given catalog
+	 *
+	 * @param catalogFile Path to catalog file
+	 * @param name        The name of the template
+	 */
+	public static boolean hasTemplate(Path catalogFile, String name) {
+		Path cwd = Util.getCwd();
+		catalogFile = cwd.resolve(catalogFile);
+		Catalog catalog = Catalog.get(catalogFile);
+		return catalog.templates.containsKey(name);
 	}
 
 	/**
@@ -195,6 +222,19 @@ public class CatalogUtil {
 				Util.warnMsg("Unable to remove catalog: " + ex.getMessage());
 			}
 		}
+	}
+
+	/**
+	 * Determines if a catalog ref with the given name exists in the given catalog
+	 *
+	 * @param catalogFile Path to catalog file
+	 * @param name        The name of the catalog ref
+	 */
+	public static boolean hasCatalogRef(Path catalogFile, String name) {
+		Path cwd = Util.getCwd();
+		catalogFile = cwd.resolve(catalogFile);
+		Catalog catalog = Catalog.get(catalogFile);
+		return catalog.catalogs.containsKey(name);
 	}
 
 	/**

--- a/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
@@ -23,11 +23,7 @@ public class ImplicitCatalogRef {
 		this.path = path;
 	}
 
-	public boolean isPossibleCommit() {
-		return ref.matches("[0-9a-f]{5,40}");
-	}
-
-	public String url(String host, String infix) {
+	private String repoUrl(String host, String infix) {
 		return host + org + "/" + repo + infix + ref + "/" + path + Catalog.JBANG_CATALOG_JSON;
 	}
 
@@ -70,17 +66,9 @@ public class ImplicitCatalogRef {
 		Optional<String> url = chain(
 				() -> Util.isURL(catalogName) ? tryDownload(catalogName) : Optional.empty(),
 				() -> catalogName.contains(".") ? tryDownload("https://" + catalogName) : Optional.empty(),
-				() -> icr.isPresent() ? tryDownload(icr.get().url(GITHUB_URL, "/blob/")) : Optional.empty(),
-				() -> icr.isPresent() && icr.get().isPossibleCommit() ? tryDownload(icr.get().url(GITHUB_URL, "/blob/"))
-						: Optional.empty(),
-				() -> icr.isPresent() ? tryDownload(icr.get().url(GITLAB_URL, "/-/blob/")) : Optional.empty(),
-				() -> icr.isPresent() && icr.get().isPossibleCommit()
-						? tryDownload(icr.get().url(GITLAB_URL, "/-/blob/"))
-						: Optional.empty(),
-				() -> icr.isPresent() ? tryDownload(icr.get().url(BITBUCKET_URL, "/src/")) : Optional.empty(),
-				() -> icr.isPresent() && icr.get().isPossibleCommit()
-						? tryDownload(icr.get().url(BITBUCKET_URL, "/src/"))
-						: Optional.empty())
+				() -> icr.isPresent() ? tryDownload(icr.get().repoUrl(GITHUB_URL, "/blob/")) : Optional.empty(),
+				() -> icr.isPresent() ? tryDownload(icr.get().repoUrl(GITLAB_URL, "/-/blob/")) : Optional.empty(),
+				() -> icr.isPresent() ? tryDownload(icr.get().repoUrl(BITBUCKET_URL, "/src/")) : Optional.empty())
 											.findFirst();
 		return url;
 	}

--- a/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
@@ -65,7 +65,7 @@ public class ImplicitCatalogRef {
 		return new ImplicitCatalogRef(org, repo, ref, path);
 	}
 
-	public static Optional<String> getImplicitCatalogUrl(String catalogName) {
+	public static Optional<String> resolveImplicitCatalogUrl(String catalogName) {
 		Optional<ImplicitCatalogRef> icr = Optional.ofNullable(parse(catalogName));
 		Optional<String> url = chain(
 				() -> Util.isURL(catalogName) ? tryDownload(catalogName) : Optional.empty(),

--- a/src/main/java/dev/jbang/catalog/Template.java
+++ b/src/main/java/dev/jbang/catalog/Template.java
@@ -56,7 +56,8 @@ public class Template extends CatalogItem {
 	}
 
 	static Catalog findNearestCatalogWithTemplate(Path dir, String templateName) {
-		return Catalog.findNearestCatalogWith(dir, catalog -> catalog.templates.containsKey(templateName));
+		return Catalog.findNearestCatalogWith(dir, true, true,
+				catalog -> catalog.templates.containsKey(templateName) ? catalog : null);
 	}
 
 	/**

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -242,7 +242,7 @@ class AliasList extends BaseAliasCommand {
 			parser.toJson(catalogs, out);
 		} else {
 			catalogs.forEach(cat -> {
-				out.println(ConsoleOutput.bold(cat.resourceRef));
+				out.println(ConsoleOutput.bold(dev.jbang.catalog.Catalog.simplifyRef(cat.resourceRef)));
 				cat.aliases.forEach(a -> printAlias(out, a, 1));
 			});
 		}
@@ -265,7 +265,7 @@ class AliasList extends BaseAliasCommand {
 
 	private static AliasOut getAliasOut(String catalogName, Catalog catalog, String name) {
 		dev.jbang.catalog.Alias alias = catalog.aliases.get(name);
-		String catName = catalogName != null ? Catalog.simplifyName(catalogName) : CatalogUtil.catalogRef(name);
+		String catName = catalogName != null ? Catalog.simplifyRef(catalogName) : CatalogUtil.catalogRef(name);
 		String fullName = catalogName != null ? name + "@" + catName : name;
 		String scriptRef = alias.scriptRef;
 		if (!catalog.aliases.containsKey(scriptRef)

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -192,7 +192,7 @@ class AliasList extends BaseAliasCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(false, true);
+			catalog = Catalog.getMerged(false, false);
 		}
 		if (showOrigin) {
 			printAliasesWithOrigin(out, catalogName, catalog, formatMixin.format);

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -265,7 +265,7 @@ class AliasList extends BaseAliasCommand {
 
 	private static AliasOut getAliasOut(String catalogName, Catalog catalog, String name) {
 		dev.jbang.catalog.Alias alias = catalog.aliases.get(name);
-		String catName = catalogName != null ? catalogName : Catalog.findImplicitName(alias.catalog);
+		String catName = catalogName != null ? catalogName : Catalog.findCatalogName(catalog, alias.catalog);
 		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
 		String scriptRef = alias.scriptRef;
 		if (!catalog.aliases.containsKey(scriptRef)

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -293,7 +293,7 @@ class AliasList extends BaseAliasCommand {
 		String prefix1 = Util.repeat(" ", indent * INDENT_SIZE);
 		String prefix2 = Util.repeat(" ", (indent + 1) * INDENT_SIZE);
 		String prefix3 = Util.repeat(" ", (indent + 2) * INDENT_SIZE);
-		out.println(prefix1 + ConsoleOutput.yellow(alias.fullName));
+		out.println(prefix1 + dev.jbang.cli.CatalogList.getColoredFullName(alias.fullName));
 		if (alias.description != null) {
 			out.println(prefix2 + alias.description);
 		}

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -192,7 +192,7 @@ class AliasList extends BaseAliasCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(true);
+			catalog = Catalog.getMerged(false, true);
 		}
 		if (showOrigin) {
 			printAliasesWithOrigin(out, catalogName, catalog, formatMixin.format);
@@ -265,8 +265,8 @@ class AliasList extends BaseAliasCommand {
 
 	private static AliasOut getAliasOut(String catalogName, Catalog catalog, String name) {
 		dev.jbang.catalog.Alias alias = catalog.aliases.get(name);
-		String catName = catalogName != null ? catalogName : Catalog.findCatalogName(catalog, alias.catalog);
-		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
+		String catName = catalogName != null ? Catalog.simplifyName(catalogName) : CatalogUtil.catalogRef(name);
+		String fullName = catalogName != null ? name + "@" + catName : name;
 		String scriptRef = alias.scriptRef;
 		if (!catalog.aliases.containsKey(scriptRef)
 				&& !Catalog.isValidCatalogReference(scriptRef)) {
@@ -275,7 +275,7 @@ class AliasList extends BaseAliasCommand {
 
 		AliasOut out = new AliasOut();
 		out.name = name;
-		out.catalogName = catName != null ? Catalog.simplifyName(catName) : null;
+		out.catalogName = catName;
 		out.fullName = fullName;
 		out.scriptRef = scriptRef;
 		out.description = alias.description;

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -192,7 +192,7 @@ class AliasList extends BaseAliasCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(false, false);
+			catalog = Catalog.getMerged(true, false);
 		}
 		if (showOrigin) {
 			printAliasesWithOrigin(out, catalogName, catalog, formatMixin.format);

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -155,7 +155,7 @@ class CatalogList extends BaseCatalogCommand {
 			if (cat != null) {
 				catalog = dev.jbang.catalog.Catalog.get(cat);
 			} else {
-				catalog = dev.jbang.catalog.Catalog.getMerged(true, true);
+				catalog = dev.jbang.catalog.Catalog.getMerged(true, false);
 			}
 			if (showOrigin) {
 				printCatalogsWithOrigin(out, name, catalog, formatMixin.format);

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -259,7 +259,6 @@ class CatalogList extends BaseCatalogCommand {
 	static class CatalogOut {
 		public String name;
 		public String resourceRef;
-		public String backingResource;
 		public String description;
 		public List<AliasList.AliasOut> aliases;
 		public List<TemplateList.TemplateOut> templates;
@@ -280,7 +279,6 @@ class CatalogList extends BaseCatalogCommand {
 				}
 			}
 			resourceRef = ref.getOriginalResource();
-			backingResource = ref.getFile().toString();
 			this.aliases = aliases;
 			this.templates = templates;
 			this.catalogs = catalogs;

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -250,7 +250,7 @@ class CatalogList extends BaseCatalogCommand {
 			parser.toJson(catalogs, out);
 		} else {
 			catalogs.forEach(cat -> {
-				out.println(ConsoleOutput.bold(cat.resourceRef));
+				out.println(ConsoleOutput.bold(dev.jbang.catalog.Catalog.simplifyRef(cat.resourceRef)));
 				cat.catalogs.forEach(c -> printCatalogRef(out, c, 1));
 			});
 		}
@@ -300,7 +300,7 @@ class CatalogList extends BaseCatalogCommand {
 
 	private static CatalogRefOut getCatalogRefOut(String catalogName, dev.jbang.catalog.Catalog catalog, String name) {
 		CatalogRef ref = catalog.catalogs.get(name);
-		String catName = catalogName != null ? dev.jbang.catalog.Catalog.simplifyName(catalogName)
+		String catName = catalogName != null ? dev.jbang.catalog.Catalog.simplifyRef(catalogName)
 				: CatalogUtil.catalogRef(name);
 		String fullName = catalogName != null ? name + "@" + catName : name;
 

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -293,6 +293,8 @@ class CatalogList extends BaseCatalogCommand {
 		public String fullName;
 		public String catalogRef;
 		public String description;
+		public boolean importItems;
+
 		public transient ResourceRef _catalogRef;
 	}
 
@@ -308,6 +310,7 @@ class CatalogList extends BaseCatalogCommand {
 		out.fullName = fullName;
 		out.catalogRef = ref.catalogRef;
 		out.description = ref.description;
+		out.importItems = Boolean.TRUE.equals(ref.importItems);
 		out._catalogRef = ref.catalog.catalogRef;
 		return out;
 	}
@@ -315,7 +318,8 @@ class CatalogList extends BaseCatalogCommand {
 	private static void printCatalogRef(PrintStream out, CatalogRefOut catalogRef, int indent) {
 		String prefix1 = Util.repeat(" ", indent * INDENT_SIZE);
 		String prefix2 = Util.repeat(" ", (indent + 1) * INDENT_SIZE);
-		out.println(prefix1 + getColoredFullName(catalogRef.fullName));
+		out.println(prefix1 + getColoredFullName(catalogRef.fullName)
+				+ (catalogRef.importItems ? ConsoleOutput.magenta(" [importing]") : ""));
 		if (catalogRef.description != null) {
 			out.println(prefix2 + catalogRef.description);
 		}

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -66,8 +66,12 @@ class CatalogAdd extends BaseCatalogCommand {
 			"-d" }, description = "A description for the catalog")
 	String description;
 
-	@CommandLine.Option(names = { "--name" }, description = "A name for the alias")
+	@CommandLine.Option(names = { "--name" }, description = "A name for the catalog")
 	String name;
+
+	@CommandLine.Option(names = {
+			"--force" }, description = "Force overwriting of existing catalog")
+	boolean force;
 
 	@CommandLine.Parameters(paramLabel = "urlOrFile", index = "0", description = "A file or URL to a catalog file", arity = "1")
 	String urlOrFile;
@@ -83,10 +87,14 @@ class CatalogAdd extends BaseCatalogCommand {
 		}
 		CatalogRef ref = CatalogRef.createByRefOrImplicit(urlOrFile);
 		Path catFile = getCatalog(false);
-		if (catFile != null) {
+		if (catFile == null) {
+			catFile = dev.jbang.catalog.Catalog.getCatalogFile(null);
+		}
+		if (force || !CatalogUtil.hasCatalogRef(catFile, name)) {
 			CatalogUtil.addCatalogRef(catFile, name, ref.catalogRef, ref.description);
 		} else {
-			catFile = CatalogUtil.addNearestCatalogRef(name, ref.catalogRef, ref.description);
+			Util.infoMsg("A catalog with name '" + name + "' already exists, use '--force' to add anyway.");
+			return EXIT_INVALID_INPUT;
 		}
 		info(String.format("Catalog '%s' added to '%s'", name, catFile));
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -293,8 +293,10 @@ class CatalogList extends BaseCatalogCommand {
 	}
 
 	private static CatalogRefOut getCatalogRefOut(String catalogName, dev.jbang.catalog.Catalog catalog, String name) {
-		String fullName = catalogName != null ? name + "@" + catalogName : name;
 		CatalogRef ref = catalog.catalogs.get(name);
+		String catName = catalogName != null ? catalogName
+				: dev.jbang.catalog.Catalog.findCatalogName(catalog, ref.catalog);
+		String fullName = catName != null ? name + "@" + dev.jbang.catalog.Catalog.simplifyName(catName) : name;
 
 		CatalogRefOut out = new CatalogRefOut();
 		out.name = name;

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -315,11 +315,22 @@ class CatalogList extends BaseCatalogCommand {
 	private static void printCatalogRef(PrintStream out, CatalogRefOut catalogRef, int indent) {
 		String prefix1 = Util.repeat(" ", indent * INDENT_SIZE);
 		String prefix2 = Util.repeat(" ", (indent + 1) * INDENT_SIZE);
-		out.println(prefix1 + ConsoleOutput.yellow(catalogRef.fullName));
+		out.println(prefix1 + getColoredFullName(catalogRef.fullName));
 		if (catalogRef.description != null) {
 			out.println(prefix2 + catalogRef.description);
 		}
 		out.println(prefix2 + catalogRef.catalogRef);
+	}
+
+	static String getColoredFullName(String fullName) {
+		StringBuilder res = new StringBuilder();
+		String[] parts = fullName.split("@");
+		res.append(ConsoleOutput.yellow(parts[0]));
+		for (int i = 1; i < parts.length; i++) {
+			res.append(ConsoleOutput.cyan("@"));
+			res.append(parts[i]);
+		}
+		return res.toString();
 	}
 }
 

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -307,7 +307,7 @@ class TemplateList extends BaseTemplateCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(true);
+			catalog = Catalog.getMerged(false, true);
 		}
 		if (showOrigin) {
 			printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, formatMixin.format);
@@ -385,12 +385,13 @@ class TemplateList extends BaseTemplateCommand {
 	private static TemplateOut getTemplateOut(String catalogName, Catalog catalog, String name,
 			boolean showFiles, boolean showProperties) {
 		dev.jbang.catalog.Template template = catalog.templates.get(name);
-		String catName = catalogName != null ? catalogName : Catalog.findCatalogName(catalog, template.catalog);
-		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
+		String catName = catalogName != null ? dev.jbang.catalog.Catalog.simplifyName(catalogName)
+				: CatalogUtil.catalogRef(name);
+		String fullName = catalogName != null ? name + "@" + catName : name;
 
 		TemplateOut out = new TemplateOut();
 		out.name = name;
-		out.catalogName = catName != null ? Catalog.simplifyName(catName) : null;
+		out.catalogName = catName;
 		out.fullName = fullName;
 		out.description = template.description;
 		if (showFiles && template.fileRefs != null) {

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -307,7 +307,7 @@ class TemplateList extends BaseTemplateCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(false, false);
+			catalog = Catalog.getMerged(true, false);
 		}
 		if (showOrigin) {
 			printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, formatMixin.format);

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -72,6 +72,10 @@ class TemplateAdd extends BaseTemplateCommand {
 	@CommandLine.Option(names = { "--name" }, description = "A name for the template")
 	String name;
 
+	@CommandLine.Option(names = {
+			"--force" }, description = "Force overwriting of existing template")
+	boolean force;
+
 	@CommandLine.Parameters(paramLabel = "files", index = "0..*", arity = "1..*", description = "Paths or URLs to template files")
 	List<String> fileRefs;
 
@@ -140,10 +144,14 @@ class TemplateAdd extends BaseTemplateCommand {
 																.orElse(new HashMap<>());
 
 		Path catFile = getCatalog(false);
-		if (catFile != null) {
+		if (catFile == null) {
+			catFile = Catalog.getCatalogFile(null);
+		}
+		if (force || !CatalogUtil.hasTemplate(catFile, name)) {
 			CatalogUtil.addTemplate(catFile, name, fileRefsMap, description, propertiesMap);
 		} else {
-			catFile = CatalogUtil.addNearestTemplate(name, fileRefsMap, description, propertiesMap);
+			Util.infoMsg("A template with name '" + name + "' already exists, use '--force' to add anyway.");
+			return EXIT_INVALID_INPUT;
 		}
 		info(String.format("Template '%s' added to '%s'", name, catFile));
 		return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -418,7 +418,7 @@ class TemplateList extends BaseTemplateCommand {
 		String prefix2 = Util.repeat(" ", (indent + 1) * INDENT_SIZE);
 		String prefix3 = Util.repeat(" ", (indent + 2) * INDENT_SIZE);
 		out.print(Util.repeat(" ", indent));
-		out.println(prefix1 + ConsoleOutput.yellow(template.fullName));
+		out.println(prefix1 + dev.jbang.cli.CatalogList.getColoredFullName(template.fullName));
 		if (template.description != null) {
 			out.println(prefix2 + template.description);
 		}

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -385,7 +385,7 @@ class TemplateList extends BaseTemplateCommand {
 	private static TemplateOut getTemplateOut(String catalogName, Catalog catalog, String name,
 			boolean showFiles, boolean showProperties) {
 		dev.jbang.catalog.Template template = catalog.templates.get(name);
-		String catName = catalogName != null ? catalogName : Catalog.findImplicitName(template.catalog);
+		String catName = catalogName != null ? catalogName : Catalog.findCatalogName(catalog, template.catalog);
 		String fullName = catName != null ? name + "@" + Catalog.simplifyName(catName) : name;
 
 		TemplateOut out = new TemplateOut();

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -360,7 +360,7 @@ class TemplateList extends BaseTemplateCommand {
 			parser.toJson(catalogs, out);
 		} else {
 			catalogs.forEach(cat -> {
-				out.println(ConsoleOutput.bold(cat.resourceRef));
+				out.println(ConsoleOutput.bold(dev.jbang.catalog.Catalog.simplifyRef(cat.resourceRef)));
 				cat.templates.forEach(t -> printTemplate(out, t, 1));
 			});
 		}
@@ -385,7 +385,7 @@ class TemplateList extends BaseTemplateCommand {
 	private static TemplateOut getTemplateOut(String catalogName, Catalog catalog, String name,
 			boolean showFiles, boolean showProperties) {
 		dev.jbang.catalog.Template template = catalog.templates.get(name);
-		String catName = catalogName != null ? dev.jbang.catalog.Catalog.simplifyName(catalogName)
+		String catName = catalogName != null ? dev.jbang.catalog.Catalog.simplifyRef(catalogName)
 				: CatalogUtil.catalogRef(name);
 		String fullName = catalogName != null ? name + "@" + catName : name;
 

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -307,7 +307,7 @@ class TemplateList extends BaseTemplateCommand {
 		} else if (cat != null) {
 			catalog = Catalog.get(cat);
 		} else {
-			catalog = Catalog.getMerged(false, true);
+			catalog = Catalog.getMerged(false, false);
 		}
 		if (showOrigin) {
 			printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, formatMixin.format);

--- a/src/main/java/dev/jbang/util/ConfigUtil.java
+++ b/src/main/java/dev/jbang/util/ConfigUtil.java
@@ -55,13 +55,13 @@ public class ConfigUtil {
 	}
 
 	private static Path findNearestLocalConfig() {
-		return Util.findNearestFileWith(null, Configuration.JBANG_CONFIG_PROPS, p -> true);
+		return Util.findNearestWith(null, Configuration.JBANG_CONFIG_PROPS, p -> p);
 	}
 
 	private static Path findNearestLocalConfigWithKey(Path dir, String key) {
-		return Util.findNearestFileWith(dir, Configuration.JBANG_CONFIG_PROPS, configFile -> {
+		return Util.findNearestWith(dir, Configuration.JBANG_CONFIG_PROPS, configFile -> {
 			Configuration cfg = Configuration.read(configFile);
-			return cfg.containsKey(key);
+			return cfg.containsKey(key) ? configFile : null;
 		});
 	}
 }

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1284,6 +1284,18 @@ public class Util {
 		return url;
 	}
 
+	public static String[] extractOrgProject(String url) {
+		String orggprj = url.replaceFirst("^https://github.com/(.*)/blob/(.*)$", "$1/$2");
+		orggprj = orggprj.replaceFirst("^https://raw.githubusercontent.com/(.*)/(.*)$", "$1/$2");
+		orggprj = orggprj.replaceFirst("^https://gitlab.com/(.*)/-/(blob|raw)/(.*)$", "$1/$2");
+		orggprj = orggprj.replaceFirst("^https://bitbucket.org/(.*)/(src|raw)/(.*)$", "$1/$2");
+		if (!orggprj.equals(url)) {
+			return orggprj.split("/", 2);
+		} else {
+			return null;
+		}
+	}
+
 	public static String getStableID(File backingFile) {
 		try {
 			return getStableID(readString(backingFile.toPath()));

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1737,30 +1737,36 @@ public class Util {
 		return Paths.get("");
 	}
 
-	public static Path findNearestFileWith(Path dir, String fileName, Function<Path, Boolean> accept) {
-		Path result = findNearestLocalFileWith(dir, fileName, accept);
+	public static <T> T findNearestWith(Path dir, String fileName, Function<Path, T> accept) {
+		T result = findNearestLocalWith(dir, fileName, accept);
 		if (result == null) {
 			Path file = Settings.getConfigDir().resolve(fileName);
-			if (Files.isRegularFile(file) && Files.isReadable(file) && accept.apply(file)) {
-				result = file;
+			if (Files.isRegularFile(file) && Files.isReadable(file)) {
+				result = accept.apply(file);
 			}
 		}
 		return result;
 	}
 
-	private static Path findNearestLocalFileWith(Path dir, String fileName, Function<Path, Boolean> accept) {
+	private static <T> T findNearestLocalWith(Path dir, String fileName, Function<Path, T> accept) {
 		if (dir == null) {
 			dir = getCwd();
 		}
 		Path root = Settings.getLocalRootDir();
-		while (dir != null && (root == null || !isSameFile(dir, root))) {
+		while (dir != null && !isSameFile(dir, root)) {
 			Path file = dir.resolve(fileName);
-			if (Files.isRegularFile(file) && Files.isReadable(file) && accept.apply(file)) {
-				return file;
+			if (Files.isRegularFile(file) && Files.isReadable(file)) {
+				T result = accept.apply(file);
+				if (result != null) {
+					return result;
+				}
 			}
 			file = dir.resolve(Settings.JBANG_DOT_DIR).resolve(fileName);
-			if (Files.isRegularFile(file) && Files.isReadable(file) && accept.apply(file)) {
-				return file;
+			if (Files.isRegularFile(file) && Files.isReadable(file)) {
+				T result = accept.apply(file);
+				if (result != null) {
+					return result;
+				}
 			}
 			dir = dir.getParent();
 		}

--- a/src/test/java/dev/jbang/TestImplicitAlias.java
+++ b/src/test/java/dev/jbang/TestImplicitAlias.java
@@ -18,9 +18,9 @@ public class TestImplicitAlias extends BaseTest {
 
 	@Test
 	public void testGitImplicitCatalog() {
-		assertThat(ImplicitCatalogRef.getImplicitCatalogUrl("jbangdev").get(),
+		assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev").get(),
 				Matchers.equalTo("https://github.com/jbangdev/jbang-catalog/blob/HEAD/jbang-catalog.json"));
-		assertThat(ImplicitCatalogRef.getImplicitCatalogUrl("jbangdev/jbang-examples").get(),
+		assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev/jbang-examples").get(),
 				Matchers.equalTo("https://github.com/jbangdev/jbang-examples/blob/HEAD/jbang-catalog.json"));
 	}
 

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -363,6 +363,30 @@ public class TestAlias extends BaseTest {
 	}
 
 	@Test
+	void testAddExisting() throws IOException {
+		Path cwd = Util.getCwd();
+		Path testFile = cwd.resolve("test.java");
+		Files.write(testFile, "// Test file".getBytes());
+		Path testFile2 = cwd.resolve("test2.java");
+		Files.write(testFile2, "// Test file 2".getBytes());
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		int exitCode = JBang.getCommandLine()
+							.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
+		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		Alias alias = Alias.get("name");
+		assertThat(alias.scriptRef, is("test.java"));
+		exitCode = JBang.getCommandLine()
+						.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile2.toString());
+		assertThat(exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		exitCode = JBang.getCommandLine()
+						.execute("alias", "add", "-f", cwd.toString(), "--name=name", "--force", testFile2.toString());
+		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		alias = Alias.get("name");
+		assertThat(alias.scriptRef, is("test2.java"));
+	}
+
+	@Test
 	void testGetAliasNone() throws IOException {
 		Alias alias = Alias.get("dummy-alias!");
 		assertThat(alias, nullValue());

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -107,7 +107,7 @@ public class TestAliasNearest extends BaseTest {
 
 	@Test
 	void testList() throws IOException {
-		Catalog catalog = Catalog.getMerged(false);
+		Catalog catalog = Catalog.getMerged(true, false);
 		assertThat(catalog, notNullValue());
 
 		HashSet<String> keys = new HashSet<>(Arrays.asList(

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -40,7 +40,7 @@ public class TestCatalog extends BaseTest {
 		testCatalogFile = cwdDir.resolve("test-catalog.json");
 		Files.write(testCatalogFile, testCatalog.getBytes());
 		clearSettingsCaches();
-		CatalogUtil.addCatalogRef(catsFile, "test", testCatalogFile.toAbsolutePath().toString(), "Test catalog");
+		CatalogUtil.addCatalogRef(catsFile, "test", testCatalogFile.toAbsolutePath().toString(), "Test catalog", null);
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestCatalogNearest.java
+++ b/src/test/java/dev/jbang/cli/TestCatalogNearest.java
@@ -44,13 +44,13 @@ public class TestCatalogNearest extends BaseTest {
 		Util.setCwd(cwd);
 		testDotDir = Files.createDirectory(cwd.resolve(".jbang"));
 		CatalogUtil.addCatalogRef(cwd.resolve(Catalog.JBANG_CATALOG_JSON), "local", aliasesFile.toString(),
-				"Local");
+				"Local", null);
 		CatalogUtil.addCatalogRef(testDotDir.resolve(Catalog.JBANG_CATALOG_JSON), "dotlocal",
-				aliasesFile.toString(), "Local .jbang");
+				aliasesFile.toString(), "Local .jbang", null);
 		CatalogUtil.addCatalogRef(parentDotDir.resolve(Catalog.JBANG_CATALOG_JSON), "dotparent",
-				aliasesFile.toString(), "Parent .jbang");
+				aliasesFile.toString(), "Parent .jbang", null);
 		CatalogUtil.addCatalogRef(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), "global",
-				aliasesFile.toString(), "Global");
+				aliasesFile.toString(), "Global", null);
 	}
 
 	private Path aliasesFile;
@@ -68,7 +68,7 @@ public class TestCatalogNearest extends BaseTest {
 
 	@Test
 	void testList() throws IOException {
-		Catalog catalog = Catalog.getMerged(false);
+		Catalog catalog = Catalog.getMerged(true, false);
 		assertThat(catalog, notNullValue());
 
 		HashSet<String> keys = new HashSet<>(Arrays.asList(
@@ -103,7 +103,7 @@ public class TestCatalogNearest extends BaseTest {
 	void testAddLocal(String ref, String result) throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addNearestCatalogRef("new", ref, null);
+		CatalogUtil.addNearestCatalogRef("new", ref, null, false);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.catalogs.keySet(), hasItem("new"));
@@ -114,7 +114,7 @@ public class TestCatalogNearest extends BaseTest {
 	void testAddLocalExplicit() throws IOException {
 		Path cwd = Util.getCwd();
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
-		CatalogUtil.addCatalogRef(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", aliasesFile.toString(), null);
+		CatalogUtil.addCatalogRef(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", aliasesFile.toString(), null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
 		assertThat(catalog.catalogs.keySet(), hasItem("new"));
@@ -131,7 +131,7 @@ public class TestCatalogNearest extends BaseTest {
 		Path localCatalog = cwd.resolve(Catalog.JBANG_CATALOG_JSON);
 		Path dotLocalCatalog = cwd.resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
-		CatalogUtil.addNearestCatalogRef("new", ref, null);
+		CatalogUtil.addNearestCatalogRef("new", ref, null, false);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
@@ -151,7 +151,7 @@ public class TestCatalogNearest extends BaseTest {
 		Path parentCatalog = cwd.getParent().resolve(Settings.JBANG_DOT_DIR).resolve(Catalog.JBANG_CATALOG_JSON);
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
-		CatalogUtil.addNearestCatalogRef("new", ref, null);
+		CatalogUtil.addNearestCatalogRef("new", ref, null, false);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
@@ -173,7 +173,7 @@ public class TestCatalogNearest extends BaseTest {
 		Files.delete(localCatalog);
 		Files.delete(dotLocalCatalog);
 		Files.delete(parentCatalog);
-		CatalogUtil.addNearestCatalogRef("new", ref, null);
+		CatalogUtil.addNearestCatalogRef("new", ref, null, false);
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));


### PR DESCRIPTION
fix: properly listing the catalog names (fixes #1678)
feat: added --force options to catalog add commands (related to the above)
feat: added import feature to catalog refs

The last feature is something that we discussed (not sure if there's an issue for it, couldn't find it): an option that imports the items defined in a catalog and makes them available to the user without having to specify the full name, eg. using `@somecatalog`.

Right now this only works for local catalogs, so if you add a catalog reference with `jbang catalog add --import maxandersen` it will make all aliases, templates and catalog refs in that catalog available to the user without having to specify `@maxandersen`.

NB: The reason for the local catalog limitation (for now?) is to prevent a cascade. Otherwise you could import a catalog that references a bunch of other catalogs and imports them all and suddenly you have a gazillion aliases and templates available. But perhaps this is a restriction that could be relaxed in the future.

Btw, with this feature you could almost implement something like the jbanghub with very little changes. If you import the Hub's catalog and if it would have a list of catalog references, like for example "sqlline", then we would have a simple way to manage "named catalogs". You could do `jbang foo@sqlline` and it would work.