### PR TITLE
fix: do not assume @ always means catalog

### DIFF
--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -14,6 +14,7 @@ import javax.annotation.Nonnull;
 import com.google.gson.annotations.SerializedName;
 
 import dev.jbang.cli.ExitException;
+import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.util.Util;
 
 public class Alias extends CatalogItem {
@@ -185,6 +186,12 @@ public class Alias extends CatalogItem {
 
 	private static Alias merge(Alias a1, String name, Function<String, Alias> findUnqualifiedAlias,
 			HashSet<String> names) {
+		// if this is a proper possible GAV, i.e.
+		// io.quarkiverse.mcp:artifact:1.0.0.Beta5@fatjar
+		// don't try interpret it.
+		if (DependencyUtil.looksLikeAPossibleGav(name)) {
+			return a1;
+		}
 		if (names.contains(name)) {
 			throw new RuntimeException("Encountered alias loop on '" + name + "'");
 		}

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -27,6 +27,9 @@ public class TestCatalog extends BaseTest {
 			"      \"script-ref\": \"one\",\n" +
 			"      \"arguments\": [\"2\"],\n" +
 			"      \"properties\": {\"two\":\"2\"}\n" +
+			"    },\n" +
+			"    \"fj\": {\n" +
+			"      \"script-ref\": \"i.look:like-a-gav:1.0.0.Beta5@fatjar\"\n" +
 			"    }\n" +
 			"  }\n" +
 			"}";
@@ -65,6 +68,13 @@ public class TestCatalog extends BaseTest {
 		Alias alias = Alias.get("one@test");
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("http://dummy"));
+	}
+
+	@Test
+	void testGetFatJar() throws IOException {
+		Alias alias = Alias.get("fj@test");
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("i.look:like-a-gav:1.0.0.Beta5@fatjar"));
 	}
 
 	@Test


### PR DESCRIPTION
with #1800 its useful to use @fatjar in catalogs for i.e.  io.quarkiverse.mcp:quarkus-mcp-stdio-sse-proxy:1.0.0.Beta5@fatjar
without it lots of unnecessary dependencies are fetched.

But turns out catalogs were merging aliases when there was just any @ in the name - ignoring  it could be possible GAV.

GAV's has :'s and version in specific places which i don't think will be confused for catalog names...but lets check :)
