### PR TITLE
fix: avoid downloading java 21 for no good reason

### DIFF
--- a/itests/exporttags.java
+++ b/itests/exporttags.java
@@ -9,7 +9,7 @@
 //FILES res/resource.properties renamed.properties=res/resource.properties
 //FILES META-INF/application.properties=res/resource.properties
 
-//JAVA 21+
+//JAVA 11+
 //DESCRIPTION some description
 //GAV org.example:exporttags:1.2.3
 

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -302,9 +302,9 @@ public class TestExport extends BaseTest {
 		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
 		assertThat(build, containsString("languageVersion = JavaLanguageVersion.of"));
 		assertThat(build, not(containsString("JavaLanguageVersion.of(8)")));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(11)")));
+		assertThat(build, containsString("JavaLanguageVersion.of(11)"));
 		assertThat(build, not(containsString("JavaLanguageVersion.of(17)")));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(21+)")));
+		assertThat(build, not(containsString("JavaLanguageVersion.of(11+)")));
 		assertThat(build, containsString("mainClass = 'org.example.exporttags.exporttags'"));
 	}
 
@@ -454,8 +454,8 @@ public class TestExport extends BaseTest {
 				"<url>https://jitpack.io/</url>"));
 		assertThat(pom, containsString("<maven.compiler.target>")); // Properties key may be in any order
 		assertThat(pom, not(containsString("<maven.compiler.source>1.8</maven.compiler.source>")));
-		assertThat(pom, not(containsString("<maven.compiler.source>11</maven.compiler.source>")));
+		assertThat(pom, containsString("<maven.compiler.source>11</maven.compiler.source>"));
 		assertThat(pom, not(containsString("<maven.compiler.source>17</maven.compiler.source>")));
-		assertThat(pom, not(containsString("<maven.compiler.source>21+</maven.compiler.source>")));
+		assertThat(pom, not(containsString("<maven.compiler.source>11+</maven.compiler.source>")));
 	}
 }


### PR DESCRIPTION
#1044  added test with `//JAVA 21+` which adds about 20-30 seconds to the runtime of TestExport as it triggers autodownload of java 21 on at least 2 unittests methods.

made it use 11+ instead and things won't be as bad unless you run with 8 :)