### PR TITLE
test: make sure itests leave project directory clean

### DIFF
--- a/src/it/java/dev/jbang/it/JarIT.java
+++ b/src/it/java/dev/jbang/it/JarIT.java
@@ -13,7 +13,7 @@ public class JarIT extends BaseIT {
 	// Then match out == "Hello World\n"
 	@Test
 	void testJavaLaunchFile() {
-		assertThat(shell("jbang helloworld.jar"))
+		assertThat(shell("jbang hellojar.jar"))
 			.outEquals("Hello World" + lineSeparator());
 	}
 


### PR DESCRIPTION
Some itests leave create files in the project folder and leave them around.
This then complicates committing any changes because you have to be careful that you don't accidentally commit those files as well.
These changes avoid that by making a temporary copy of the entire itests folder and run the tests from there.

Also fixed one test that I guess depended on the order that the tests were run in because there doesn't exist a `helloworld.jar` in the itests folder.