### PR TITLE
chore: made `version --verbose` more verbose

### DIFF
--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -41,6 +41,10 @@ public class Version extends BaseCommand {
 			out.println("Cache: " + Settings.getCacheDir());
 			out.println("Config: " + Settings.getConfigDir());
 			out.println("Repository: " + ArtifactResolver.getLocalMavenRepo());
+			out.println("Java: " + System.getProperty("java.home") + " [" + System.getProperty("java.version") + "]");
+			out.println("OS: " + Util.getOS());
+			out.println("Arch: " + Util.getArch());
+			out.println("Shell: " + Util.getShell());
 		}
 
 		return EXIT_OK;


### PR DESCRIPTION
Added a couple of more informational lines that can help us debug issues that people might have with JBang.
