### PR TITLE
feat: linuxdistro jdk provider

### DIFF
--- a/src/main/java/dev/jbang/net/JdkManager.java
+++ b/src/main/java/dev/jbang/net/JdkManager.java
@@ -30,7 +30,7 @@ public class JdkManager {
 
 	// TODO Don't hard-code this list
 	public static final String[] PROVIDERS_ALL = new String[] { "current", "default", "javahome", "path", "jbang",
-			"sdkman", "scoop", "linuxdistro" };
+			"sdkman", "scoop", "linux" };
 	public static final String[] PROVIDERS_DEFAULT = new String[] { "current", "default", "javahome", "path", "jbang" };
 
 	public static void initProvidersByName(String... providerNames) {
@@ -68,8 +68,8 @@ public class JdkManager {
 			case "scoop":
 				provider = new ScoopJdkProvider();
 				break;
-			case "linuxdistro":
-				provider = new LinuxDistroJdkProvider();
+			case "linux":
+				provider = new LinuxJdkProvider();
 				break;
 			default:
 				Util.warnMsg("Unknown JDK provider: " + name);

--- a/src/main/java/dev/jbang/net/JdkManager.java
+++ b/src/main/java/dev/jbang/net/JdkManager.java
@@ -21,13 +21,7 @@ import javax.annotation.Nullable;
 
 import dev.jbang.Settings;
 import dev.jbang.cli.ExitException;
-import dev.jbang.net.jdkproviders.CurrentJdkProvider;
-import dev.jbang.net.jdkproviders.DefaultJdkProvider;
-import dev.jbang.net.jdkproviders.JBangJdkProvider;
-import dev.jbang.net.jdkproviders.JavaHomeJdkProvider;
-import dev.jbang.net.jdkproviders.PathJdkProvider;
-import dev.jbang.net.jdkproviders.ScoopJdkProvider;
-import dev.jbang.net.jdkproviders.SdkmanJdkProvider;
+import dev.jbang.net.jdkproviders.*;
 import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
 
@@ -36,7 +30,7 @@ public class JdkManager {
 
 	// TODO Don't hard-code this list
 	public static final String[] PROVIDERS_ALL = new String[] { "current", "default", "javahome", "path", "jbang",
-			"sdkman", "scoop" };
+			"sdkman", "scoop", "linuxdistro" };
 	public static final String[] PROVIDERS_DEFAULT = new String[] { "current", "default", "javahome", "path", "jbang" };
 
 	public static void initProvidersByName(String... providerNames) {
@@ -73,6 +67,9 @@ public class JdkManager {
 				break;
 			case "scoop":
 				provider = new ScoopJdkProvider();
+				break;
+			case "linuxdistro":
+				provider = new LinuxDistroJdkProvider();
 				break;
 			default:
 				Util.warnMsg("Unknown JDK provider: " + name);

--- a/src/main/java/dev/jbang/net/JdkProvider.java
+++ b/src/main/java/dev/jbang/net/JdkProvider.java
@@ -121,6 +121,8 @@ public interface JdkProvider {
 
 	default String name() {
 		String nm = getClass().getSimpleName();
+		// TODO: this 11 is here assuming it ends in "JdkProvider" - dont make that
+		// broken assumption
 		return nm.substring(0, nm.length() - 11).toLowerCase();
 	}
 

--- a/src/main/java/dev/jbang/net/JdkProvider.java
+++ b/src/main/java/dev/jbang/net/JdkProvider.java
@@ -121,9 +121,11 @@ public interface JdkProvider {
 
 	default String name() {
 		String nm = getClass().getSimpleName();
-		// TODO: this 11 is here assuming it ends in "JdkProvider" - dont make that
-		// broken assumption
-		return nm.substring(0, nm.length() - 11).toLowerCase();
+		if (nm.endsWith("JdkProvider")) {
+			return nm.substring(0, nm.length() - 11).toLowerCase();
+		} else {
+			return nm.toLowerCase();
+		}
 	}
 
 	/**

--- a/src/main/java/dev/jbang/net/jdkproviders/BaseFoldersJdkProvider.java
+++ b/src/main/java/dev/jbang/net/jdkproviders/BaseFoldersJdkProvider.java
@@ -87,7 +87,7 @@ public abstract class BaseFoldersJdkProvider implements JdkProvider {
 		return getJdksRoot().resolve(jdk);
 	}
 
-	private Predicate<Path> sameJdk(Path jdkRoot) {
+	protected Predicate<Path> sameJdk(Path jdkRoot) {
 		Path release = jdkRoot.resolve("release");
 		return (Path p) -> {
 			try {
@@ -100,7 +100,7 @@ public abstract class BaseFoldersJdkProvider implements JdkProvider {
 
 	protected Stream<Path> listJdkPaths() throws IOException {
 		if (Files.isDirectory(getJdksRoot())) {
-			return Files.list(getJdksRoot());
+			return Files.list(getJdksRoot()).filter(this::acceptFolder);
 		}
 		return Stream.empty();
 	}
@@ -114,10 +114,14 @@ public abstract class BaseFoldersJdkProvider implements JdkProvider {
 	protected Jdk createJdk(Path home) {
 		String name = home.getFileName().toString();
 		Optional<String> version = JavaUtil.resolveJavaVersionStringFromPath(home);
-		if (version.isPresent()) {
+		if (version.isPresent() && acceptFolder(home)) {
 			return createJdk(jdkId(name), home, version.get());
 		}
 		return null;
+	}
+
+	protected boolean acceptFolder(Path jdkFolder) {
+		return Util.searchPath("javac", jdkFolder.resolve("bin").toString()) != null;
 	}
 
 	protected boolean isValidId(String id) {

--- a/src/main/java/dev/jbang/net/jdkproviders/LinuxDistroJdkProvider.java
+++ b/src/main/java/dev/jbang/net/jdkproviders/LinuxDistroJdkProvider.java
@@ -1,5 +1,6 @@
 package dev.jbang.net.jdkproviders;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -36,5 +37,23 @@ public class LinuxDistroJdkProvider extends BaseFoldersJdkProvider {
 	@Override
 	public boolean canUse() {
 		return Files.isDirectory(JDKS_ROOT);
+	}
+
+	@Override
+	protected boolean acceptFolder(Path jdkFolder) {
+		return super.acceptFolder(jdkFolder) && !isSameFolderSymLink(jdkFolder);
+	}
+
+	// Returns true if a path is a symlink to an entry in the same folder
+	private boolean isSameFolderSymLink(Path jdkFolder) {
+		Path absFolder = jdkFolder.toAbsolutePath();
+		if (Files.isSymbolicLink(absFolder)) {
+			try {
+				Path realPath = absFolder.toRealPath();
+				return Files.isSameFile(absFolder.getParent(), realPath.getParent());
+			} catch (IOException e) {
+				/* ignore */ }
+		}
+		return false;
 	}
 }

--- a/src/main/java/dev/jbang/net/jdkproviders/LinuxDistroJdkProvider.java
+++ b/src/main/java/dev/jbang/net/jdkproviders/LinuxDistroJdkProvider.java
@@ -1,0 +1,40 @@
+package dev.jbang.net.jdkproviders;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This JDK provider is intended to detects JDKs that have been installed in
+ * standard location of the users linux distro.
+ *
+ * For now just using `/usr/lib/jvm` as apparently fedora, debian, ubuntu and
+ * centos/rhel use it.
+ *
+ * If need different behavior per linux distro its intended this provider will
+ * adjust based on identified distro.
+ *
+ */
+public class LinuxDistroJdkProvider extends BaseFoldersJdkProvider {
+	private static final Path JDKS_ROOT = Paths.get("/usr/lib/jvm");
+
+	@Nonnull
+	@Override
+	protected Path getJdksRoot() {
+		return JDKS_ROOT;
+	}
+
+	@Nullable
+	@Override
+	protected String jdkId(String name) {
+		return name + "-nixdistro";
+	}
+
+	@Override
+	public boolean canUse() {
+		return Files.isDirectory(JDKS_ROOT);
+	}
+}

--- a/src/main/java/dev/jbang/net/jdkproviders/LinuxJdkProvider.java
+++ b/src/main/java/dev/jbang/net/jdkproviders/LinuxJdkProvider.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
  * adjust based on identified distro.
  *
  */
-public class LinuxDistroJdkProvider extends BaseFoldersJdkProvider {
+public class LinuxJdkProvider extends BaseFoldersJdkProvider {
 	private static final Path JDKS_ROOT = Paths.get("/usr/lib/jvm");
 
 	@Nonnull
@@ -31,7 +31,7 @@ public class LinuxDistroJdkProvider extends BaseFoldersJdkProvider {
 	@Nullable
 	@Override
 	protected String jdkId(String name) {
-		return name + "-nixdistro";
+		return name + "-linux";
 	}
 
 	@Override

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -451,9 +451,15 @@ class TestJdk extends BaseTest {
 
 	private void initMockJdkDir(Path jdkPath, String version, String key) {
 		Util.mkdirs(jdkPath);
+		Path jdkBinPath = jdkPath.resolve("bin");
+		Util.mkdirs(jdkBinPath);
 		String rawJavaVersion = key + "=\"" + version + "\"";
 		Path release = jdkPath.resolve("release");
 		try {
+			Path javacPath = jdkBinPath.resolve("javac");
+			Util.writeString(javacPath, "dummy");
+			javacPath.toFile().setExecutable(true, true);
+			Util.writeString(jdkBinPath.resolve("javac.exe"), "dummy");
 			Util.writeString(release, rawJavaVersion);
 		} catch (IOException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
adds `linuxdistro` provider which for now searches `/usr/lib/jvm` for jdks.

It is not enabled by default as it is not possible to safely determine the version and build of the jdk
present or needed to be installed if mising.

Meaning to get it user need to run `jbang config set jdkproviders all` or `jbang config set jdkproviders linuxdistro` if only want this.

You can see which providers are finding jdks by running `jbang jdk list --show-details`

Fixes #1825 

@quintesse I see that `jbang jdk list --show-details` list what looks like all dirs even though javac is not available. is that expected?