### PR TITLE
fix: fixes issue with too long command lines on windows

### DIFF
--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -130,7 +130,11 @@ public abstract class CompileBuildStep implements Builder<Project> {
 	}
 
 	protected void runCompiler(List<String> optionList) throws IOException {
-		runCompiler(CommandBuffer.of(optionList).asProcessBuilder().inheritIO());
+		runCompiler(CommandBuffer	.of(optionList)
+									.applyWindowsMaxLengthLimit(CommandBuffer.MAX_LENGTH_WINPROCBUILDER,
+											Util.getShell())
+									.asProcessBuilder()
+									.inheritIO());
 	}
 
 	protected void runCompiler(ProcessBuilder processBuilder) throws IOException {

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -71,6 +71,7 @@ public class NativeBuildStep implements Builder<Project> {
 		Util.verboseMsg("native-image: " + String.join(" ", optionList));
 
 		ProcessBuilder pb = CommandBuffer	.of(optionList)
+											.applyWindowsMaxLengthLimit(32000, Util.getShell())
 											.asProcessBuilder()
 											.inheritIO();
 

--- a/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
@@ -16,9 +16,6 @@ public abstract class BaseCmdGenerator<T extends CmdGenerator> implements CmdGen
 
 	protected Util.Shell shell = Util.getShell();
 
-	// 8192 character command line length limit imposed by CMD.EXE
-	protected static final int COMMAND_LINE_LENGTH_LIMIT = 8000;
-
 	@SuppressWarnings("unchecked")
 	public T arguments(List<String> arguments) {
 		this.arguments = arguments != null ? arguments : Collections.emptyList();

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -184,21 +184,9 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 	}
 
 	protected String generateCommandLineString(List<String> fullArgs) throws IOException {
-		CommandBuffer cb = CommandBuffer.of(fullArgs);
-		String args = cb.asCommandLine(shell);
-		// Check if we can and need to use @-files on Windows
-		boolean useArgsFile = false;
-		if (args.length() > COMMAND_LINE_LENGTH_LIMIT && Util.getShell() != Util.Shell.bash) {
-			// @file is only available from java 9 onwards.
-			String requestedJavaVersion = ctx.getProject().getJavaVersion();
-			int actualVersion = JavaUtil.javaVersion(requestedJavaVersion);
-			useArgsFile = actualVersion >= 9;
-		}
-		if (useArgsFile) {
-			return cb.asJavaArgsFile(shell);
-		} else {
-			return args;
-		}
+		return CommandBuffer.of(fullArgs)
+							.applyWindowsMaxLengthLimit(CommandBuffer.MAX_LENGTH_WINCLI, shell)
+							.asCommandLine(shell);
 	}
 
 	private static void addPropertyFlags(Map<String, String> properties, String def, List<String> result) {


### PR DESCRIPTION
We were already doing this for the `java` command, but not for the `javac` and `native-image` commands becuase they were run using the `ProcessBuilder` API and it turns out it has a limit of 32K characters on Windows.

Fixes #1861
