### PR TITLE
feat: export an additional env var pointing to the location of jbang

### DIFF
--- a/itests/shellenv.feature
+++ b/itests/shellenv.feature
@@ -1,0 +1,13 @@
+Feature: env variables
+
+Scenario: JBANG_RUNTIME_SHELL available
+When command('jbang env@jbangdev jbang')
+Then match err contains "^JBANG_RUNTIME_SHELL"
+
+Scenario: JBANG_STDIN_NOTTY available
+  When command('jbang env@jbangdev jbang')
+  Then match err contains "^JBANG_STDIN_NOTTY"
+
+Scenario: JBANG_LAUNCH_CMD available
+  When command('jbang env@jbangdev jbang')
+  Then match err contains "^JBANG_LAUNCH_CMD"

--- a/itests/shellenv.feature
+++ b/itests/shellenv.feature
@@ -1,13 +1,13 @@
 Feature: env variables
 
 Scenario: JBANG_RUNTIME_SHELL available
-When command('jbang env@jbangdev jbang')
-Then match err contains "^JBANG_RUNTIME_SHELL"
+When command('jbang env@jbangdev JBANG')
+Then match out contains "JBANG_RUNTIME_SHELL"
 
 Scenario: JBANG_STDIN_NOTTY available
-  When command('jbang env@jbangdev jbang')
-  Then match err contains "^JBANG_STDIN_NOTTY"
+  When command('jbang env@jbangdev JBANG')
+  Then match out contains "JBANG_STDIN_NOTTY"
 
 Scenario: JBANG_LAUNCH_CMD available
-  When command('jbang env@jbangdev jbang')
-  Then match err contains "^JBANG_LAUNCH_CMD"
+  When command('jbang env@jbangdev JBANG')
+  Then match out contains "JBANG_LAUNCH_CMD"

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -220,7 +220,7 @@ fi
 ## run it using command substitution to have just the user process once jbang is done
 export JBANG_RUNTIME_SHELL=bash
 export JBANG_STDIN_NOTTY=$([ -t 0 ] && echo "false" || echo "true")
-export JBANG=$0
+export JBANG_LAUNCH_CMD=$0
 output=$(CLICOLOR_FORCE=1 "${JAVA_EXEC}" ${JBANG_JAVA_OPTIONS} -classpath "${jarPath}" dev.jbang.Main "$@")
 err=$?
 if [ $err -eq 255 ]; then

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -220,6 +220,7 @@ fi
 ## run it using command substitution to have just the user process once jbang is done
 export JBANG_RUNTIME_SHELL=bash
 export JBANG_STDIN_NOTTY=$([ -t 0 ] && echo "false" || echo "true")
+export JBANG=$0
 output=$(CLICOLOR_FORCE=1 "${JAVA_EXEC}" ${JBANG_JAVA_OPTIONS} -classpath "${jarPath}" dev.jbang.Main "$@")
 err=$?
 if [ $err -eq 255 ]; then

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -63,6 +63,7 @@ if not exist "%TDIR%" ( mkdir "%TDIR%" )
 set tmpfile=%TDIR%\%RANDOM%.jbang.tmp
 rem execute jbang and pipe to temporary random file
 set JBANG_RUNTIME_SHELL=cmd
+set JBANG_LAUNCH_CMD=%~nx0
 2>nul >nul timeout /t 0 && (set JBANG_STDIN_NOTTY=false) || (set JBANG_STDIN_NOTTY=true)
 set "CMD=!JAVA_EXEC!"
 SETLOCAL DISABLEDELAYEDEXPANSION

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -167,6 +167,7 @@ if ($JAVA_EXEC -eq "") {
 
 $env:JBANG_RUNTIME_SHELL="powershell"
 $env:JBANG_STDIN_NOTTY=$MyInvocation.ExpectingInput
+$env:JBANG_LAUNCH_CMD = $PSCommandPath
 $output = & "$JAVA_EXEC" $env:JBANG_JAVA_OPTIONS -classpath "$jarPath" dev.jbang.Main @args
 $err=$LASTEXITCODE
 


### PR DESCRIPTION
It's *really* hard (impossible?) to find the location of the script that launched the JVM from within jbang. It would be really useful to be able to do that so you can run jbang again with some logic to precompute the command line. This works really simply:

```
$ jbang --interactive
WARNING: Using incubator modules: jdk.incubator.vector, jdk.incubator.foreign
|  Welcome to JShell -- Version 17.0.7
|  For an introduction type: /help intro

jshell> System.getenv("JBANG")
$1 ==> "/home/dsyer/.sdkman/candidates/jbang/current/bin/jbang"
```

Edit: I don't know how to do this for Windows users. Anyone got an idea?
