### PR TITLE
fix: handle symbolic links in untar

### DIFF
--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -454,6 +454,17 @@ public class Util {
 		}
 	}
 
+	static public void warnMsg(String msg, Throwable verboseInfo) {
+		if (!isQuiet()) {
+			System.err.print(getMsgHeader());
+			System.err.print("[WARN] ");
+			System.err.println(msg);
+			if (isVerbose()) {
+				verboseInfo.printStackTrace();
+			}
+		}
+	}
+
 	static public void errorMsg(String msg) {
 		System.err.print(getMsgHeader());
 		System.err.print("[ERROR] ");


### PR DESCRIPTION
if you try something like ` JBANG_JDK_VENDOR=graalvm just jbang --java 23 --native --verbose pcli.java` you get an error about native-image permissions.

turns out graalvm targz files has symbolic links for native-image which we don't currently honor - as no other JDK seem to do this.

This fixes that.