### PR TITLE
chore: fix justfile for windows

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,4 +1,4 @@
-open := if os() == "macos" { "open" } else { "xdg-open" }
+open := if os() == "macos" { "open" } else if os() == "windows" { "start" } else { "xdg-open" }
 
 #@default:
 #    just --choose
@@ -12,7 +12,7 @@ test:
     ./gradlew test
 
 preitest := if path_exists('build/install/jbang/bin') != 'true' {
-  './gradlew installDist -x test'
+    './gradlew spotlessApply installDist -x test'
 } else {
     ''
 }


### PR DESCRIPTION
The actions for opening a web browser with the results from the tests didn't work on Windows. Now it does.