### PR TITLE
Add `jbang jdk list --available` in javaversions.adoc

### DIFF
--- a/docs/modules/ROOT/pages/javaversions.adoc
+++ b/docs/modules/ROOT/pages/javaversions.adoc
@@ -46,6 +46,9 @@ It's easy to `install` additional JDKs by running:
 
 which will download and install JDK version 14 into JBang's cache (`~/.jbang/cache/jdks` by default).
 The list of versions that are available for installation can be found here: https://adoptopenjdk.net/releases.html
+or by running:
+
+  jbang jdk list --available
 
 The first JDK that gets installed by JBang will be set as the "default" JDK. This is from then on the JDK that will be
 used by JBang if no Java could be found on the system (meaning `javac` wasn't found on the `PATH` and no `JAVA_HOME` is set).


### PR DESCRIPTION
I propose to add this command to the documentation so that the user can check the available versions without leaving this terminal.
