### PR TITLE
feat: export maven/gradle, support dependency-versions plugin

### DIFF
--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -675,8 +675,8 @@ class ExportGradleProject extends BaseExportProject {
 								.data("compilerArgs", compilerArgs)
 								.render();
 		Util.writeString(destination, result);
-		Util.writeString(projectDir.resolve("settings.gradle"), "");
-		Util.writeString(projectDir.resolve("gradle.properties"), "org.gradle.configuration-cache=true\n");
+		Util.writeString(projectDir.resolve("settings.gradle"), "\n");
+		Util.writeString(projectDir.resolve("gradle.properties"), "\n");
 	}
 
 	private List<String> gradleify(List<String> collectDependencies) {

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -676,7 +676,7 @@ class ExportGradleProject extends BaseExportProject {
 								.render();
 		Util.writeString(destination, result);
 		Util.writeString(projectDir.resolve("settings.gradle"), "\n");
-		Util.writeString(projectDir.resolve("gradle.properties"), "\n");
+		Util.writeString(projectDir.resolve("gradle.properties"), "org.gradle.configuration-cache=false\n");
 	}
 
 	private List<String> gradleify(List<String> collectDependencies) {

--- a/src/main/resources/export-build.qute.gradle
+++ b/src/main/resources/export-build.qute.gradle
@@ -9,6 +9,7 @@ plugins {
 	id 'org.jetbrains.kotlin.jvm' version '{kotlinVersion}'
 {/if}
 	id 'application'
+	id 'com.github.ben-manes.versions' version '0.52.0'
 }
 
 {#if description}

--- a/src/main/resources/export-pom.qute.xml
+++ b/src/main/resources/export-pom.qute.xml
@@ -131,24 +131,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>versions-maven-plugin</artifactId>
-				<version>2.18.0</version>
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>dependency-updates-report</report>
-							<report>plugin-updates-report</report>
-							<report>property-updates-report</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-			</plugin>
-		</plugins>
-	</reporting>
-
 </project>

--- a/src/main/resources/export-pom.qute.xml
+++ b/src/main/resources/export-pom.qute.xml
@@ -131,4 +131,24 @@
 			</plugin>
 		</plugins>
 	</build>
+
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.18.0</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>dependency-updates-report</report>
+							<report>plugin-updates-report</report>
+							<report>property-updates-report</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
+
 </project>


### PR DESCRIPTION
Allows a quick deps version check to be run to see if the deps are up-to-date using command `gradle dependencyUpdates` or `mvn versions:display-dependency-updates`

Closes #1976 
