### PR TITLE
feat: honor add-opens/exports from jar manifest

### DIFF
--- a/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
+++ b/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
@@ -100,6 +100,7 @@ public class CmdGeneratorBuilder {
 			Alias alias = ((AliasResourceResolver.AliasedResourceRef) project.getResourceRef()).getAlias();
 			updateFromAlias(alias);
 		}
+
 		CmdGenerator gen;
 		if (project.isJShell() || interactive == Boolean.TRUE) {
 			gen = createJshCmdGenerator();

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -82,6 +82,22 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 		JdkProvider.Jdk jdk = JdkManager.getOrInstallJdk(requestedJavaVersion);
 		String javacmd = JavaUtil.resolveInJavaHome("java", requestedJavaVersion);
 
+		if (jdk.getMajorVersion() > 9) {
+			String opens = ctx.getProject().getManifestAttributes().get("Add-Opens");
+			if (opens != null) {
+				for (String val : opens.split(" ")) {
+					optionalArgs.add("--add-opens=" + val + "=ALL-UNNAMED");
+				}
+			}
+
+			String exports = ctx.getProject().getManifestAttributes().get("Add-Exports");
+			if (exports != null) {
+				for (String val : exports.split(" ")) {
+					optionalArgs.add("--add-exports=" + val + "=ALL-UNNAMED");
+				}
+			}
+		}
+
 		addPropertyFlags(project.getProperties(), "-D", optionalArgs);
 
 		if (debugString != null) {


### PR DESCRIPTION
fixes #1852

make it now trivial to run things like: `fish.payara.extras:payara-micro:LATEST` and `com.google.googlejavaformat:google-java-format:RELEASE`

opening in draft as I haven't figured a reliable way to avoid the add opens to be skipped when running on older than java 9.