### PR TITLE
fix: export maven/gradle should not touch default packages

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,13 +24,15 @@ jobs:
         with:
           fetch-depth: 2
       - name: Verify Changed files in docs
-        uses: tj-actions/verify-changed-files@fda469d6b456070da68fa3fdbc07a513d858b200 # v8.8
         id: verify-changed-files
-        with:
-          files: |
-             docs
+        run: |
+          if git diff --name-only HEAD~1 | grep '^docs/' > /dev/null; then
+            echo "files_changed=true" >> $GITHUB_ENV
+          else
+            echo "files_changed=false" >> $GITHUB_ENV
+          fi
       - name: update website
-        if: ${{ github.ref == 'refs/heads/main' && steps.verify-changed-files.outputs.files_changed == 'true'}} 
+        if: ${{ github.ref == 'refs/heads/main' && env.files_changed == 'true' }}
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1
         with:
           workflow: github-pages


### PR DESCRIPTION
github action tj-actions/verify-changed-files was comprimised in this pr https://github.com/tj-actions/changed-files/pull/2460

we use sha's for our github actions to exactly not be exposed to this kind of issues.

Other alternative is to not use random github actions and for this usecase of detecting file changes we don't actually seem to need an action.

So thats what this PR does :)