### PR TITLE
feat!: alias arguments are now appended

### DIFF
--- a/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
+++ b/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
@@ -146,9 +146,17 @@ public class CmdGeneratorBuilder {
 	private void updateFromAlias(Alias alias) {
 		if (arguments.isEmpty()) {
 			setArguments(handleRemoteFiles(alias.arguments));
+		} else if (alias.arguments != null && !alias.arguments.isEmpty()) {
+			List<String> args = new ArrayList<>(handleRemoteFiles(alias.arguments));
+			args.addAll(arguments);
+			setArguments(args);
 		}
 		if (runtimeOptions.isEmpty()) {
 			runtimeOptions(alias.runtimeOptions);
+		} else if (alias.runtimeOptions != null && !alias.runtimeOptions.isEmpty()) {
+			List<String> opts = new ArrayList<>(alias.runtimeOptions);
+			opts.addAll(runtimeOptions);
+			runtimeOptions(opts);
 		}
 		if (mainClass == null) {
 			mainClass(alias.mainClass);


### PR DESCRIPTION
Arguments passed to an alias are now appended to any arguments that are already defined in the alias instead of replacing them.

Fixes #605
