### PR TITLE
fix: fix dependency resolution re depMgmt

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,8 @@ dependencies {
 	implementation "org.slf4j:jcl-over-slf4j:1.7.30"
 	implementation "org.jboss:jandex:2.2.3.Final"
 
-	implementation "eu.maveniverse.maven.mima:context:2.4.12"
-	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.12"
+	implementation "eu.maveniverse.maven.mima:context:2.4.20"
+	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.20"
 
 	testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
 	testImplementation "org.junit.jupiter:junit-jupiter:5.10.1"

--- a/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
+++ b/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
@@ -182,16 +182,18 @@ public class ArtifactResolver implements Closeable {
 															.collect(Collectors.groupingBy(Dependency::getScope));
 
 			List<Dependency> deps = scopeDeps.get(JavaScopes.COMPILE);
-			List<Dependency> managedDeps = null;
+			List<Dependency> managedDeps = deps	.stream()
+												.flatMap(d -> getManagedDependencies(d).stream())
+												.collect(Collectors.toList());
+
 			if (scopeDeps.containsKey("import")) {
 				// If there are any @pom artifacts we'll apply their
-				// managed dependencies to the given dependencies
+				// managed dependencies to the given dependencies BEFORE ordinary deps
 				List<Dependency> boms = scopeDeps.get("import");
 				List<Dependency> mdeps = boms	.stream()
 												.flatMap(d -> getManagedDependencies(d).stream())
 												.collect(Collectors.toList());
-				deps = deps.stream().map(d -> applyManagedDependencies(d, mdeps)).collect(Collectors.toList());
-				managedDeps = mdeps;
+				managedDeps.addAll(0, mdeps);
 			}
 
 			CollectRequest collectRequest = new CollectRequest()
@@ -301,21 +303,6 @@ public class ArtifactResolver implements Closeable {
 				return res;
 			}
 		};
-	}
-
-	private Dependency applyManagedDependencies(Dependency d, List<Dependency> managedDeps) {
-		Artifact art = d.getArtifact();
-		if (art.getVersion().isEmpty()) {
-			Optional<Artifact> ma = managedDeps	.stream()
-												.map(Dependency::getArtifact)
-												.filter(a -> a.getGroupId().equals(art.getGroupId())
-														&& a.getArtifactId().equals(art.getArtifactId()))
-												.findFirst();
-			if (ma.isPresent()) {
-				return new Dependency(ma.get(), d.getScope(), d.getOptional(), d.getExclusions());
-			}
-		}
-		return d;
 	}
 
 	private List<Dependency> getManagedDependencies(Dependency dependency) {


### PR DESCRIPTION
Issue is related how Maven3 works, as JBang creates "fake" root and adds direct dependencies to it. This in Maven3 implies that depMgmt entries of added dependencies are NOT applied.

Example: `jbang io.quarkus:quarkus-tls-registry:jar:3.15.1` will use Jackson 2.16... instead of wanted 2.17...

Fix: I missed that depMgmt of BOMs is already slurped up, so basically just do the same to **all deps**, while BOMs are added first (to prevail). ~~Also, no need to "apply" depMgt and any sort of magic, just let Resolver it's job.~~ There is need for magic, as unlike Maven, JBang allows use of GA and will deduce V from BOM.

Example now uses Jackson 2.17... as can be seen in gist w/ PR applied locally:
https://gist.github.com/cstamas/024db87af357b658492a9d9b60857bfa
