### PR TITLE
chore(deps): update Kotlin to 2.0.21

### DIFF
--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -14,7 +14,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "2.0.0";
+	public static final String DEFAULT_KOTLIN_VERSION = "2.0.21";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);


### PR DESCRIPTION
Upgrade Kotlin support from 2.0.0 to 2.0.21.  Fixes #1859 