### PR TITLE
fix: 32-bit arm architecture detection missing

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -417,7 +417,7 @@ public class Util {
 	}
 
 	public enum Arch {
-		x32, x64, aarch64, arm64, ppc64, ppc64le, s390x, unknown
+		x32, x64, aarch64, arm, arm64, ppc64, ppc64le, s390x, unknown
 	}
 
 	public enum Shell {
@@ -552,6 +552,8 @@ public class Util {
 			return Arch.x32;
 		} else if (arch.matches("^(aarch64)$")) {
 			return Arch.aarch64;
+		} else if (arch.matches("^(aarch64)$")) {
+			return Arch.arm;
 		} else if (arch.matches("^(ppc64)$")) {
 			return Arch.ppc64;
 		} else if (arch.matches("^(ppc64le)$")) {

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -552,7 +552,7 @@ public class Util {
 			return Arch.x32;
 		} else if (arch.matches("^(aarch64)$")) {
 			return Arch.aarch64;
-		} else if (arch.matches("^(aarch64)$")) {
+		} else if (arch.matches("^(arm)$")) {
 			return Arch.arm;
 		} else if (arch.matches("^(ppc64)$")) {
 			return Arch.ppc64;


### PR DESCRIPTION
The initial `jbang` shell script can download it's default JDK (Unless it detects an existing JDK on the system, when it will use the java version).

In all other cases, it sets the architecture to `unknown` so this PR will allow it to detect the 32-bit arm architecture properly.

Noting that this will generate a merge conflict with my riscv64 PR due to the `Arch` list but it's an easy merge :-)

Initially draft as I haven't test built it.