### PR TITLE
Fixes for --preview option and using build.jbang

### DIFF
--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -2,6 +2,7 @@ package dev.jbang;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import dev.jbang.cli.JBang;
 
@@ -31,9 +32,11 @@ public class Main {
 		}
 		// Check if we have a parameter and it's not the same as any of the subcommand
 		// names
-		if (!remainingArgs.isEmpty() && !spec.subcommands().containsKey(remainingArgs.get(0))
-				|| hasRunOpts(leadingOpts)) {
+		if (!remainingArgs.isEmpty()
+				&& !spec.subcommands().containsKey(remainingArgs.get(0)) || hasRunOpts(leadingOpts)) {
+			List<String> jbangOpts = stripNonInheritedJBangOpts(leadingOpts);
 			List<String> result = new ArrayList<>();
+			result.addAll(jbangOpts);
 			result.add("run");
 			result.addAll(leadingOpts);
 			result.addAll(remainingArgs);
@@ -49,5 +52,13 @@ public class Main {
 							.anyMatch(o -> o.startsWith("-i=") || o.startsWith("--interactive=")
 									|| o.startsWith("-c=") || o.startsWith("--code=") || o.startsWith("--build-dir="));
 		return res;
+	}
+
+	private static List<String> stripNonInheritedJBangOpts(List<String> opts) {
+		List<String> jbangOpts = opts	.stream()
+										.filter(o -> "--preview".equals(o) || o.startsWith("--preview="))
+										.collect(Collectors.toList());
+		opts.removeAll(jbangOpts);
+		return jbangOpts;
 	}
 }

--- a/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
@@ -57,12 +57,23 @@ public class RenamingScriptResourceResolver implements ResourceResolver {
 						&& (!Util.isPreview() || !Project.BuildFile.fileNames().contains(probe.getName()))) {
 					if (probe.isDirectory()) {
 						File defaultApp = new File(probe, "main.java");
-						if (defaultApp.exists()) {
+						File buildFile = new File(probe, Project.BuildFile.jbang.fileName);
+						if (Util.isPreview() && buildFile.exists()) {
+							Util.verboseMsg("Directory where build.jbang exists. Running build.jbang.");
+							probe = buildFile;
+						} else if (defaultApp.exists()) {
 							Util.verboseMsg("Directory where main.java exists. Running main.java.");
 							probe = defaultApp;
 						} else {
-							throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Cannot run " + probe
-									+ " as it is a directory and no default application (i.e. `main.java`) found.");
+							String msg;
+							if (Util.isPreview()) {
+								msg = "Cannot run " + probe
+										+ " as it is a directory and no build file (i.e. `build.jbang`) or default application (i.e. `main.java`) was found.";
+							} else {
+								msg = "Cannot run " + probe
+										+ " as it is a directory and no default application (i.e. `main.java`) was found.";
+							}
+							throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, msg);
 						}
 					}
 					String original = Util.readString(probe.toPath());

--- a/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
@@ -60,7 +60,7 @@ public class RenamingScriptResourceResolver implements ResourceResolver {
 						File buildFile = new File(probe, Project.BuildFile.jbang.fileName);
 						if (Util.isPreview() && buildFile.exists()) {
 							Util.verboseMsg("Directory where build.jbang exists. Running build.jbang.");
-							probe = buildFile;
+							return ResourceRef.forFile(buildFile.toPath());
 						} else if (defaultApp.exists()) {
 							Util.verboseMsg("Directory where main.java exists. Running main.java.");
 							probe = defaultApp;


### PR DESCRIPTION
FIrst of all JBang will now correctly handle trying to run `jbang --preview somefile.java` and secondly the message when unsuccessfully trying to run a folder (eg `jbang --preview .`) will now mention `build.jbang` (before it would only mention `main.java`).
And finally running `jbang --preview .` will now actually work if the folder contains a `build.jbang` file.