### PR TITLE
fix: no longer get an exception when using option names as values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
 	implementation 'org.apache.commons:commons-text:1.11.0'
 	implementation 'org.apache.commons:commons-compress:1.25.0'
-	implementation 'info.picocli:picocli:4.6.3'
+	implementation 'info.picocli:picocli:4.7.5'
 	implementation 'io.quarkus.qute:qute-core:1.12.2.Final'
 	implementation 'kr.motd.maven:os-maven-plugin:1.7.1'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -254,6 +254,8 @@ public class JBang extends BaseCommand {
 					.setDefaultValueProvider(defaultValueProvider)
 					.setResourceBundle(new ConfigurationResourceBundle())
 					.setStopAtPositional(true)
+					.setAllowOptionsAsOptionParameters(true)
+					.setAllowSubcommandsAsOptionParameters(true)
 					.setOut(localout)
 					.setErr(localerr);
 	}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -2516,4 +2516,11 @@ public class TestRun extends BaseTest {
 
 		assertThat(cmdline, endsWith("echo baz"));
 	}
+
+	@Test
+	void testNativeOptsVerbose() {
+		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("build", "-n", "-N=--verbose", arg);
+	}
+
 }


### PR DESCRIPTION
Fixes #1786
