### PR TITLE
docs: add prerequisite Java 11 version to build

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -10,6 +10,10 @@ If `just` fails with error about `fzf` missing you can use `just --list` to manu
 
 == How to build
 
+=== Prerequisite
+
+Java 11 must be installed for the build
+
 === Quickstart
 
 Clone the repository, cd `jbang` and run `./gradlew build`.


### PR DESCRIPTION
the build is not working with Java 17 and Java 21
Java 11 is used on CI


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
