### PR TITLE
docs: Fix whitespace in dependencies.adoc

### DIFF
--- a/docs/modules/ROOT/pages/dependencies.adoc
+++ b/docs/modules/ROOT/pages/dependencies.adoc
@@ -73,7 +73,7 @@ is the equivalent of the following Maven dependency declaration:
     <groupId>io.netty</groupId>
     <artifactId>netty-transport-native-kqueue</artifactId>
     <version>4.1.107.Final</version>
-	<classifier>osx-aarch_64</classifier>
+    <classifier>osx-aarch_64</classifier>
 </dependency>
 ```
 ====


### PR DESCRIPTION
Very small change to replace TAB with 4 spaces.