### PR TITLE
fix: use main-SNAPSHOT as best-effort fallback for jitpack

### DIFF
--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -112,11 +112,14 @@ name of the module by appending `#name-of-module` to the URL.
 And finally if the link you provide is to a specific branch of the project then you need to append
 `#:SNAPSHOT` to the URL. (If you have both a branch and a module name then use `#name-of-module:SNAPSHOT`)
 
+Note: if no branch specified `main-SNAPSHOT` will be used and if you list `main` or `master` they will both
+be treated as if you want the snapshot version.
+
 .Examples of links and their resulting locator:
 |===
 |Link | Locator
 |https://github.com/jbangdev/jbang
-|com.github.jbangdev:jbang:HEAD-SNAPSHOT
+|com.github.jbangdev:jbang:main-SNAPSHOT
 
 |https://github.com/jbangdev/jbang/tree/v1.2.3
 |com.github.jbangdev:jbang:v1.2.3
@@ -125,13 +128,13 @@ And finally if the link you provide is to a specific branch of the project then 
 |com.github.jbangdev:jbang:f1f34b031d
 
 |https://github.com/jbangdev/jbang#mymodule
-|com.github.jbangdev.jbang:mymodule:HEAD-SNAPSHOT
+|com.github.jbangdev.jbang:mymodule:main-SNAPSHOT
 
 |https://github.com/jbangdev/jbang/tree/mybranch#:SNAPSHOT
 |com.github.jbangdev:jbang:mybranch-SNAPSHOT
 
 |https://github.com/jbangdev/jbang/tree/mybranch#mymodule:SNAPSHOT
-|com.github.jbangdev.jbang.mymodule:mybranch-SNAPSHOT
+|com.github.jbangdev.jbang: mymodule:mybranch-SNAPSHOT
 |===
 
 == Offline mode

--- a/src/main/java/dev/jbang/dependencies/JitPackUtil.java
+++ b/src/main/java/dev/jbang/dependencies/JitPackUtil.java
@@ -61,14 +61,16 @@ public class JitPackUtil {
 						// Override GAV coords with values from the #part of the URL
 						Pgamv pgamv = coords.get().module(module);
 						if ((snapshot != null && pgamv.version != null) ||
-								(!hash.endsWith(":") && "master".equals(pgamv.version))) {
+								(!hash.endsWith(":") && ("master".equals(pgamv.version)) || "main".equals(pgamv.version))) {
 							pgamv = pgamv.version(pgamv.version + "-SNAPSHOT");
 						}
 						ref = pgamv.toGav();
 					} else {
 						if ("master".equals(coords.get().version)) {
 							ref = coords.get().version("master" + "-SNAPSHOT").toGav();
-						} else {
+						} else if ("main".equals(coords.get().version)) {
+							ref = coords.get().version("main" + "-SNAPSHOT").toGav();
+						}else {
 							ref = coords.get().toGav();
 						}
 					}
@@ -110,7 +112,8 @@ public class JitPackUtil {
 		String toGav() {
 			String v;
 			if (version == null) {
-				v = "-SNAPSHOT"; // using HEAD as no longer possible to know what default branch is called.
+				v = "main-SNAPSHOT"; // using HEAD as no longer possible to know what default branch is called.
+				// thus for now we default to assume 'main' as default.
 			} else if (POSSIBLE_SHA1_PATTERN.matcher(version).matches()) {
 				v = version.substring(0, 10);
 			} else {

--- a/src/test/java/dev/jbang/dependencies/TestJitPack.java
+++ b/src/test/java/dev/jbang/dependencies/TestJitPack.java
@@ -1,5 +1,6 @@
 package dev.jbang.dependencies;
 
+import static dev.jbang.dependencies.JitPackUtil.ensureGAV;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -10,59 +11,83 @@ public class TestJitPack extends BaseTest {
 
 	@Test
 	void testExtractGithubUrlDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang"),
-				"com.github.jbangdev:jbang:-SNAPSHOT");
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang"),
+				"com.github.jbangdev:jbang:main-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/main"),
+				"com.github.jbangdev:jbang:main-SNAPSHOT");
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master"),
 				"com.github.jbangdev:jbang:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master/foo"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master/foo"),
 				"com.github.jbangdev.jbang:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/v0.20.0"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/v0.20.0"),
 				"com.github.jbangdev:jbang:v0.20.0");
 
 		assertEquals(
-				JitPackUtil.ensureGAV(
+				ensureGAV(
 						"https://github.com/jbangdev/jbang/commit/90dfcbf354fc0838f08eea0680bf736b7c069b4e"),
 				"com.github.jbangdev:jbang:90dfcbf354");
 
 	}
 
 	@Test
+	void testDocumentedLocators() {
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang"),
+				"com.github.jbangdev:jbang:main-SNAPSHOT");
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/v1.2.3"),
+				"com.github.jbangdev:jbang:v1.2.3");
+
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/f1f34b031d2163e0cdc6f9a3725b59f47129c923"),
+					"com.github.jbangdev:jbang:f1f34b031d");
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang#mymodule"),
+"com.github.jbangdev.jbang:mymodule:main-SNAPSHOT");
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/mybranch#:SNAPSHOT"),
+"com.github.jbangdev:jbang:mybranch-SNAPSHOT");
+
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/mybranch#mymodule:SNAPSHOT"),
+"com.github.jbangdev.jbang:mymodule:mybranch-SNAPSHOT");
+	}
+	@Test
 	void testExtractGithubUrlWithHashDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang#foo"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang#foo"),
 				"com.github.jbangdev.jbang:foo:-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo"),
 				"com.github.jbangdev.jbang:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master#:"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master#:"),
 				"com.github.jbangdev:jbang:master");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo:"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master#foo:"),
 				"com.github.jbangdev.jbang:foo:master");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/master/foo#bar"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/master/foo#bar"),
 				"com.github.jbangdev.jbang:bar:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#foo:SNAPSHOT"),
