### PR TITLE
ensure -parameters is set for javac

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -173,3 +173,8 @@ jobs:
           echo "::add-matcher::.github/karatewindows-matcher.json" 
           .\itests.cmd
           echo "::remove-matcher owner=karate-windows::"
+      - name: Write out Unit Test report annotation for forked repo
+        if: ${{ failure() &&  (github.event.pull_request.head.repo.full_name != github.repository) }}
+        uses: mikepenz/action-junit-report@v5
+        with:
+          annotate_only: true # forked repo cannot write to checks so just do annotations

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -16,6 +16,27 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up GitHub CLI
+       uses: actions/setup-gh@v2
+
+      - name: Get workflow run details
+        id: workflow_details
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }} \
+            --jq '.head_branch' > branch.txt
+          BRANCH_NAME=$(cat branch.txt)
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_ENV
+
+      - name: Fetch PR number
+        id: fetch_pr
+        run: |
+          PR=$(gh pr list --head "${{ env.branch_name }}" --json number --jq '.[0].number')
+          echo "pr_number=${PR}" >> $GITHUB_ENV
+
+      - name: Output PR number
+        run: |
+          echo "The PR number is: ${{ env.pr_number }}"
+
       - name: Download Test Report
         uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2
         with:

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -471,7 +471,11 @@ public class ProjectBuilder {
 		prj.setMainClass(src.tagReader.getMain().orElse(null));
 		prj.setModuleName(src.tagReader.getModule().orElse(null));
 		if (prj.getMainSource() instanceof JavaSource) {
+			// todo: have way to turn these off? lets wait until someone asks and has a
+			// usecase
+			// where ability to debug and support named parameters is bad.
 			prj.getMainSourceSet().addCompileOption("-g");
+			prj.getMainSourceSet().addCompileOption("-parameters");
 		}
 		return updateProject(src, prj, resolver);
 	}

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -1,7 +1,15 @@
 package dev.jbang.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -122,7 +130,8 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getMainClass(), equalTo("mainclass"));
 		assertThat(prj.getModuleName().get(), equalTo("mymodule"));
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(4));
-		assertThat(prj.getMainSourceSet().getCompileOptions(), contains("-g", "--enable-preview", "--verbose"));
+		assertThat(prj.getMainSourceSet().getCompileOptions(),
+				contains("-g", "-parameters", "--enable-preview", "--verbose"));
 		assertThat(prj.isNativeImage(), is(Boolean.FALSE));
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(2));
 		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "-d"));
@@ -231,7 +240,7 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getModuleName().get(), equalTo("mymodule")); // This is not updated from Alias here!
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(5));
 		assertThat(prj.getMainSourceSet().getCompileOptions(),
-				contains("-g", "--enable-preview", "--verbose", "--ctwo"));
+				contains("-g", "-parameters", "--enable-preview", "--verbose", "--ctwo"));
 		assertThat(prj.isNativeImage(), is(Boolean.TRUE));
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(4));
 		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "-d", "-O1", "--ntwo"));

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -121,7 +121,7 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getJavaVersion(), equalTo("11+"));
 		assertThat(prj.getMainClass(), equalTo("mainclass"));
 		assertThat(prj.getModuleName().get(), equalTo("mymodule"));
-		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(3));
+		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(4));
 		assertThat(prj.getMainSourceSet().getCompileOptions(), contains("-g", "--enable-preview", "--verbose"));
 		assertThat(prj.isNativeImage(), is(Boolean.FALSE));
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(2));
@@ -229,7 +229,7 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getJavaVersion(), equalTo("twojava"));
 		assertThat(prj.getMainClass(), equalTo("mainclass")); // This is not updated from Alias here!
 		assertThat(prj.getModuleName().get(), equalTo("mymodule")); // This is not updated from Alias here!
-		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(4));
+		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(5));
 		assertThat(prj.getMainSourceSet().getCompileOptions(),
 				contains("-g", "--enable-preview", "--verbose", "--ctwo"));
 		assertThat(prj.isNativeImage(), is(Boolean.TRUE));


### PR DESCRIPTION
I've [had enough ](https://github.com/mariofusco/site-summarizer/pull/2) with java not by default adding `-parameters` 

since java 8 `-parameters` been supported and if you use any Quarkus, Spring, Micronaut or any other annotation driven framework or library you need `-parameters` to have functional code.

Only downside I can think of is that the bytecode gets slightly bigger and pre-Java 8 code that somehow assumes names starts with "argN" breaks - that is minuscule impact  IMO.

But it is what kept me from adding it until now.

Now I'm realizing that it actually is worse to NOT include it due to so many libraries requiring it and having to tell everyone to include `//JAVAC_OPTIONS -parameters` to fix possible obscure errors is not worth worth.

we do the same for `-g` (debug symbols) and thus I implemented it exactly the same here - if input is a javasource file enable it. kotlin et.al. not affected (kotlinc already defaults to this).

Also multiple -parameters is ignored by javac so users already having it are not affected.


