### PR TITLE
feat: when no jdk installable show possible reasons/erros

### DIFF
--- a/src/main/java/dev/jbang/net/jdkproviders/JBangJdkProvider.java
+++ b/src/main/java/dev/jbang/net/jdkproviders/JBangJdkProvider.java
@@ -69,7 +69,8 @@ public class JBangJdkProvider extends BaseFoldersJdkProvider {
 			result.sort(Jdk::compareTo);
 			return Collections.unmodifiableList(result);
 		} catch (IOException e) {
-			Util.verboseMsg("Couldn't list available JDKs", e);
+			Util.errorMsg("Could not list available JDK's using foojay.io: " + e.getMessage(), e);
+			// Util.verboseMsg("Couldn't list available JDKs", e);
 		}
 		return Collections.emptyList();
 	}


### PR DESCRIPTION
in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/JBang.20failure/near/455708888 @gsmet had this happen:

```
Error:  [ERROR] JDK version is not available for installation: 21
Use 'jbang jdk list --available' to see a list of JDKs available for installation
[jbang] Run with --verbose for more details
Error: Process completed with exit code 2.
```

as it happens in github he can't really easily re-run with verbose to get info why failed.

This PR tries without having to reorganize the whole call chain and print out last possible exception for each provider.


