### PR TITLE
feat: export maven/gradle project

### DIFF
--- a/docs/modules/ROOT/pages/exporting.adoc
+++ b/docs/modules/ROOT/pages/exporting.adoc
@@ -19,6 +19,8 @@ Note, the local generated jar will have classpath references that are machine de
 jar use `jbang export portable <script>` and the dependent jars will be put in `lib` directory and
 generated jar will have relative references to the jars in the `lib` folder.
 
+You can also use `jbang export gradle|maven <script>` to export the set of the script, its additional sources and resources, along with their dependencies, to a Gradle or Maven project, allowing you to proceed with full-scale development in your favorite IDE.
+
 == Exporting to Maven Repository
 
 If your application or script need to be used from another java project it can be beneficial to publish your jar into a maven repository.
@@ -45,3 +47,110 @@ You should only need to change `hello.java` to match your application/script.
 
 You can read more about how jitpack handle builds at https://jitpack.io/docs/BUILDING/.
 
+== Exporting as a project
+
+If you want to transition your developed script to a full-scale Java project, you can use `jbang export gradle|maven <script>` to export it as a Gradle or Maven project. If you have specified multiple sources or resources using `//SOURCES` or `//FILES` in the script, they will also be exported. Tags such as `//JAVA`, `//DEPS`, `//REPOS`, `//GAV`, and `//DESCRIPTION` will also be reflected in the exported `build.gradle` or `pom.xml`.
+
+Unless explicitly specified via command options or tags, the GAV of the exported project defaults to `org.example:<script name>:999-SNAPSHOT`.
+
+Let's say you want to export the following `hello.java` to a project:
+
+[source,java]
+----
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//SOURCES model/Message.java
+//FILES application.properties
+//DEPS org.slf4j:slf4j-simple:2.0.17
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import model.Message;
+
+public class hello {
+    private static final Logger log = LoggerFactory.getLogger(hello.class);
+
+    public static void main(String... args) {
+        log.info("{}", new Message());
+    }
+}
+----
+
+=== To a Gradle project
+
+You can export the script to a Gradle project with the GAV `dev.jbang:myapp:1.0.0-SNAPSHOT` as follows:
+
+[source,bash]
+----
+jbang export gradle --group dev.jbang --artifact myapp --version 1.0.0-SNAPSHOT hello.java
+----
+
+The generated project would look like this:
+
+[source]
+----
+hello
+├── build.gradle
+└── src
+    └── main
+        ├── java
+        │   ├── dev
+        │   │   └── jbang
+        │   │       └── myapp
+        │   │           └── hello.java
+        │   └── model
+        │       └── Message.java
+        └── resources
+            └── application.properties
+----
+
+The `build.gradle` file would include the following dependencies:
+
+[source,gradle]
+----
+dependencies {
+    implementation 'org.slf4j:slf4j-simple:2.0.17'
+}
+----
+
+=== To a Maven project
+
+You can export the script to a Maven project with the GAV `dev.jbang:myapp:1.0.0-SNAPSHOT` as follows:
+
+[source,bash]
+----
+jbang export maven --group dev.jbang --artifact myapp --version 1.0.0-SNAPSHOT hello.java
+----
+
+The generated project would look like this:
+
+[source]
+----
+hello
+├── pom.xml
+└── src
+    └── main
+        ├── java
+        │   ├── dev
+        │   │   └── jbang
+        │   │       └── myapp
+        │   │           └── hello.java
+        │   └── model
+        │       └── Message.java
+        └── resources
+            └── application.properties
+----
+
+The `pom.xml` file would include the following dependencies:
+
+[source,gradle]
+----
+<dependencies>
+    <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>2.0.17</version>
+        <scope>compile</scope>
+    </dependency>
+</dependencies>
+----

