### PR TITLE
chore: update to Kotlin 1.9.24

### DIFF
--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -14,7 +14,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "1.8.22";
+	public static final String DEFAULT_KOTLIN_VERSION = "1.9.24";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);


### PR DESCRIPTION
Upgrade Kotlin from 1.8.22 to 1.9.24. We do not yet upgrade to Kotlin 2.0.0, giving it more time to mature.
