### PR TITLE
fix: Fix CommandBuffer when running on Windows from bash

### DIFF
--- a/src/main/java/dev/jbang/util/CommandBuffer.java
+++ b/src/main/java/dev/jbang/util/CommandBuffer.java
@@ -161,7 +161,7 @@ public class CommandBuffer {
 		// argument, this is close to impossible to handle on Windows.
 		// (see
 		// https://stackoverflow.com/questions/30157414/batch-argument-with-quotes-and-spaces)
-		if (shell != Util.Shell.bash && cmdNeedQuotesChars.matcher(arg).find()) {
+		if (Util.isWindows() && cmdNeedQuotesChars.matcher(arg).find()) {
 			arg = "\"" + arg + "\"";
 		}
 		return arg;

--- a/src/test/java/dev/jbang/util/TestCommandBuffer.java
+++ b/src/test/java/dev/jbang/util/TestCommandBuffer.java
@@ -1,5 +1,6 @@
 package dev.jbang.util;
 
+import static dev.jbang.util.Util.JBANG_RUNTIME_SHELL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -12,9 +13,25 @@ public class TestCommandBuffer extends BaseTest {
 	@Test
 	void testRunWinBat() {
 		if (Util.getOS() == Util.OS.windows) {
-			String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def");
+			String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
+					"abc=def", "abc,def");
 			assertThat(out, containsString("ARG = abc def"));
 			assertThat(out, containsString("ARG = abc;def"));
+			assertThat(out, containsString("ARG = abc=def"));
+			assertThat(out, containsString("ARG = abc,def"));
+		}
+	}
+
+	@Test
+	void testRunWinBatFromBash() {
+		if (Util.getOS() == Util.OS.windows) {
+			environmentVariables.set(JBANG_RUNTIME_SHELL, "bash");
+			String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
+					"abc=def", "abc,def");
+			assertThat(out, containsString("ARG = abc def"));
+			assertThat(out, containsString("ARG = abc;def"));
+			assertThat(out, containsString("ARG = abc=def"));
+			assertThat(out, containsString("ARG = abc,def"));
 		}
 	}
 


### PR DESCRIPTION
When using the CommandBuffer on Windows to create a ProcessBuilder the code would take into account the Shell that JBang was run from. But in the case of a ProcessBuilder the Shell is irrelevant and we should always assume CMD.

Fixes #1974