--- a/docs/modules/ROOT/pages/exporting.adoc
+++ b/docs/modules/ROOT/pages/exporting.adoc
@@ -78,11 +78,11 @@ public class hello {
 
 === To a Gradle project
 
-You can export the script to a Gradle project with the GAV `dev.jbang:myapp:1.0.0-SNAPSHOT` as follows:
+You can export the script to a Gradle project with the GAV `org.acme:myapp:1.0.0-SNAPSHOT` as follows:
 
 [source,bash]
 ----
-jbang export gradle --group dev.jbang --artifact myapp --version 1.0.0-SNAPSHOT hello.java
+jbang export gradle --group org.acme --artifact myapp --version 1.0.0-SNAPSHOT hello.java
 ----
 
 The generated project would look like this:
@@ -94,12 +94,12 @@ hello
 └── src
     └── main
         ├── java
-        │   ├── dev
-        │   │   └── jbang
-        │   │       └── myapp
-        │   │           └── hello.java
-        │   └── model
-        │       └── Message.java
+        │   ├── model
+        │   │   └── Message.java
+        │   └── org
+        │       └── acme
+        │           └── myapp
+        │               └── hello.java
         └── resources
             └── application.properties
 ----
@@ -115,11 +115,11 @@ dependencies {
 
 === To a Maven project
 
-You can export the script to a Maven project with the GAV `dev.jbang:myapp:1.0.0-SNAPSHOT` as follows:
+You can export the script to a Maven project with the GAV `org.acme:myapp:1.0.0-SNAPSHOT` as follows:
 
 [source,bash]
 ----
-jbang export maven --group dev.jbang --artifact myapp --version 1.0.0-SNAPSHOT hello.java
+jbang export maven --group org.acme --artifact myapp --version 1.0.0-SNAPSHOT hello.java
 ----
 
 The generated project would look like this:
@@ -131,12 +131,12 @@ hello
 └── src
     └── main
         ├── java
-        │   ├── dev
-        │   │   └── jbang
-        │   │       └── myapp
-        │   │           └── hello.java
-        │   └── model
-        │       └── Message.java
+        │   ├── model
+        │   │   └── Message.java
+        │   └── org
+        │       └── acme
+        │           └── myapp
+        │               └── hello.java
         └── resources
             └── application.properties
 ----

--- a/itests/classpath_log_bom.java
+++ b/itests/classpath_log_bom.java
@@ -1,0 +1,24 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DEPS org.apache.logging.log4j:log4j-bom:2.24.3@pom
+//DEPS org.apache.logging.log4j:log4j-api
+//DEPS org.apache.logging.log4j:log4j-core
+
+import static java.lang.System.out;
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
+
+class classpath_example {
+
+	static final Logger logger = LogManager.getLogger(classpath_example.class);
+
+	public static void main(String[] args) {
+		Configurator.initialize(new DefaultConfiguration());
+		Arrays.asList(args).forEach(arg -> out.println(arg));
+	}
+}

--- a/itests/exporttags.java
+++ b/itests/exporttags.java
@@ -1,0 +1,19 @@
+
+//REPOS central,jitpack
+//DEPS log4j:log4j:1.2.17
+
+//SOURCES Two.java
+//SOURCES nested/*.java
+//SOURCES othernested/*.java
+
+//FILES res/resource.properties renamed.properties=res/resource.properties
+//FILES META-INF/application.properties=res/resource.properties
+
+//JAVA 21+
+//DESCRIPTION some description
+//GAV org.example:exporttags:1.2.3
+
+public class exporttags {
+    public static void main(String... args) {
+    }
+}

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -33,7 +33,8 @@ import io.quarkus.qute.Template;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
-@Command(name = "export", description = "Export the result of a build.", subcommands = { ExportPortable.class,
+@Command(name = "export", description = "Export the result of a build or the set of the sources to a project.", subcommands = {
+		ExportPortable.class,
 		ExportLocal.class, ExportMavenPublish.class, ExportNative.class, ExportFatjar.class, ExportJlink.class,
 		ExportGradleProject.class, ExportMavenProject.class })
 public class Export {

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -557,11 +557,10 @@ abstract class BaseExportProject extends BaseExportCommand {
 
 	private void createProjectForExport(BuildContext ctx, Path projectDir) throws IOException {
 		Project prj = ctx.getProject();
-		String projectName = projectDir.getFileName().toString();
-		Path tmpProjectDir = Files.createTempDirectory(projectName);
+		Util.mkdirs(projectDir);
 
 		// Sources
-		Path srcJavaDir = tmpProjectDir.resolve("src/main/java");
+		Path srcJavaDir = projectDir.resolve("src/main/java");
 		String srcPackageName = group + "." + artifact;
 		Path srcPackageDir = srcJavaDir.resolve(srcPackageName.replace(".", "/"));
 		Util.mkdirs(srcPackageDir);
@@ -577,7 +576,7 @@ abstract class BaseExportProject extends BaseExportCommand {
 		}
 
 		// Resources
-		Path srcResourcesDir = tmpProjectDir.resolve("src/main/resources");
+		Path srcResourcesDir = projectDir.resolve("src/main/resources");
 		for (RefTarget ref : prj.getMainSourceSet().getResources()) {
 			Path destFile = ref.to(srcResourcesDir);
 			Util.mkdirs(destFile.getParent());
@@ -585,9 +584,7 @@ abstract class BaseExportProject extends BaseExportCommand {
 		}
 
 		// Build file
-		renderBuildFile(ctx, tmpProjectDir, fullClassName);
-
-		Files.move(tmpProjectDir, projectDir);
+		renderBuildFile(ctx, projectDir, fullClassName);
 	}
 
 	private Path copySource(ResourceRef sourceRef, Path srcJavaDir, Path srcPackageDir, String srcPackageName)

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -522,7 +522,6 @@ abstract class BaseExportProject extends BaseExportCommand {
 				return EXIT_INVALID_INPUT;
 			}
 		}
-		info("Exporting as " + getType() + " project to: " + projectDir);
 
 		Project prj = ctx.getProject();
 		if (prj.isJar() || prj.getMainSourceSet().getSources().isEmpty()) {
@@ -552,6 +551,7 @@ abstract class BaseExportProject extends BaseExportCommand {
 
 		createProjectForExport(ctx, projectDir);
 
+		info("Exported as " + getType() + " project to " + projectDir);
 		return EXIT_OK;
 	}
 
@@ -655,7 +655,9 @@ class ExportGradleProject extends BaseExportProject {
 								.data("description", prj.getDescription().orElse(""))
 								.data("repositories", repositories	.stream()
 																	.map(MavenRepo::getUrl)
-																	.filter(s -> !"".equals(s)))
+																	.filter(s -> !"".equals(s))
+																	.collect(Collectors.toList()))
+								.data("javaVersion", prj.getJavaVersion())
 								.data("gradledependencies", gradleify(depIds))
 								.data("fullClassName", fullClassName)
 								.render();
@@ -718,9 +720,15 @@ class ExportMavenProject extends BaseExportProject {
 								.data("version", version)
 								.data("description", prj.getDescription().orElse(""))
 								.data("properties", properties)
-								.data("repositories", repositories.stream().filter(r -> !r.getUrl().isEmpty()))
-								.data("boms", boms.stream().map(MavenCoordinate::fromString))
-								.data("dependencies", depIds.stream().map(MavenCoordinate::fromString))
+								.data("repositories", repositories	.stream()
+																	.filter(r -> !r.getUrl().isEmpty())
+																	.collect(Collectors.toList()))
+								.data("boms", boms	.stream()
+													.map(MavenCoordinate::fromString)
+													.collect(Collectors.toList()))
+								.data("dependencies", depIds.stream()
+															.map(MavenCoordinate::fromString)
+															.collect(Collectors.toList()))
 								.data("fullClassName", fullClassName)
 								.render();
 		Util.writeString(destination, result);

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -619,7 +619,10 @@ abstract class BaseExportProject extends BaseExportCommand {
 	abstract void renderBuildFile(BuildContext ctx, Path projectDir, String fullClassName) throws IOException;
 
 	String getJavaVersion(Project prj, boolean minorVersionFor8) {
-		int javaVersion = JavaUtil.javaVersion(prj.getJavaVersion());
+		if (prj.getJavaVersion() == null) {
+			return null;
+		}
+		int javaVersion = JavaUtil.minRequestedVersion(prj.getJavaVersion());
 		if (!minorVersionFor8) {
 			return Integer.toString(javaVersion);
 		}
@@ -700,8 +703,10 @@ class ExportMavenProject extends BaseExportProject {
 
 		Map<String, String> properties = new HashMap<>();
 		String javaVersion = getJavaVersion(prj, true);
-		properties.put("maven.compiler.source", javaVersion);
-		properties.put("maven.compiler.target", javaVersion);
+		if (javaVersion != null) {
+			properties.put("maven.compiler.source", javaVersion);
+			properties.put("maven.compiler.target", javaVersion);
+		}
 
 		List<MavenRepo> repositories = prj.getRepositories();
 		List<String> dependencies = prj.getMainSourceSet().getDependencies();

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -8,8 +8,8 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
@@ -19,13 +19,8 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.CatalogUtil;
-import dev.jbang.dependencies.ArtifactInfo;
-import dev.jbang.dependencies.ArtifactResolver;
-import dev.jbang.dependencies.MavenCoordinate;
-import dev.jbang.source.BuildContext;
-import dev.jbang.source.Project;
-import dev.jbang.source.ProjectBuilder;
-import dev.jbang.source.ResourceRef;
+import dev.jbang.dependencies.*;
+import dev.jbang.source.*;
 import dev.jbang.source.resolvers.AliasResourceResolver;
 import dev.jbang.util.JarUtil;
 import dev.jbang.util.JavaUtil;
@@ -39,7 +34,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(name = "export", description = "Export the result of a build.", subcommands = { ExportPortable.class,
-		ExportLocal.class, ExportMavenPublish.class, ExportNative.class, ExportFatjar.class, ExportJlink.class })
+		ExportLocal.class, ExportMavenPublish.class, ExportNative.class, ExportFatjar.class, ExportJlink.class,
+		ExportGradleProject.class, ExportMavenProject.class })
 public class Export {
 }
 
@@ -500,5 +496,233 @@ class ExportJlink extends BaseExportCommand {
 	private Path getJlinkOutputPath() {
 		Path outputPath = exportMixin.getOutputPath("-jlink");
 		return outputPath;
+	}
+}
+
+abstract class BaseExportProject extends BaseExportCommand {
+
+	@CommandLine.Option(names = { "--group", "-g" }, description = "The group ID to use for the exported project.")
+	String group;
+
+	@CommandLine.Option(names = { "--artifact",
+			"-a" }, description = "The artifact ID to use for the exported project.")
+	String artifact;
+
+	@CommandLine.Option(names = { "--version", "-v" }, description = "The version to use for the exported project.")
+	String version;
+
+	@Override
+	int apply(BuildContext ctx) throws IOException {
+		Path projectDir = exportMixin.getOutputPath("");
+		if (projectDir.toFile().exists()) {
+			if (exportMixin.force) {
+				Util.deletePath(projectDir, false);
+			} else {
+				Util.errorMsg("Cannot export as " + projectDir + " already exists. Use --force to overwrite.");
+				return EXIT_INVALID_INPUT;
+			}
+		}
+		info("Exporting as " + getType() + " project to: " + projectDir);
+
+		Project prj = ctx.getProject();
+		if (prj.isJar() || prj.getMainSourceSet().getSources().isEmpty()) {
+			Util.errorMsg("You can only export source files");
+			return EXIT_INVALID_INPUT;
+		}
+
+		if (prj.getGav().isPresent()) {
+			MavenCoordinate coord = MavenCoordinate.fromString(prj.getGav().get()).withVersion();
+			if (group == null) {
+				group = coord.getGroupId();
+			}
+			if (artifact == null) {
+				artifact = coord.getArtifactId();
+			}
+			if (version == null) {
+				version = coord.getVersion();
+			}
+		}
+
+		if (group == null) {
+			group = "org.example.project";
+		}
+		artifact = artifact != null ? artifact
+				: Util.getBaseName(Objects.requireNonNull(prj.getResourceRef().getFile()).getFileName().toString());
+		version = version != null ? version : MavenCoordinate.DEFAULT_VERSION;
+
+		createProjectForExport(ctx, projectDir);
+
+		return EXIT_OK;
+	}
+
+	private void createProjectForExport(BuildContext ctx, Path projectDir) throws IOException {
+		Project prj = ctx.getProject();
+		String projectName = projectDir.getFileName().toString();
+		Path tmpProjectDir = Files.createTempDirectory(projectName);
+
+		// Sources
+		Path srcJavaDir = tmpProjectDir.resolve("src/main/java");
+		String srcPackageName = group + "." + artifact;
+		Path srcPackageDir = srcJavaDir.resolve(srcPackageName.replace(".", "/"));
+		Util.mkdirs(srcPackageDir);
+
+		String fullClassName = "";
+		for (ResourceRef sourceRef : prj.getMainSourceSet().getSources()) {
+			Path destFile = copySource(sourceRef, srcJavaDir, srcPackageDir, srcPackageName);
+			if (sourceRef.equals(prj.getResourceRef())) {
+				String mainFileName = Util.unkebabify(destFile.getFileName().toString());
+				Optional<String> mainPackageName = Util.getSourcePackage(Util.readString(destFile));
+				fullClassName = mainPackageName.map(s -> s + ".").orElse("") + Util.getBaseName(mainFileName);
+			}
+		}
+
+		// Resources
+		Path srcResourcesDir = tmpProjectDir.resolve("src/main/resources");
+		for (RefTarget ref : prj.getMainSourceSet().getResources()) {
+			Path destFile = ref.to(srcResourcesDir);
+			Util.mkdirs(destFile.getParent());
+			Files.copy(Objects.requireNonNull(ref.getSource().getFile()).toAbsolutePath(), destFile);
+		}
+
+		// Build file
+		renderBuildFile(ctx, tmpProjectDir, fullClassName);
+
+		Files.move(tmpProjectDir, projectDir);
+	}
+
+	private Path copySource(ResourceRef sourceRef, Path srcJavaDir, Path srcPackageDir, String srcPackageName)
+			throws IOException {
+		Path srcFile = Objects.requireNonNull(sourceRef.getFile());
+		Source src = Source.forResourceRef(sourceRef, Function.identity());
+		String fileName = Util.unkebabify(srcFile.getFileName().toString());
+		Path destFile;
+		if (src.getJavaPackage().isPresent()) {
+			Path packageDir = srcJavaDir.resolve(src.getJavaPackage().get().replace(".", File.separator));
+			Util.mkdirs(packageDir);
+			destFile = packageDir.resolve(fileName);
+			Files.copy(srcFile, destFile);
+		} else {
+			destFile = srcPackageDir.resolve(fileName);
+			Files.copy(srcFile, destFile);
+			prependPackage(destFile, srcPackageName);
+		}
+		return destFile;
+	}
+
+	private void prependPackage(Path source, String packageName) throws IOException {
+		String content = "package " + packageName + ";" + System.lineSeparator()
+				+ System.lineSeparator()
+				+ Util.readString(source);
+		Util.writeString(source, content);
+	}
+
+	abstract String getType();
+
+	abstract void renderBuildFile(BuildContext ctx, Path projectDir, String fullClassName) throws IOException;
+}
+
+@Command(name = "gradle", description = "Exports a Gradle project")
+class ExportGradleProject extends BaseExportProject {
+
+	@Override
+	String getType() {
+		return "gradle";
+	}
+
+	@Override
+	void renderBuildFile(BuildContext ctx, Path projectDir, String fullClassName) throws IOException {
+		Project prj = ctx.getProject();
+		ResourceRef templateRef = ResourceRef.forResource("classpath:/export-build.qute.gradle");
+		Path destination = projectDir.resolve("build.gradle");
+
+		List<MavenRepo> repositories = prj.getRepositories();
+		List<String> dependencies = prj.getMainSourceSet().getDependencies();
+		// Turn any URL dependencies into regular GAV coordinates
+		List<String> depIds = dependencies	.stream()
+											.map(JitPackUtil::ensureGAV)
+											.collect(Collectors.toList());
+		// And if we encountered URLs let's make sure the JitPack repo is available
+		if (!depIds.equals(dependencies)
+				&& repositories.stream().noneMatch(r -> DependencyUtil.REPO_JITPACK.equals(r.getUrl()))) {
+			prj.addRepository(DependencyUtil.toMavenRepo(DependencyUtil.ALIAS_JITPACK));
+		}
+
+		TemplateEngine engine = TemplateEngine.instance();
+		Template template = engine.getTemplate(templateRef);
+		if (template == null)
+			throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
+		String result = template
+								.data("group", group)
+								.data("artifact", artifact)
+								.data("version", version)
+								.data("description", prj.getDescription().orElse(""))
+								.data("repositories", repositories	.stream()
+																	.map(MavenRepo::getUrl)
+																	.filter(s -> !"".equals(s)))
+								.data("gradledependencies", gradleify(depIds))
+								.data("fullClassName", fullClassName)
+								.render();
+		Util.writeString(destination, result);
+	}
+
+	private List<String> gradleify(List<String> collectDependencies) {
+		return collectDependencies.stream().map(item -> {
+			if (item.endsWith("@pom")) {
+				return "implementation platform ('" + item.substring(0, item.lastIndexOf("@pom")) + "')";
+			} else {
+				return "implementation '" + item + "'";
+			}
+		}).collect(Collectors.toList());
+	}
+}
+
+@Command(name = "maven", description = "Exports a Maven project")
+class ExportMavenProject extends BaseExportProject {
+
+	@Override
+	String getType() {
+		return "maven";
+	}
+
+	@Override
+	void renderBuildFile(BuildContext ctx, Path projectDir, String fullClassName) throws IOException {
+		Project prj = ctx.getProject();
+		ResourceRef templateRef = ResourceRef.forResource("classpath:/export-pom.qute.xml");
+		Path destination = projectDir.resolve("pom.xml");
+
+		Map<String, String> properties = new HashMap<>();
+		if (prj.getJavaVersion() != null) {
+			properties.put("maven.compiler.source", prj.getJavaVersion());
+			properties.put("maven.compiler.target", prj.getJavaVersion());
+		}
+
+		List<MavenRepo> repositories = prj.getRepositories();
+		List<String> dependencies = prj.getMainSourceSet().getDependencies();
+		// Turn any URL dependencies into regular GAV coordinates
+		List<String> depIds = dependencies	.stream()
+											.map(JitPackUtil::ensureGAV)
+											.collect(Collectors.toList());
+		// And if we encountered URLs let's make sure the JitPack repo is available
+		if (!depIds.equals(dependencies)
+				&& repositories.stream().noneMatch(r -> DependencyUtil.REPO_JITPACK.equals(r.getUrl()))) {
+			prj.addRepository(DependencyUtil.toMavenRepo(DependencyUtil.ALIAS_JITPACK));
+		}
+
+		TemplateEngine engine = TemplateEngine.instance();
+		Template template = engine.getTemplate(templateRef);
+		if (template == null)
+			throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
+		String result = template
+								.data("group", group)
+								.data("artifact", artifact)
+								.data("version", version)
+								.data("description", prj.getDescription().orElse(""))
+								.data("properties", properties)
+								.data("repositories", repositories.stream().filter(r -> !r.getUrl().isEmpty()))
+								.data("dependencies", depIds.stream().map(MavenCoordinate::fromString))
+								.data("fullClassName", fullClassName)
+								.render();
+		Util.writeString(destination, result);
+
 	}
 }

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -708,6 +708,9 @@ class ExportMavenProject extends BaseExportProject {
 			prj.addRepository(DependencyUtil.toMavenRepo(DependencyUtil.ALIAS_JITPACK));
 		}
 
+		List<String> boms = depIds.stream().filter(d -> d.endsWith("@pom")).collect(Collectors.toList());
+		depIds = depIds.stream().filter(d -> !d.endsWith("@pom")).collect(Collectors.toList());
+
 		TemplateEngine engine = TemplateEngine.instance();
 		Template template = engine.getTemplate(templateRef);
 		if (template == null)
@@ -719,10 +722,10 @@ class ExportMavenProject extends BaseExportProject {
 								.data("description", prj.getDescription().orElse(""))
 								.data("properties", properties)
 								.data("repositories", repositories.stream().filter(r -> !r.getUrl().isEmpty()))
+								.data("boms", boms.stream().map(MavenCoordinate::fromString))
 								.data("dependencies", depIds.stream().map(MavenCoordinate::fromString))
 								.data("fullClassName", fullClassName)
 								.render();
 		Util.writeString(destination, result);
-
 	}
 }

--- a/src/main/resources/export-build.qute.gradle
+++ b/src/main/resources/export-build.qute.gradle
@@ -7,10 +7,18 @@ repositories {
 	mavenCentral()
 {#for url in repositories}
 	maven {
-		url  "{url}"
+		url "{url}"
 	}
 {/for}
 }
+
+{#if javaVersion}
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of({javaVersion})
+	}
+}
+{/if}
 
 dependencies {
 {#for item in gradledependencies}

--- a/src/main/resources/export-build.qute.gradle
+++ b/src/main/resources/export-build.qute.gradle
@@ -1,0 +1,23 @@
+plugins {
+	id 'java'
+	id 'application'
+}
+
+repositories {
+	mavenCentral()
+{#for url in repositories}
+	maven {
+		url  "{url}"
+	}
+{/for}
+}
+
+dependencies {
+{#for item in gradledependencies}
+	{item}
+{/for}
+}
+
+application {
+	mainClass = '{fullClassName}'
+}

--- a/src/main/resources/export-build.qute.gradle
+++ b/src/main/resources/export-build.qute.gradle
@@ -3,6 +3,10 @@ plugins {
 	id 'application'
 }
 
+{#if description}
+description = '{description}'
+{/if}
+
 repositories {
 	mavenCentral()
 {#for url in repositories}

--- a/src/main/resources/export-pom.qute.xml
+++ b/src/main/resources/export-pom.qute.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+		 xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>{group}</groupId>
+	<artifactId>{artifact}</artifactId>
+	<version>{version}</version>
+	<description>{description}</description>
+	{#if !properties.empty}
+	<properties>
+		{#for item in properties.entrySet}
+		<{item.key}>{item.value}</{item.key}>
+		{/for}
+	</properties>
+	{/if}
+	<dependencies>
+		{#for item in dependencies}
+		<dependency>
+			<groupId>{item.groupId}</groupId>
+			<artifactId>{item.artifactId}</artifactId>
+			<version>{item.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		{/for}
+	</dependencies>
+	{#if !repositories.empty}
+	<repositories>
+		{#for item in repositories}
+		<repository>
+			<id>{item.id}</id>
+			<url>{item.url}</url>
+		</repository>
+		{/for}
+	</repositories>
+	{/if}
+</project>

--- a/src/main/resources/export-pom.qute.xml
+++ b/src/main/resources/export-pom.qute.xml
@@ -7,24 +7,41 @@
 	<artifactId>{artifact}</artifactId>
 	<version>{version}</version>
 	<description>{description}</description>
-	{#if !properties.empty}
+	{#if properties}
 	<properties>
 		{#for item in properties.entrySet}
 		<{item.key}>{item.value}</{item.key}>
 		{/for}
 	</properties>
 	{/if}
+	{#if boms}
+	<dependencyManagement>
+		<dependencies>
+			{#for item in boms}
+			<dependency>
+				<groupId>{item.groupId}</groupId>
+				<artifactId>{item.artifactId}</artifactId>
+				<version>{item.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			{/for}
+		</dependencies>
+	</dependencyManagement>
+	{/if}
 	<dependencies>
 		{#for item in dependencies}
 		<dependency>
 			<groupId>{item.groupId}</groupId>
 			<artifactId>{item.artifactId}</artifactId>
+			{#if item.version}
 			<version>{item.version}</version>
+			{/if}
 			<scope>compile</scope>
 		</dependency>
 		{/for}
 	</dependencies>
-	{#if !repositories.empty}
+	{#if repositories}
 	<repositories>
 		{#for item in repositories}
 		<repository>

--- a/src/main/resources/export-pom.qute.xml
+++ b/src/main/resources/export-pom.qute.xml
@@ -7,14 +7,14 @@
 	<artifactId>{artifact}</artifactId>
 	<version>{version}</version>
 	<description>{description}</description>
-	{#if properties}
+	{#if !properties.empty}
 	<properties>
 		{#for item in properties.entrySet}
 		<{item.key}>{item.value}</{item.key}>
 		{/for}
 	</properties>
 	{/if}
-	{#if boms}
+	{#if !boms.empty}
 	<dependencyManagement>
 		<dependencies>
 			{#for item in boms}
@@ -41,7 +41,7 @@
 		</dependency>
 		{/for}
 	</dependencies>
-	{#if repositories}
+	{#if !repositories.empty}
 	<repositories>
 		{#for item in repositories}
 		<repository>

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -210,7 +210,7 @@ public class TestExport extends BaseTest {
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
 		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, containsString("languageVersion = JavaLanguageVersion.of"));
+		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
 		assertThat(build, containsString("mainClass = 'org.example.project.classpath_log.classpath_log'"));
 	}
 
@@ -231,7 +231,7 @@ public class TestExport extends BaseTest {
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
 		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, containsString("languageVersion = JavaLanguageVersion.of"));
+		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
 		assertThat(build, containsString("mainClass = 'dev.jbang.test.app.classpath_log'"));
 	}
 
@@ -254,7 +254,7 @@ public class TestExport extends BaseTest {
 		assertThat(build, containsString("implementation platform ('org.apache.logging.log4j:log4j-bom:2.24.3')"));
 		assertThat(build, containsString("implementation 'org.apache.logging.log4j:log4j-api'"));
 		assertThat(build, containsString("implementation 'org.apache.logging.log4j:log4j-core'"));
-		assertThat(build, containsString("languageVersion = JavaLanguageVersion.of"));
+		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
 		assertThat(build, containsString("mainClass = 'org.example.project.classpath_log_bom.classpath_log_bom'"));
 	}
 
@@ -327,13 +327,11 @@ public class TestExport extends BaseTest {
 				"<groupId>org.example.project</groupId>",
 				"<artifactId>classpath_log</artifactId>",
 				"<version>999-SNAPSHOT</version>",
-				"<properties>",
-				"<maven.compiler.source>",
 				"<dependencies>",
 				"<groupId>log4j</groupId>",
 				"<artifactId>log4j</artifactId>",
 				"<version>1.2.17</version>"));
-		assertThat(pom, containsString("<maven.compiler.target>")); // Properties key may be in any order
+		assertThat(pom, not(containsString("<properties>")));
 		assertThat(pom, not(containsString("<dependencyManagement>")));
 		assertThat(pom, not(containsString("<repositories>")));
 	}
@@ -358,13 +356,11 @@ public class TestExport extends BaseTest {
 				"<groupId>dev.jbang.test</groupId>",
 				"<artifactId>app</artifactId>",
 				"<version>1.2.3</version>",
-				"<properties>",
-				"<maven.compiler.source>",
 				"<dependencies>",
 				"<groupId>log4j</groupId>",
 				"<artifactId>log4j</artifactId>",
 				"<version>1.2.17</version>"));
-		assertThat(pom, containsString("<maven.compiler.target>")); // Properties key may be in any order
+		assertThat(pom, not(containsString("<properties>")));
 		assertThat(pom, not(containsString("<dependencyManagement>")));
 		assertThat(pom, not(containsString("<repositories>")));
 	}
@@ -389,8 +385,6 @@ public class TestExport extends BaseTest {
 				"<groupId>org.example.project</groupId>",
 				"<artifactId>classpath_log_bom</artifactId>",
 				"<version>999-SNAPSHOT</version>",
-				"<properties>",
-				"<maven.compiler.source>",
 				"<dependencyManagement>",
 				"<groupId>org.apache.logging.log4j</groupId>",
 				"<artifactId>log4j-bom</artifactId>",
@@ -400,7 +394,7 @@ public class TestExport extends BaseTest {
 				"<artifactId>log4j-api</artifactId>",
 				"<groupId>org.apache.logging.log4j</groupId>",
 				"<artifactId>log4j-core</artifactId>"));
-		assertThat(pom, containsString("<maven.compiler.target>")); // Properties key may be in any order
+		assertThat(pom, not(containsString("<properties>")));
 		assertThat(pom, not(containsString("<repositories>")));
 	}
 


### PR DESCRIPTION
My initial attempt to fix #1044. I know there are still rough edges but at least the following basic usages work. Let me send it for your review so that I can check I'm on the right track.

Add two subcommands to 'jbang export':
* jbang export maven
* jbang export gradle
 
Those generate a template maven/gradle project the user can start developing the script further.

Fix #1044

Usage examples:
```console
jbang export maven hello.java # generates hello/ project with org.example.project:hello:999-SNAPSHOT
jbang export gradle -g dev.jbang.hello -a hello -v 1.0.0 -O hello2 hello.java # generates hello2/ with dev.jbang.hello:hello:1.0.0
```