### PR TITLE
fix: Append alias arguments from jbang-catalog.json to the end of the command (#1910)

### DIFF
--- a/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
+++ b/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
@@ -148,8 +148,9 @@ public class CmdGeneratorBuilder {
 		if (arguments.isEmpty()) {
 			setArguments(handleRemoteFiles(alias.arguments));
 		} else if (alias.arguments != null && !alias.arguments.isEmpty()) {
-			List<String> args = new ArrayList<>(handleRemoteFiles(alias.arguments));
+			List<String> args = new ArrayList<>();
 			args.addAll(arguments);
+			args.addAll(handleRemoteFiles(alias.arguments));
 			setArguments(args);
 		}
 		if (runtimeOptions.isEmpty()) {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -2577,7 +2577,7 @@ public class TestRun extends BaseTest {
 
 		String cmdline = run.updateGeneratorForRun(genb).build().generate();
 
-		assertThat(cmdline, endsWith("echo foo bar baz"));
+		assertThat(cmdline, endsWith("echo baz foo bar"));
 	}
 
 	@Test


### PR DESCRIPTION
Append alias arguments from jbang-catalog.json to the end of the command (#1910)