### PR TITLE
Update Kotlin to 2.1.0

### DIFF
--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -14,7 +14,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "2.0.21";
+	public static final String DEFAULT_KOTLIN_VERSION = "2.1.0";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);


### PR DESCRIPTION
Updated Kotlin to the latest stable version 2.1.0

https://kotlinlang.org/docs/releases.html#release-details
