### PR TITLE
chore: minor export cleanup/improvements

### DIFF
--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -22,7 +22,6 @@ import dev.jbang.catalog.CatalogUtil;
 import dev.jbang.dependencies.*;
 import dev.jbang.source.*;
 import dev.jbang.source.resolvers.AliasResourceResolver;
-import dev.jbang.source.sources.GroovySource;
 import dev.jbang.source.sources.KotlinSource;
 import dev.jbang.util.JarUtil;
 import dev.jbang.util.JavaUtil;
@@ -514,6 +513,9 @@ abstract class BaseExportProject extends BaseExportCommand {
 	@CommandLine.Option(names = { "--version", "-v" }, description = "The version to use for the exported project.")
 	String version;
 
+	protected EnumSet<Source.Type> supportedSourceTypes = EnumSet.of(Source.Type.java, Source.Type.groovy,
+			Source.Type.kotlin);
+
 	@Override
 	int apply(BuildContext ctx) throws IOException {
 		Path projectDir = exportMixin.getOutputPath("");
@@ -566,9 +568,8 @@ abstract class BaseExportProject extends BaseExportCommand {
 		Util.mkdirs(projectDir);
 
 		// Sources
-		boolean isGroovy = ctx.getProject().getMainSource() instanceof GroovySource;
-		boolean isKotlin = ctx.getProject().getMainSource() instanceof KotlinSource;
-		Path srcJavaDir = projectDir.resolve("src/main/" + (isKotlin ? "kotlin" : (isGroovy ? "groovy" : "java")));
+		String srcFolder = ctx.getProject().getMainSource().getType().sourceFolder;
+		Path srcJavaDir = projectDir.resolve("src/main/" + srcFolder);
 		for (ResourceRef sourceRef : prj.getMainSourceSet().getSources()) {
 			copySource(sourceRef, srcJavaDir);
 		}
@@ -650,9 +651,12 @@ class ExportGradleProject extends BaseExportProject {
 		Template template = engine.getTemplate(templateRef);
 		if (template == null)
 			throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
-		boolean isGroovy = prj.getMainSource() instanceof GroovySource;
-		boolean isKotlin = prj.getMainSource() instanceof KotlinSource;
-		String kotlinVersion = isKotlin ? ((KotlinSource) prj.getMainSource()).getKotlinVersion() : "";
+		Source.Type srcType = prj.getMainSource().getType();
+		if (!supportedSourceTypes.contains(srcType)) {
+			throw new ExitException(EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
+		}
+		String kotlinVersion = srcType == Source.Type.kotlin ? ((KotlinSource) prj.getMainSource()).getKotlinVersion()
+				: "";
 		String javaVersion = getJavaVersion(prj, false);
 		String jvmArgs = gradleArgs(prj.getRuntimeOptions());
 		String compilerArgs = gradleArgs(prj.getMainSourceSet().getCompileOptions());
@@ -660,7 +664,7 @@ class ExportGradleProject extends BaseExportProject {
 								.data("group", group)
 								.data("artifact", artifact)
 								.data("version", version)
-								.data("language", (isKotlin ? "kotlin" : (isGroovy ? "groovy" : "java")))
+								.data("language", srcType.name())
 								.data("javaVersion", javaVersion)
 								.data("kotlinVersion", kotlinVersion)
 								.data("description", prj.getDescription().orElse(""))
@@ -734,11 +738,14 @@ class ExportMavenProject extends BaseExportProject {
 		Template template = engine.getTemplate(templateRef);
 		if (template == null)
 			throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
-		boolean isGroovy = prj.getMainSource() instanceof GroovySource;
-		boolean isKotlin = prj.getMainSource() instanceof KotlinSource;
-		String kotlinVersion = isKotlin ? ((KotlinSource) prj.getMainSource()).getKotlinVersion() : "";
+		Source.Type srcType = prj.getMainSource().getType();
+		if (!supportedSourceTypes.contains(srcType)) {
+			throw new ExitException(EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
+		}
+		String kotlinVersion = srcType == Source.Type.kotlin ? ((KotlinSource) prj.getMainSource()).getKotlinVersion()
+				: "";
 		Map<String, String> properties = new HashMap<>();
-		if (isKotlin) {
+		if (srcType == Source.Type.kotlin) {
 			properties.put("kotlin.version", kotlinVersion);
 		}
 		String javaVersion = getJavaVersion(prj, false);
@@ -746,7 +753,7 @@ class ExportMavenProject extends BaseExportProject {
 								.data("group", group)
 								.data("artifact", artifact)
 								.data("version", version)
-								.data("language", (isKotlin ? "kotlin" : (isGroovy ? "groovy" : "java")))
+								.data("language", srcType.name())
 								.data("javaVersion", javaVersion)
 								.data("kotlinVersion", kotlinVersion)
 								.data("description", prj.getDescription().orElse(""))

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -33,13 +33,16 @@ public abstract class Source {
 	protected final TagReader tagReader;
 
 	public enum Type {
-		java("java"), jshell("jsh"), kotlin("kt"),
-		groovy("groovy"), markdown("md");
+		java("java", "java"), jshell("jsh", "java"),
+		kotlin("kt", "kotlin"), groovy("groovy", "groovy"),
+		markdown("md", "java");
 
 		public final String extension;
+		public final String sourceFolder;
 
-		Type(String extension) {
+		Type(String extension, String sourceFolder) {
 			this.extension = extension;
+			this.sourceFolder = sourceFolder;
 		}
 
 		public static List<String> extensions() {
@@ -69,6 +72,8 @@ public abstract class Source {
 	public Stream<String> getTags() {
 		return tagReader.getTags();
 	}
+
+	public abstract @Nonnull Type getType();
 
 	protected List<String> collectBinaryDependencies() {
 		return tagReader.collectBinaryDependencies();

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -278,7 +278,7 @@ public abstract class CompileBuildStep implements Builder<Project> {
 	protected String getSuggestedMain() {
 		Project project = ctx.getProject();
 		if (!project.getResourceRef().isStdin()) {
-			return project.getResourceRef().getFile().getFileName().toString().replace(getMainExtension(), "");
+			return project.getResourceRef().getFile().getFileName().toString().replace("." + getMainExtension(), "");
 		} else {
 			return null;
 		}

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import javax.annotation.Nonnull;
+
 import org.jboss.jandex.ClassInfo;
 
 import dev.jbang.net.GroovyManager;
@@ -25,6 +27,11 @@ public class GroovySource extends Source {
 
 	public GroovySource(String script, Function<String, String> replaceProperties) {
 		super(script, replaceProperties);
+	}
+
+	@Override
+	public @Nonnull Type getType() {
+		return Type.groovy;
 	}
 
 	@Override
@@ -103,7 +110,7 @@ public class GroovySource extends Source {
 
 			@Override
 			protected String getMainExtension() {
-				return ".groovy";
+				return Type.groovy.extension;
 			}
 
 			@Override

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -5,6 +5,8 @@ import static dev.jbang.util.JavaUtil.resolveInJavaHome;
 import java.util.List;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.source.*;
 import dev.jbang.source.AppBuilder;
 import dev.jbang.source.buildsteps.CompileBuildStep;
@@ -21,6 +23,11 @@ public class JavaSource extends Source {
 
 	protected JavaSource(ResourceRef ref, String script, Function<String, String> replaceProperties) {
 		super(ref, script, replaceProperties);
+	}
+
+	@Override
+	public @Nonnull Type getType() {
+		return Type.java;
 	}
 
 	@Override
@@ -66,7 +73,7 @@ public class JavaSource extends Source {
 
 			@Override
 			protected String getMainExtension() {
-				return ".java";
+				return Type.java.extension;
 			}
 		}
 	}

--- a/src/main/java/dev/jbang/source/sources/JshSource.java
+++ b/src/main/java/dev/jbang/source/sources/JshSource.java
@@ -2,6 +2,8 @@ package dev.jbang.source.sources;
 
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.source.*;
 
 public class JshSource extends JavaSource {
@@ -11,6 +13,11 @@ public class JshSource extends JavaSource {
 
 	protected JshSource(ResourceRef ref, String script, Function<String, String> replaceProperties) {
 		super(ref, script, replaceProperties);
+	}
+
+	@Override
+	public @Nonnull Type getType() {
+		return Type.jshell;
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import javax.annotation.Nonnull;
+
 import org.jboss.jandex.ClassInfo;
 
 import dev.jbang.net.KotlinManager;
@@ -21,6 +23,11 @@ public class KotlinSource extends Source {
 
 	public KotlinSource(String script, Function<String, String> replaceProperties) {
 		super(script, replaceProperties);
+	}
+
+	@Override
+	public @Nonnull Type getType() {
+		return Type.kotlin;
 	}
 
 	@Override
@@ -81,7 +88,7 @@ public class KotlinSource extends Source {
 
 			@Override
 			protected String getMainExtension() {
-				return ".kt";
+				return Type.kotlin.extension;
 			}
 
 			@Override

--- a/src/main/java/dev/jbang/source/sources/MarkdownSource.java
+++ b/src/main/java/dev/jbang/source/sources/MarkdownSource.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 import dev.jbang.source.ResourceRef;
@@ -17,6 +19,11 @@ public class MarkdownSource extends JshSource {
 
 	protected MarkdownSource(ResourceRef ref, String script, Function<String, String> replaceProperties) {
 		super(ref, script, replaceProperties);
+	}
+
+	@Override
+	public @Nonnull Type getType() {
+		return Type.markdown;
 	}
 
 	public static Source create(ResourceRef resourceRef, Function<String, String> replaceProperties) {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1133,6 +1133,7 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	@Disabled("Service doesn't seem very stable")
 	void testFetchFromBluesky(@TempDir Path dir) throws IOException {
 
 		verifyHello("https://bsky.app/profile/maxandersen.xam.dk/post/3lb2vbnfpns24", dir, false);


### PR DESCRIPTION
There was a bit too many instanceof tests for my taste so I made the `Source` return its `Type` (that was an existing type but it wasn't being exposed) and extended the `Type` to include the "maven source folder" name (which is the name of the folder that sources should be in when using the maven project structure, eg: "src/main/**java**")

I also made sure that the code will exit with an error when trying to export an unsupported language (especially useful now that people are looking to support other languages like Python/Jython)