### PR TITLE
fix: allow env as alias for java-env

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -7,6 +7,9 @@ open := if os() == "macos" { "open" } else if os() == "windows" { "start" } else
 build:
     ./gradlew spotlessApply installDist -x test
 
+format:
+    ./gradlew spotlessApply
+
 # run tests
 test:
     ./gradlew test
@@ -27,7 +30,7 @@ itest:
     @cd itests && ./itests.sh
 
 # open shell with latest build in path
-jbang +args:
+jbang *args:
     PATH="build/install/jbang/bin:$PATH" jbang {{args}}
 
 # open integeration test report

--- a/docs/modules/cli/pages/jbang-export-gradle.adoc
+++ b/docs/modules/cli/pages/jbang-export-gradle.adoc
@@ -1,0 +1,148 @@
+// This is a generated documentation file based on picocli
+// To change it update the picocli code or the genrator
+// tag::picocli-generated-full-manpage[]
+// tag::picocli-generated-man-section-header[]
+:doctype: manpage
+:manmanual: jbang Manual
+:man-linkstyle: pass:[blue R < >]
+= jbang-export-gradle(1)
+
+// end::picocli-generated-man-section-header[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+jbang-export-gradle - Exports a Gradle project
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*jbang export gradle* *-o* [*-h*] [*--force*] *--fresh* [*--insecure*] [*--[no-]*
+             *       integrations*] [*--itr*] [*--jsh*] *--quiet* *--verbose* [*--module*
+                    [=_<module>_]] [*-a*=_<artifact>_] [*--catalog*=_<catalog>_]
+                    [*--config*=_<config>_] [*-g*=_<group>_] [*-j*=_<javaVersion>_]
+                    [*-m*=_<main>_] [*-O*=_<outputFile>_] [*--source-type*=_<forceType>_]
+                    [*-v*=_<version>_] [*-C*=_<compileOptions>_]...
+                    [*--cp*=_<classpaths>_]... [*-D*=_<String=String>_]...
+                    [*--deps*=_<dependencies>_]... [*--files*=_<resources>_]...
+                    [*--manifest*=_<String=String>_]... [*--repos*=_<repositories>_]...
+                    [*-s*=_<sources>_]... [_<scriptOrFile>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Exports a Gradle project
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-a*, *--artifact*=_<artifact>_::
+  The artifact ID to use for the exported project.
+
+*-C*, *--compile-option*=_<compileOptions>_::
+  Options to pass to the compiler
+
+*--catalog*=_<catalog>_::
+  Path to catalog file to be used instead of the default
+
+*--config*=_<config>_::
+  Path to config file to be used instead of the default
+
+*--cp, --class-path*=_<classpaths>_::
+  Add class path entries.
+
+*-D*, _<String=String>_::
+  set a system property
+
+*--deps*=_<dependencies>_::
+  Add additional dependencies (Use commas to separate them).
+
+*--files*=_<resources>_::
+  Add additional files.
+
+*--force*::
+  Force export, i.e. overwrite exported file if already exists
+
+*--fresh*::
+  Make sure we use fresh (i.e. non-cached) resources.
+
+*-g*, *--group*=_<group>_::
+  The group ID to use for the exported project.
+
+*-h*, *--help*::
+  Display help/info. Use 'jbang <command> -h' for detailed usage.
+
+*--insecure*::
+  Enable insecure trust of all SSL certificates.
+
+*--[no-]integrations*::
+  Enable integration execution (default: true)
+
+*--itr, --ignore-transitive-repositories*::
+  Ignore remote repositories found in transitive dependencies
+
+*-j*, *--java*=_<javaVersion>_::
+  JDK version to use for running the script.
+
+*--jsh*::
+  Force input to be interpreted with jsh/jshell. Deprecated: use '--source-type jshell'
+
+*-m*, *--main*=_<main>_::
+  Main class to use when running. Used primarily for running jar's.
+
+*--manifest*=_<String=String>_::
+  
+
+*--module*[=_<module>_]::
+  Treat resource as a module. Optionally with the given module name
+
+*-o*, *--offline*::
+  Work offline. Fail-fast if dependencies are missing. No connections will be attempted
+
+*-O*, *--output*=_<outputFile>_::
+  The name or path to use for the exported file. If not specified a name will be determined from the original source reference and export flags.
+
+*--quiet*::
+  jbang will be quiet, only print when error occurs.
+
+*--repos*=_<repositories>_::
+  Add additional repositories.
+
+*-s*, *--sources*=_<sources>_::
+  Add additional sources.
+
+*--source-type*=_<forceType>_::
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+
+*-v*, *--version*=_<version>_::
+  The version to use for the exported project.
+
+*--verbose*::
+  jbang will be verbose on what it does.
+
+// end::picocli-generated-man-section-options[]
+
+// tag::picocli-generated-man-section-arguments[]
+== Arguments
+
+[_<scriptOrFile>_]::
+  A reference to a source file
+
+// end::picocli-generated-man-section-arguments[]
+
+// tag::picocli-generated-man-section-commands[]
+// end::picocli-generated-man-section-commands[]
+
+// tag::picocli-generated-man-section-exit-status[]
+// end::picocli-generated-man-section-exit-status[]
+
+// tag::picocli-generated-man-section-footer[]
+// end::picocli-generated-man-section-footer[]
+
+// end::picocli-generated-full-manpage[]

--- a/docs/modules/cli/pages/jbang-export-maven.adoc
+++ b/docs/modules/cli/pages/jbang-export-maven.adoc
@@ -1,0 +1,148 @@
+// This is a generated documentation file based on picocli
+// To change it update the picocli code or the genrator
+// tag::picocli-generated-full-manpage[]
+// tag::picocli-generated-man-section-header[]
+:doctype: manpage
+:manmanual: jbang Manual
+:man-linkstyle: pass:[blue R < >]
+= jbang-export-maven(1)
+
+// end::picocli-generated-man-section-header[]
+
+// tag::picocli-generated-man-section-name[]
+== Name
+
+jbang-export-maven - Exports a Maven project
+
+// end::picocli-generated-man-section-name[]
+
+// tag::picocli-generated-man-section-synopsis[]
+== Synopsis
+
+*jbang export maven* *-o* [*-h*] [*--force*] *--fresh* [*--insecure*] [*--[no-]integrations*]
+                   [*--itr*] [*--jsh*] *--quiet* *--verbose* [*--module*[=_<module>_]]
+                   [*-a*=_<artifact>_] [*--catalog*=_<catalog>_] [*--config*=_<config>_]
+                   [*-g*=_<group>_] [*-j*=_<javaVersion>_] [*-m*=_<main>_]
+                   [*-O*=_<outputFile>_] [*--source-type*=_<forceType>_] [*-v*=_<version>_]
+                   [*-C*=_<compileOptions>_]... [*--cp*=_<classpaths>_]...
+                   [*-D*=_<String=String>_]... [*--deps*=_<dependencies>_]...
+                   [*--files*=_<resources>_]... [*--manifest*=_<String=String>_]...
+                   [*--repos*=_<repositories>_]... [*-s*=_<sources>_]...
+                   [_<scriptOrFile>_]
+
+// end::picocli-generated-man-section-synopsis[]
+
+// tag::picocli-generated-man-section-description[]
+== Description
+
+Exports a Maven project
+
+// end::picocli-generated-man-section-description[]
+
+// tag::picocli-generated-man-section-options[]
+== Options
+
+*-a*, *--artifact*=_<artifact>_::
+  The artifact ID to use for the exported project.
+
+*-C*, *--compile-option*=_<compileOptions>_::
+  Options to pass to the compiler
+
+*--catalog*=_<catalog>_::
+  Path to catalog file to be used instead of the default
+
+*--config*=_<config>_::
+  Path to config file to be used instead of the default
+
+*--cp, --class-path*=_<classpaths>_::
+  Add class path entries.
+
+*-D*, _<String=String>_::
+  set a system property
+
+*--deps*=_<dependencies>_::
+  Add additional dependencies (Use commas to separate them).
+
+*--files*=_<resources>_::
+  Add additional files.
+
+*--force*::
+  Force export, i.e. overwrite exported file if already exists
+
+*--fresh*::
+  Make sure we use fresh (i.e. non-cached) resources.
+
+*-g*, *--group*=_<group>_::
+  The group ID to use for the exported project.
+
+*-h*, *--help*::
+  Display help/info. Use 'jbang <command> -h' for detailed usage.
+
+*--insecure*::
+  Enable insecure trust of all SSL certificates.
+
+*--[no-]integrations*::
+  Enable integration execution (default: true)
+
+*--itr, --ignore-transitive-repositories*::
+  Ignore remote repositories found in transitive dependencies
+
+*-j*, *--java*=_<javaVersion>_::
+  JDK version to use for running the script.
+
+*--jsh*::
+  Force input to be interpreted with jsh/jshell. Deprecated: use '--source-type jshell'
+
+*-m*, *--main*=_<main>_::
+  Main class to use when running. Used primarily for running jar's.
+
+*--manifest*=_<String=String>_::
+  
+
+*--module*[=_<module>_]::
+  Treat resource as a module. Optionally with the given module name
+
+*-o*, *--offline*::
+  Work offline. Fail-fast if dependencies are missing. No connections will be attempted
+
+*-O*, *--output*=_<outputFile>_::
+  The name or path to use for the exported file. If not specified a name will be determined from the original source reference and export flags.
+
+*--quiet*::
+  jbang will be quiet, only print when error occurs.
+
+*--repos*=_<repositories>_::
+  Add additional repositories.
+
+*-s*, *--sources*=_<sources>_::
+  Add additional sources.
+
+*--source-type*=_<forceType>_::
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+
+*-v*, *--version*=_<version>_::
+  The version to use for the exported project.
+
+*--verbose*::
+  jbang will be verbose on what it does.
+
+// end::picocli-generated-man-section-options[]
+
+// tag::picocli-generated-man-section-arguments[]
+== Arguments
+
+[_<scriptOrFile>_]::
+  A reference to a source file
+
+// end::picocli-generated-man-section-arguments[]
+
+// tag::picocli-generated-man-section-commands[]
+// end::picocli-generated-man-section-commands[]
+
+// tag::picocli-generated-man-section-exit-status[]
+// end::picocli-generated-man-section-exit-status[]
+
+// tag::picocli-generated-man-section-footer[]
+// end::picocli-generated-man-section-footer[]
+
+// end::picocli-generated-full-manpage[]

--- a/docs/modules/cli/pages/jbang-jdk.adoc
+++ b/docs/modules/cli/pages/jbang-jdk.adoc
@@ -62,7 +62,7 @@ xref:jbang-jdk-home.adoc[*home*]::
 xref:jbang-jdk-install.adoc[*install*]::
   Installs a JDK.
 
-xref:jbang-jdk-java-env.adoc[*java-env*]::
+xref:jbang-jdk-java-env.adoc[*java-env*, *env*]::
   Prints out the environment variables needed to use the given JDK.
 
 xref:jbang-jdk-list.adoc[*list*]::

--- a/docs/modules/cli/partials/nav-jbang.adoc
+++ b/docs/modules/cli/partials/nav-jbang.adoc
@@ -28,7 +28,7 @@
 *** xref:jbang-jdk-default.adoc[default]
 *** xref:jbang-jdk-home.adoc[home]
 *** xref:jbang-jdk-install.adoc[install]
-*** xref:jbang-jdk-java-env.adoc[java-env]
+*** xref:jbang-jdk-java-env.adoc[java-env, env]
 *** xref:jbang-jdk-list.adoc[list]
 *** xref:jbang-jdk-uninstall.adoc[uninstall]
 ** xref:jbang-version.adoc[version]

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -174,7 +174,7 @@ public class Jdk {
 		return EXIT_OK;
 	}
 
-	@CommandLine.Command(name = "java-env", description = "Prints out the environment variables needed to use the given JDK.")
+	@CommandLine.Command(name = "java-env", aliases = "env", description = "Prints out the environment variables needed to use the given JDK.")
 	public Integer javaEnv(
 			@CommandLine.Parameters(paramLabel = "versionOrId", index = "0", description = "The version of the JDK to select", arity = "0..1") String versionOrId) {
 		jdkProvidersMixin.initJdkProviders();


### PR DESCRIPTION
tired of forgetting its java-env and not just env.

keeps things backwards compatible.