### PR TITLE
Make 'app list' only return executables

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -322,6 +322,7 @@ class AppList extends BaseCommand {
 	private static List<AppOut> listCommandFiles() {
 		try (Stream<Path> files = Files.list(Settings.getConfigBinDir())) {
 			return files
+						.filter(Files::isExecutable)
 						.sorted()
 						.map(AppOut::new)
 						.filter(distinctByKey(AppOut::getName))


### PR DESCRIPTION
Currently `jbang app list` prints out all the files in the bin directory. This PR fixes this by filtering the files by the executable flag (scripts in PATH are picked up by the shell only if they're executable anyways)