### PR TITLE
feat: introduce type 'fatjar'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,8 +103,8 @@ dependencies {
 	implementation "org.slf4j:jcl-over-slf4j:1.7.30"
 	implementation "org.jboss:jandex:2.2.3.Final"
 
-	implementation "eu.maveniverse.maven.mima:context:2.4.4"
-	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.4"
+	implementation "eu.maveniverse.maven.mima:context:2.4.12"
+	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.12"
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.1"
@@ -235,6 +235,7 @@ compileJava9Java {
 shadowJar {
 	minimize() {
 		//exclude(dependency('org.slf4j:slf4j-api:.*'))
+		exclude(dependency('eu.maveniverse.maven.mima:context:.*'))
 		exclude(dependency('eu.maveniverse.maven.mima.runtime:standalone-static:.*'))
 		exclude(dependency('org.slf4j:jcl-over-slf4j:.*'))
 		exclude(dependency('org.slf4j:slf4j-nop:.*'))

--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -78,6 +78,18 @@ is the equivalent of the following Maven dependency declaration:
 ```
 ====
 
+== 'fatjar' dependencies [Experimental]
+
+Maven 4 introduces a special dependency type called `fatjar` which can be used to designate that the dependency should be treated as a jar that have all its dependencies included and thus not require fetching declared dependencies.
+
+JBang 0.117 adds support for this allowing you to just add `@fatjar` at the end.
+
+Example:
+
+`jbang eu.maveniverse.maven.plugins:toolbox:0.1.9:cli@fatjar`
+
+Without `@fatjar` it would resolve dependencies which would be redundant.
+
 == Managed dependencies ("BOM POM"'s) [Experimental]
 
 When using libraries and frameworks it can get tedious to mange and update multiple versions.

--- a/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
+++ b/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
@@ -15,6 +15,7 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.ArtifactType;
 import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.artifact.DefaultArtifactType;
 import org.eclipse.aether.collection.CollectRequest;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.metadata.Metadata;
@@ -145,6 +146,9 @@ public class ArtifactResolver implements Closeable {
 																			? ContextOverrides.SnapshotUpdatePolicy.ALWAYS
 																			: null)
 																	.repositoryListener(listener);
+
+		overridesBuilder.extraArtifactTypes(
+				Collections.singletonList(new DefaultArtifactType("fatjar", "jar", null, "java", true, true)));
 
 		this.context = Runtimes.INSTANCE.getRuntime().create(overridesBuilder.build());
 	}
@@ -354,6 +358,8 @@ public class ArtifactResolver implements Closeable {
 			if (type != null) {
 				ext = type.getExtension();
 				cls = Optional.ofNullable(cls).orElse(type.getClassifier());
+				return new DefaultArtifact(coord.getGroupId(), coord.getArtifactId(), cls, ext, coord.getVersion(),
+						type);
 			}
 		}
 		return new DefaultArtifact(coord.getGroupId(), coord.getArtifactId(), cls, ext, coord.getVersion());


### PR DESCRIPTION
A new ArtifactType that is also present in Maven4. The 'fatjar' type denotes a Java JAR file that is
"self sufficient", contains all the dependencies. This makes resolver stop resolving. Usable when for example there is an `uber` or `cli` classified artifact, as in other cases resolver would pick up POM and (probably wrongfully) resolve it.

Fixes #1778

Alows something like this
```
$ jbang eu.maveniverse.maven.plugins:toolbox:0.1.9:cli@fatjar
```

Note: Maven4 introduced this type, but Maven3 has no idea about it. JBang uses new feature of MIMA that allows one to define own ArtifactTypes. See https://github.com/apache/maven/pull/1459
