### PR TITLE
feat: added jbanghub to builtin catalog

### DIFF
--- a/itests/catalog.feature
+++ b/itests/catalog.feature
@@ -51,3 +51,8 @@ Scenario: list remote catalog templates
   Then  match exit == 0
   And match out contains "@jbangdev"
   And match out !contains "@jbangdev/jbang-catalog"
+
+Scenario: Removing built-in catalog
+When command('jbang catalog remove jbanghub')
+* match exit == 0
+* match err contains "Cannot remove catalog ref jbanghub from built-in catalog"

--- a/itests/template.feature
+++ b/itests/template.feature
@@ -1,0 +1,6 @@
+Feature: template
+
+Scenario: Removing built-in template
+When command('jbang template remove hello')
+* match exit == 0
+* match err contains "Cannot remove template hello from built-in catalog"

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -281,6 +281,9 @@ public class Catalog {
 		}
 		if (catalog == null) {
 			catalog = accept.apply(getBuiltin());
+			if (catalog == null && includeImported) {
+				catalog = findImportedCatalogsWith(getBuiltin(), accept);
+			}
 		}
 		return catalog;
 	}

--- a/src/main/java/dev/jbang/catalog/CatalogUtil.java
+++ b/src/main/java/dev/jbang/catalog/CatalogUtil.java
@@ -81,6 +81,8 @@ public class CatalogUtil {
 		if (catalog != null) {
 			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
 				Util.warnMsg("Unable to remove alias " + name + " because it is imported from a remote catalog");
+			} else if (catalog.equals(Catalog.getBuiltin())) {
+				Util.warnMsg("Cannot remove alias " + name + " from built-in catalog");
 			} else {
 				removeAlias(catalog, name);
 			}
@@ -175,6 +177,8 @@ public class CatalogUtil {
 		if (catalog != null) {
 			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
 				Util.warnMsg("Unable to remove template " + name + " because it is imported from a remote catalog");
+			} else if (catalog.equals(Catalog.getBuiltin())) {
+				Util.warnMsg("Cannot remove template " + name + " from built-in catalog");
 			} else {
 				removeTemplate(catalog, name);
 			}
@@ -214,6 +218,8 @@ public class CatalogUtil {
 		if (catalog != null) {
 			if (catalog.catalogRef.isURL() && Util.isRemoteRef(catalog.catalogRef.getOriginalResource())) {
 				Util.warnMsg("Unable to remove catalog ref " + name + " because it is imported from a remote catalog");
+			} else if (catalog.equals(Catalog.getBuiltin())) {
+				Util.warnMsg("Cannot remove catalog ref " + name + " from built-in catalog");
 			} else {
 				removeCatalogRef(catalog, name);
 			}

--- a/src/main/resources/jbang-catalog.json
+++ b/src/main/resources/jbang-catalog.json
@@ -1,4 +1,11 @@
 {
+  "catalogs": {
+    "jbanghub": {
+      "catalog-ref": "https://raw.githubusercontent.com/jbanghub/jbang-catalog/main/jbang-catalog.json",
+      "description": "JBangHub - Unleashing the Java community",
+      "import": true
+    }
+  },
   "templates": {
     "gpt": {
       "file-refs": {"{filename}":  "init-gpt.java.qute"},

--- a/src/test/java/dev/jbang/cli/TestCatalogNearest.java
+++ b/src/test/java/dev/jbang/cli/TestCatalogNearest.java
@@ -2,11 +2,7 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -22,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import dev.jbang.BaseTest;
 import dev.jbang.Settings;
 import dev.jbang.catalog.Catalog;
+import dev.jbang.catalog.CatalogRef;
 import dev.jbang.catalog.CatalogUtil;
 import dev.jbang.util.Util;
 
@@ -75,13 +72,22 @@ public class TestCatalogNearest extends BaseTest {
 				"global",
 				"dotparent",
 				"dotlocal",
-				"local"));
-		assertThat(catalog.catalogs.keySet(), equalTo(keys));
+				"local",
+				"jbanghub"));
+		assertThat(catalog.catalogs.keySet().containsAll(keys), is(true));
 
 		assertThat(catalog.catalogs.get("global").catalogRef, is(aliasesFile.toString()));
 		assertThat(catalog.catalogs.get("dotparent").catalogRef, is(aliasesFile.toString()));
 		assertThat(catalog.catalogs.get("dotlocal").catalogRef, is(aliasesFile.toString()));
 		assertThat(catalog.catalogs.get("local").catalogRef, is(aliasesFile.toString()));
+		assertThat(catalog.catalogs.get("jbanghub").catalog, is(Catalog.getBuiltin()));
+
+		catalog.catalogs.keySet().removeAll(keys);
+		// After removing the known keys, the rest must come from the jbanghub import
+		final String JBANGHUB_URL = "https://raw.githubusercontent.com/jbanghub/jbang-catalog/main/jbang-catalog.json";
+		for (CatalogRef c : catalog.catalogs.values()) {
+			assertThat(c.catalog.catalogRef.getOriginalResource(), is(JBANGHUB_URL));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This is the simplest solution where we add the jbanghub catalog ref to the "builtin" catalog. It does mean however that a user could never remove it (they could override it, for example to make it non-importing, but they could not remove it).