+		assertEquals(ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#foo:SNAPSHOT"),
 				"com.github.jbangdev.jbang:foo:somebranch-SNAPSHOT");
 
 		assertEquals("com.github.jbangdev:jbang:somebranch",
-				JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch"));
+				ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch"));
 
 		assertEquals("com.github.jbangdev.jbang:artid:somebranch",
-				JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#artid"));
+				ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#artid"));
 
 		assertEquals("com.github.jbangdev:jbang:somebranch-SNAPSHOT",
-				JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#:SNAPSHOT"));
+				ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#:SNAPSHOT"));
 
 		assertEquals("com.github.jbangdev.jbang:artid:somebranch-SNAPSHOT",
-				JitPackUtil.ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#artid:SNAPSHOT"));
+				ensureGAV("https://github.com/jbangdev/jbang/tree/somebranch#artid:SNAPSHOT"));
 
 		assertEquals(
-				JitPackUtil.ensureGAV(
+				ensureGAV(
 						"https://github.com/jbangdev/jbang/commit/90dfcbf354fc0838f08eea0680bf736b7c069b4e#foo"),
 				"com.github.jbangdev.jbang:foo:90dfcbf354");
 
@@ -70,20 +95,20 @@ public class TestJitPack extends BaseTest {
 
 	@Test
 	void testExtractGitlabUrlDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab"),
 				"com.gitlab.gitlab-org:gitlab:-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master"),
 				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/v12.7.9-ee"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/v12.7.9-ee"),
 				"com.gitlab.gitlab-org:gitlab:v12.7.9-ee");
 
 		assertEquals(
-				JitPackUtil.ensureGAV(
+				ensureGAV(
 						"https://gitlab.com/gitlab-org/gitlab/-/commit/120262d85822e6a3d4e04f5c84d0075c60309d97"),
 				"com.gitlab.gitlab-org:gitlab:120262d858");
 
@@ -91,20 +116,20 @@ public class TestJitPack extends BaseTest {
 
 	@Test
 	void testExtractGitlabUrlWithHashDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab#foo"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab#foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master#foo"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master#foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo#bar"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo#bar"),
 				"com.gitlab.gitlab-org.gitlab:bar:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/somebranch#foo:SNAPSHOT"),
+		assertEquals(ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/somebranch#foo:SNAPSHOT"),
 				"com.gitlab.gitlab-org.gitlab:foo:somebranch-SNAPSHOT");
 
 		assertEquals(
-				JitPackUtil.ensureGAV(
+				ensureGAV(
 						"https://gitlab.com/gitlab-org/gitlab/-/commit/120262d85822e6a3d4e04f5c84d0075c60309d97#foo"),
 				"com.gitlab.gitlab-org.gitlab:foo:120262d858");
 
@@ -112,19 +137,19 @@ public class TestJitPack extends BaseTest {
 
 	@Test
 	void testExtractBitbucketUrlDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler"),
 				"org.bitbucket.ceylon:ceylon-compiler:-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/"),
 				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/0.4/"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/0.4/"),
 				"org.bitbucket.ceylon:ceylon-compiler:0.4");
 
-		assertEquals(JitPackUtil.ensureGAV(
+		assertEquals(ensureGAV(
 				"https://bitbucket.org/ceylon/ceylon-compiler/commits/9a5e4667af5ae03e036dff1294b81b653be6dffc"),
 				"org.bitbucket.ceylon:ceylon-compiler:9a5e4667af");
 
@@ -132,19 +157,19 @@ public class TestJitPack extends BaseTest {
 
 	@Test
 	void testExtractBitbucketUrlWithHashDependencies() {
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler#foo"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler#foo"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/#foo"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/#foo"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/#bar"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/#bar"),
 				"org.bitbucket.ceylon.ceylon-compiler:bar:master-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/somebranch/#foo:SNAPSHOT"),
+		assertEquals(ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/somebranch/#foo:SNAPSHOT"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:somebranch-SNAPSHOT");
 
-		assertEquals(JitPackUtil.ensureGAV(
+		assertEquals(ensureGAV(
 				"https://bitbucket.org/ceylon/ceylon-compiler/commits/9a5e4667af5ae03e036dff1294b81b653be6dffc#foo"),
 				"org.bitbucket.ceylon.ceylon-compiler:foo:9a5e4667af");
 


### PR DESCRIPTION
https://github.com/jbangdev/jbang/issues/1817 made me bite the bullet and have github urls default to use `main-SNAPSHOT` so it wont fail on new stuff. The whole reason I hesitated was that jitpack in past would accept HEAD-SNAPSHOT to pickup whatever is the default name on github (main or master). But that stop working some years ago - back then I hoped it was just a glitch..but since not fixed i'm now at least making it work for new things.

also updated the docs and added more tests as things were slightly incorrect.

Fixes #1817 
