### PR TITLE
feat: add riscv64 support

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -417,7 +417,7 @@ public class Util {
 	}
 
 	public enum Arch {
-		x32, x64, aarch64, arm64, ppc64, ppc64le, s390x, unknown
+		x32, x64, aarch64, arm64, ppc64, ppc64le, s390x, riscv64, unknown
 	}
 
 	public enum Shell {
@@ -560,6 +560,8 @@ public class Util {
 			return Arch.s390x;
 		} else if (arch.matches("^(arm64)$")) {
 			return Arch.arm64;
+		} else if (arch.matches("^(riscv64)$")) {
+			return Arch.riscv64;
 		} else {
 			verboseMsg("Unknown Arch: " + arch);
 			return Arch.unknown;

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -95,7 +95,7 @@ case "$(uname -m)" in
   s390x)
     arch=s390x;;
   arm64)
-    arch=arm64
+    arch=arm64;;
   riscv64)
     arch=riscv64;;
     ;;

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -97,7 +97,7 @@ case "$(uname -m)" in
   arm64)
     arch=arm64;;
   riscv64)
-    arch=riscv64;;
+    arch=riscv64
     ;;
   *)
     ## AIX gives a machine ID for `uname -m` but it only supports ppc64

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -96,6 +96,8 @@ case "$(uname -m)" in
     arch=s390x;;
   arm64)
     arch=arm64
+  riscv64)
+    arch=riscv64;;
     ;;
   *)
     ## AIX gives a machine ID for `uname -m` but it only supports ppc64


### PR DESCRIPTION
Title says it all. Now that Temurin has a GA JDK21 and ea versions on other openjdk release lines this will add support for Linux/riscv64.

Related: I was tempted to modify the default `JBANG_DEFAULT_JAVA_VERSION` for this platform to 21 instead of 17 in https://github.com/jbangdev/jbang/blob/826755c427070d2b69e88256a164658160bbedc6/src/main/scripts/jbang#L10C45-L10C46

This is because 21 is currently the only "GA" level at Adoptium. The 17 that is pulled down by default to bootstrap the process is an early access release. I'll leave it to reviewers to decide if that is a concern but I may raise a separate issue to consider bumping it to 21. I'll note that the obvious potential concern with doing that is that there are platforms (arm32) which is not available from Temurin in a GA JDK21 version. All other platforms should now be available.
