### PR TITLE
Update Kotlin support to use the latest version. Fix some runtime UX issues.

### DIFF
--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -14,7 +14,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "1.8.22";
+	public static final String DEFAULT_KOTLIN_VERSION = "2.0.0";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -24,6 +24,13 @@ public class KotlinSource extends Source {
 	}
 
 	@Override
+	protected List<String> collectBinaryDependencies() {
+		final List<String> allDependencies = super.collectBinaryDependencies();
+		allDependencies.add("org.jetbrains.kotlin:kotlin-stdlib:" + getKotlinVersion());
+		return allDependencies;
+	}
+
+	@Override
 	protected List<String> getCompileOptions() {
 		return tagReader.collectOptions("COMPILE_OPTIONS");
 	}

--- a/src/main/resources/init-hello.kt.qute
+++ b/src/main/resources/init-hello.kt.qute
@@ -1,4 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}
@@ -8,6 +9,6 @@
 {magiccontent}
 {#else}
 public fun main() {
-    println("Hello World");
+    println("Hello World")
 }
 {/if}


### PR DESCRIPTION
- update the default kotlin version
- transparently add kotlin-stdlib to the deps based on the configured kotlin version. without this users would sometimes be given an error about missing intrinsics.  curiouslier, it seemed to matter if the script was invoked directly vs as a parameter to the `jbang` command.
- remove the trailing `;` in the kotlin template