### PR TITLE
refactor: Added `LazyResourceRef`

### DIFF
--- a/src/main/java/dev/jbang/Configuration.java
+++ b/src/main/java/dev/jbang/Configuration.java
@@ -257,7 +257,7 @@ public class Configuration {
 	}
 
 	public static Configuration get(Path catalogPath) {
-		return get(ResourceRef.forNamedFile(catalogPath.toString(), catalogPath));
+		return get(ResourceRef.forResolvedResource(catalogPath.toString(), catalogPath));
 	}
 
 	private static Configuration get(ResourceRef ref) {

--- a/src/main/java/dev/jbang/source/DirectResourceRef.java
+++ b/src/main/java/dev/jbang/source/DirectResourceRef.java
@@ -1,0 +1,75 @@
+package dev.jbang.source;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+public class DirectResourceRef implements ResourceRef {
+	@Nullable
+	private final String originalResource;
+	@Nullable
+	private final Path file;
+
+	protected DirectResourceRef(@Nullable String ref, @Nullable Path file) {
+		this.originalResource = ref;
+		this.file = file;
+	}
+
+	@Nullable
+	@Override
+	public String getOriginalResource() {
+		return originalResource;
+	}
+
+	@Nullable
+	@Override
+	public Path getFile() {
+		return file;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		DirectResourceRef that = (DirectResourceRef) o;
+		return Objects.equals(originalResource, that.originalResource) &&
+				Objects.equals(file, that.file);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(originalResource, file);
+	}
+
+	@Override
+	public int compareTo(ResourceRef o) {
+		if (o == null) {
+			return 1;
+		}
+		return toString().compareTo(o.toString());
+	}
+
+	@Override
+	public String toString() {
+		if (originalResource != null && file != null) {
+			if (originalResource.equals(file.toString())) {
+				return originalResource;
+			} else {
+				return originalResource + " (cached as: " + file + ")";
+			}
+		} else {
+			String res = "";
+			if (originalResource != null) {
+				res += originalResource;
+			}
+			if (file != null) {
+				res += file;
+			}
+			return res;
+		}
+	}
+
+}

--- a/src/main/java/dev/jbang/source/LazyResourceRef.java
+++ b/src/main/java/dev/jbang/source/LazyResourceRef.java
@@ -1,0 +1,97 @@
+package dev.jbang.source;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import dev.jbang.util.Util;
+
+public class LazyResourceRef implements ResourceRef {
+	@Nonnull
+	private final ResourceResolver resolver;
+	@Nonnull
+	private final String originalResource;
+	@Nullable
+	private ResourceRef resolvedRef;
+
+	public LazyResourceRef(@Nonnull ResourceResolver resolver, @Nonnull String resource) {
+		this.resolver = resolver;
+		this.originalResource = resource;
+	}
+
+	@Nonnull
+	@Override
+	public String getOriginalResource() {
+		return originalResource;
+	}
+
+	@Nullable
+	@Override
+	public Path getFile() {
+		if (resolvedRef == null) {
+			resolvedRef = resolver.resolve(getOriginalResource());
+			if (resolvedRef == null) {
+				throw new LazyResolveException();
+			}
+		}
+		return resolvedRef.getFile();
+	}
+
+	@Nonnull
+	@Override
+	public String getExtension() {
+		if (resolvedRef != null) {
+			return resolvedRef.getExtension();
+		} else {
+			return Util.extension(getOriginalResource());
+		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof ResourceRef))
+			return false;
+		ResourceRef that = (ResourceRef) o;
+		if (resolvedRef != null) {
+			return resolvedRef.equals(that);
+		} else {
+			return Objects.equals(getOriginalResource(), that.getOriginalResource());
+		}
+	}
+
+	@Override
+	public int hashCode() {
+		if (resolvedRef != null) {
+			return resolvedRef.hashCode();
+		} else {
+			return Objects.hash(getOriginalResource());
+		}
+	}
+
+	@Override
+	public int compareTo(ResourceRef o) {
+		if (o == null) {
+			return 1;
+		}
+		return toString().compareTo(o.toString());
+	}
+
+	@Override
+	public String toString() {
+		if (resolvedRef != null) {
+			return resolvedRef.toString();
+		} else {
+			return getOriginalResource() + " (unresolved)";
+		}
+	}
+
+	public class LazyResolveException extends RuntimeException {
+		public LazyResolveException() {
+			super("Unable to lazily resolve resource: " + originalResource);
+		}
+	}
+}

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -506,8 +505,6 @@ public class ProjectBuilder {
 
 	private List<RefTarget> allToFileRef(List<String> resources) {
 		ResourceResolver resolver = ResourceResolver.forResources();
-		Function<String, String> propsResolver = it -> PropertiesValueResolver.replaceProperties(it,
-				getContextProperties());
 		return resources.stream()
 			.flatMap(f -> TagReader.explodeFileRef(null, Util.getCwd(), f).stream())
 			.map(f -> TagReader.toFileRef(f, resolver))

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -4,50 +4,93 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import dev.jbang.util.Util;
 
-public class ResourceRef implements Comparable<ResourceRef> {
-	// original requested resource
-	@Nullable
-	private final String originalResource;
-	// cache folder it is stored inside
-	@Nullable
-	private final Path file;
-
-	public static final ResourceRef nullRef = new ResourceRef(null, null);
-
-	protected ResourceRef(@Nullable String ref, @Nullable Path file) {
-		this.originalResource = ref;
-		this.file = file;
-	}
-
-	public boolean isURL() {
-		return originalResource != null && Util.isURL(originalResource);
-	}
-
-	public boolean isClasspath() {
-		return originalResource != null && Util.isClassPathRef(originalResource);
-	}
-
-	public boolean isStdin() {
-		return originalResource != null && isStdin(originalResource);
-	}
-
-	public boolean exists() {
-		return file != null && Files.isRegularFile(file);
-	}
+/**
+ * Represents a reference to a resource, which can be identified by an original
+ * resource string or a resolved file path. Resource references may point to
+ * files, URLs, classpath entries, or piped-in contents (stdin). Regardless of
+ * what they point to, their main goal is to provide access to the resource
+ * contents without having to know how those contents are obtained.
+ *
+ * Instances of this interface can be created directly by using one of the
+ * factory methods like {@code forFile} and
+ * {@code forResolvedResource) but often they are the result of a call to {@code
+ * Resolver.resolve}.
+ */
+public interface ResourceRef extends Comparable<ResourceRef> {
+	ResourceRef nullRef = new DirectResourceRef(null, null);
 
 	@Nullable
-	public Path getFile() {
-		return file;
+	String getOriginalResource();
+
+	/**
+	 * Determines whether the original resource is a valid URL.
+	 * 
+	 * @return true if the original resource is not null and is a valid URL,
+	 *         otherwise false
+	 */
+	default boolean isURL() {
+		return getOriginalResource() != null && Util.isURL(getOriginalResource());
 	}
 
-	public InputStream getInputStream() throws IOException {
+	/**
+	 * Determines whether the original resource is a valid classpath reference.
+	 * 
+	 * @return true if the original resource is not null and is a valid classpath
+	 *         reference, otherwise false
+	 */
+	default boolean isClasspath() {
+		return getOriginalResource() != null && Util.isClassPathRef(getOriginalResource());
+	}
+
+	/**
+	 * Determines whether the original resource represents contents piped in from
+	 * stdin.
+	 * 
+	 * @return true if the original resource is not null and is stdin, otherwise
+	 *         false
+	 */
+	default boolean isStdin() {
+		return getOriginalResource() != null && isStdin(getOriginalResource());
+	}
+
+	/**
+	 * Returns a file representation for this resource reference. If an original
+	 * resource was provided, this method will return a resolved file representation
+	 * of that resource. Depending on the resource reference, the process of
+	 * resolving might have been done when the reference was created, or it might be
+	 * done when calling this method. In which case some kind of RuntimeException
+	 * might be thrown if the resolving process fails.
+	 * 
+	 * @return A file reference, possibly null
+	 */
+	@Nullable
+	Path getFile();
+
+	/**
+	 * Checks whether the resource represented by this reference exists as a regular
+	 * file.
+	 * 
+	 * @return true if the file exists and is a regular file, false otherwise
+	 */
+	default boolean exists() {
+		return getFile() != null && Files.isRegularFile(getFile());
+	}
+
+	/**
+	 * Retrieves an InputStream for the resource represented by this reference. If a
+	 * file representation of the resource exists, the InputStream is opened for
+	 * that file. If no file is associated, this method returns null.
+	 *
+	 * @return an InputStream for the resource, or null if no file is associated
+	 * @throws IOException if an I/O error occurs while opening the InputStream
+	 */
+	default InputStream getInputStream() throws IOException {
 		if (getFile() != null) {
 			return Files.newInputStream(getFile());
 		} else {
@@ -55,83 +98,75 @@ public class ResourceRef implements Comparable<ResourceRef> {
 		}
 	}
 
-	@Nullable
-	public String getOriginalResource() {
-		return originalResource;
-	}
-
+	/**
+	 * Retrieves the file extension of the resource represented by this reference.
+	 * 
+	 * @return the file extension of the resource, or an empty string if no
+	 *         extension is found
+	 */
 	@Nonnull
-	public String getExtension() {
-		if (file != null) {
-			return Util.extension(file.toString());
-		} else if (originalResource != null) {
-			return Util.extension(originalResource);
+	default String getExtension() {
+		if (getFile() != null) {
+			return Util.extension(getFile().toString());
+		} else if (getOriginalResource() != null) {
+			return Util.extension(getOriginalResource());
 		} else {
 			return "";
 		}
 	}
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		ResourceRef that = (ResourceRef) o;
-		return Objects.equals(originalResource, that.originalResource) &&
-				Objects.equals(file, that.file);
+	/**
+	 * Creates a new {@code ResourceRef} instance for the given file path.
+	 *
+	 * @param file the file path used to create the resource reference
+	 * @return a {@code ResourceRef} instance representing the specified file
+	 */
+	static ResourceRef forFile(@Nonnull Path file) {
+		return new DirectResourceRef(file.toString(), file);
 	}
 
-	@Override
-	public int hashCode() {
-		return Objects.hash(originalResource, file);
+	/**
+	 * Creates a new {@code ResourceRef} instance for a resolved resource. It takes
+	 * the original resource string, which can be things like file paths, urls,
+	 * classpath references, etc and associates it with the given file reference.
+	 *
+	 * @param resource         the original resource as a string
+	 * @param resolvedResource the resolved file path of the resource
+	 * @return a {@code ResourceRef} instance representing the specified resolved
+	 *         resource
+	 */
+	static ResourceRef forResolvedResource(@Nonnull String resource, @Nonnull Path resolvedResource) {
+		return new DirectResourceRef(resource, resolvedResource);
 	}
 
-	@Override
-	public int compareTo(ResourceRef o) {
-		if (o == null) {
-			return 1;
-		}
-		return toString().compareTo(o.toString());
-	}
-
-	@Override
-	public String toString() {
-		if (originalResource != null && file != null) {
-			if (originalResource.equals(file.toString())) {
-				return originalResource;
-			} else {
-				return originalResource + " (cached as: " + file + ")";
-			}
-		} else {
-			String res = "";
-			if (originalResource != null) {
-				res += originalResource;
-			}
-			if (file != null) {
-				res += file;
-			}
-			return res;
-		}
-	}
-
-	public static ResourceRef forFile(Path file) {
-		return new ResourceRef(file.toString(), file);
-	}
-
-	public static ResourceRef forNamedFile(String resource, Path file) {
-		return new ResourceRef(resource, file);
-	}
-
-	public static ResourceRef forCachedResource(String resource, Path cachedResource) {
-		return new ResourceRef(resource, cachedResource);
-	}
-
-	public static ResourceRef forResource(String resource) {
+	/**
+	 * Creates a new {@code ResourceRef} instance for the given resource string. It
+	 * does this by using a default resource resolver to resolve the resource string
+	 * to a file.
+	 *
+	 * @param resource the resource string used to create the resource reference
+	 * @return a {@code ResourceRef} instance representing the specified resource
+	 *         string
+	 */
+	static ResourceRef forResource(@Nonnull String resource) {
 		return ResourceResolver.forResources().resolve(resource);
 	}
 
-	public static boolean isStdin(String scriptResource) {
+	/**
+	 * Creates a new {@code ResourceRef} that lazily resolves the given resource
+	 * string using the provided resolver. It does this only when the
+	 * {@code getFile} method is called.
+	 *
+	 * @param resolver the resource resolver used to resolve the resource string
+	 * @param resource the resource string used to create the resource reference
+	 * @return a {@code ResourceRef} instance representing the specified resource
+	 *         string
+	 */
+	static ResourceRef lazy(@Nonnull ResourceResolver resolver, @Nonnull String resource) {
+		return new LazyResourceRef(resolver, resource);
+	}
+
+	static boolean isStdin(@Nonnull String scriptResource) {
 		return scriptResource.equals("-") || scriptResource.equals("/dev/stdin");
 	}
 }

--- a/src/main/java/dev/jbang/source/ResourceResolver.java
+++ b/src/main/java/dev/jbang/source/ResourceResolver.java
@@ -1,5 +1,8 @@
 package dev.jbang.source;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import dev.jbang.source.resolvers.*;
 
 /**
@@ -28,6 +31,7 @@ public interface ResourceResolver {
 	 * @param trusted  If the request should be considered trusted or not
 	 * @return A <code>ResourceRef</code> or <code>null</code>
 	 */
+	@Nullable
 	default ResourceRef resolve(String resource, boolean trusted) {
 		return resolve(resource);
 	}
@@ -48,10 +52,12 @@ public interface ResourceResolver {
 	 * @param resource The resource string to resolve
 	 * @return A <code>ResourceRef</code> or <code>null</code>
 	 */
+	@Nullable
 	default ResourceRef resolve(String resource) {
 		return resolve(resource, false);
 	}
 
+	@Nonnull
 	String description();
 
 	/**
@@ -60,6 +66,7 @@ public interface ResourceResolver {
 	 *
 	 * @return A <code>ResourceRef</code> or <code>null</code>
 	 */
+	@Nonnull
 	static ResourceResolver forResources() {
 		return new CombinedResourceResolver(
 				new RemoteResourceResolver(true),

--- a/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
 
 import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.Catalog;
+import dev.jbang.source.DirectResourceRef;
 import dev.jbang.source.ResourceRef;
 import dev.jbang.source.ResourceResolver;
 
@@ -24,6 +25,7 @@ public class AliasResourceResolver implements ResourceResolver {
 		this.resolverFactory = resolverFactory;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return String.format("Alias resolver from catalog %s using %s",
@@ -51,7 +53,7 @@ public class AliasResourceResolver implements ResourceResolver {
 		return ref;
 	}
 
-	public static class AliasedResourceRef extends ResourceRef {
+	public static class AliasedResourceRef extends DirectResourceRef {
 		@Nonnull
 		private final Alias alias;
 

--- a/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
+import dev.jbang.source.DirectResourceRef;
 import dev.jbang.source.ResourceRef;
 import dev.jbang.source.ResourceResolver;
 
@@ -21,6 +22,7 @@ import dev.jbang.source.ResourceResolver;
  * reference to that.
  */
 public class ClasspathResourceResolver implements ResourceResolver {
+	@Nonnull
 	@Override
 	public String description() {
 		return "Classpath resolver";
@@ -39,7 +41,7 @@ public class ClasspathResourceResolver implements ResourceResolver {
 		String ref = cpResource.substring(11);
 		ClassLoader cl = Thread.currentThread().getContextClassLoader();
 		if (cl == null) {
-			cl = ResourceRef.class.getClassLoader();
+			cl = DirectResourceRef.class.getClassLoader();
 		}
 		URL url = cl.getResource(ref);
 		if (url == null) {
@@ -49,7 +51,7 @@ public class ClasspathResourceResolver implements ResourceResolver {
 		return new ClasspathResourceRef(cpResource, url);
 	}
 
-	public static class ClasspathResourceRef extends ResourceRef {
+	public static class ClasspathResourceRef extends DirectResourceRef {
 		@Nonnull
 		private URL url;
 

--- a/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.source.ResourceRef;
 import dev.jbang.source.ResourceResolver;
 
@@ -30,6 +32,7 @@ public class CombinedResourceResolver implements ResourceResolver {
 			.orElse(null);
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return String.format("Chain of [%s]",

--- a/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
@@ -4,6 +4,8 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.source.ResourceRef;
 import dev.jbang.source.ResourceResolver;
 import dev.jbang.util.Util;
@@ -15,6 +17,7 @@ import dev.jbang.util.Util;
  */
 public class FileResourceResolver implements ResourceResolver {
 
+	@Nonnull
 	@Override
 	public String description() {
 		return "File Resource resolver";
@@ -32,7 +35,7 @@ public class FileResourceResolver implements ResourceResolver {
 		}
 
 		if (probe != null && Files.isReadable(probe)) {
-			result = ResourceRef.forNamedFile(resource, probe);
+			result = ResourceRef.forResolvedResource(resource, probe);
 		}
 
 		return result;

--- a/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
@@ -3,6 +3,8 @@ package dev.jbang.source.resolvers;
 import java.nio.file.Path;
 import java.util.function.Function;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.dependencies.ModularClassPath;
 import dev.jbang.source.ResourceRef;
@@ -20,6 +22,7 @@ public class GavResourceResolver implements ResourceResolver {
 		this.depResolver = depResolver;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return "Maven GAV";
@@ -36,7 +39,7 @@ public class GavResourceResolver implements ResourceResolver {
 			// one we asked for, which we assume is always the first one in the list
 			// (hopefully we're right).
 			Path file = mcp.getArtifacts().get(0).getFile();
-			result = ResourceRef.forCachedResource(resource, file);
+			result = ResourceRef.forResolvedResource(resource, file);
 		}
 
 		return result;

--- a/src/main/java/dev/jbang/source/resolvers/LazyResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/LazyResourceResolver.java
@@ -1,0 +1,39 @@
+package dev.jbang.source.resolvers;
+
+import javax.annotation.Nonnull;
+
+import dev.jbang.source.ResourceRef;
+import dev.jbang.source.ResourceResolver;
+
+/**
+ * A {@code LazyResourceResolver} is a wrapper around an existing
+ * {@link ResourceResolver} that enables lazy resolution of resources. This
+ * means that resource resolution is deferred until access to the resource
+ * content is explicitly requested, at which point the resource will be handed
+ * over to the wrapped resolver for resolution.
+ */
+public class LazyResourceResolver implements ResourceResolver {
+	private final ResourceResolver wrappedResolver;
+
+	public LazyResourceResolver(ResourceResolver wrappedResolver) {
+		this.wrappedResolver = wrappedResolver;
+	}
+
+	@Nonnull
+	@Override
+	public String description() {
+		return "Lazy Resource resolver";
+	}
+
+	@Override
+	public ResourceRef resolve(String resource, boolean trusted) {
+		return ResourceRef.lazy(wrappedResolver, resource);
+	}
+
+	public static ResourceResolver lazy(ResourceResolver resolver) {
+		if (resolver instanceof LazyResourceResolver) {
+			return resolver;
+		}
+		return new LazyResourceResolver(resolver);
+	}
+}

--- a/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.Cache;
 import dev.jbang.Settings;
 import dev.jbang.cli.BaseCommand;
@@ -46,6 +48,7 @@ public class LiteralScriptResourceResolver implements ResourceResolver {
 		return result;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return "Literal stdin";
@@ -64,7 +67,7 @@ public class LiteralScriptResourceResolver implements ResourceResolver {
 		}
 		Path scriptFile = cache.resolve(basename + suffix);
 		Util.writeString(scriptFile, scriptText);
-		result = ResourceRef.forCachedResource(resource, scriptFile);
+		result = ResourceRef.forResolvedResource(resource, scriptFile);
 		return result;
 	}
 }

--- a/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
@@ -9,6 +9,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 import dev.jbang.net.TrustedSources;
@@ -28,6 +30,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 		this.alwaysTrust = alwaysTrust;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return String.format("%s remote resource", alwaysTrust ? "Trusted" : "Non-trusted");
@@ -91,7 +94,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 
 			Path path = Util.swizzleContent(swizzledUrl, Util.downloadAndCacheFile(swizzledUrl));
 
-			return ResourceRef.forCachedResource(scriptURL, path);
+			return ResourceRef.forResolvedResource(scriptURL, path);
 		} catch (IOException | URISyntaxException e) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
 		}
@@ -114,7 +117,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 		try {
 			String url = swizzleURL(scriptURL);
 			Path path = Util.downloadAndCacheFile(url);
-			return ResourceRef.forCachedResource(scriptURL, path);
+			return ResourceRef.forResolvedResource(scriptURL, path);
 		} catch (IOException e) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not download " + scriptURL, e);
 		}

--- a/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
@@ -7,6 +7,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.Cache;
 import dev.jbang.Settings;
 import dev.jbang.cli.BaseCommand;
@@ -30,6 +32,7 @@ public class RenamingScriptResourceResolver implements ResourceResolver {
 		this.forceType = forceType;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return "Renaming resolver";
@@ -90,7 +93,7 @@ public class RenamingScriptResourceResolver implements ResourceResolver {
 						.resolve(Util.unkebabify(name));
 					tempFile.getParent().toFile().mkdirs();
 					Util.writeString(tempFile.toAbsolutePath(), original);
-					result = ResourceRef.forCachedResource(resource, tempFile);
+					result = ResourceRef.forResolvedResource(resource, tempFile);
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
@@ -5,6 +5,8 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import javax.annotation.Nonnull;
+
 import dev.jbang.catalog.Catalog;
 import dev.jbang.cli.ResourceNotFoundException;
 import dev.jbang.source.ResourceRef;
@@ -25,6 +27,7 @@ public class SiblingResourceResolver implements ResourceResolver {
 		this.resolver = resolver;
 	}
 
+	@Nonnull
 	@Override
 	public String description() {
 		return String.format("%s via %s", sibling.getOriginalResource(), resolver.description());

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -210,7 +210,7 @@ public class TestProjectBuilder extends BaseTest {
 				ResourceRef.forFile(examplesTestFolder.resolve("gh_release_stats.java")),
 				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedTwo.java")),
 				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedOne.java")),
-				ResourceRef.forNamedFile("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(4));
 		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
 				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")), null),
@@ -218,7 +218,7 @@ public class TestProjectBuilder extends BaseTest {
 						Paths.get("renamed.properties")),
 				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
 						Paths.get("META-INF/application.properties")),
-				RefTarget.create(ResourceRef.forNamedFile("res/test.properties",
+				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
 						examplesTestFolder.resolve("res/test.properties")), null)));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(6));
 		assertThat(prj.getMainSourceSet().getDependencies(), contains(
@@ -266,10 +266,10 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getRuntimeOptions(), contains("-Dfoo=bar", "-Dbar=aap noot mies"));
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(1));
 		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				ResourceRef.forNamedFile("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(1));
 		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forNamedFile("res/test.properties",
+				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
 						examplesTestFolder.resolve("res/test.properties")), null)));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(1));
 		assertThat(prj.getMainSourceSet().getDependencies(), contains("twodep"));
@@ -307,10 +307,10 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getRuntimeOptions(), contains("-Dfoo=bar", "-Dbar=aap noot mies"));
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(1));
 		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				ResourceRef.forNamedFile("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(1));
 		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forNamedFile("res/test.properties",
+				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
 						examplesTestFolder.resolve("res/test.properties")), null)));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(2));
 		assertThat(prj.getMainSourceSet().getDependencies(), contains(

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -104,7 +104,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		TestSource.createTmpFileWithContent(HiJBangPath.getParent(), "inner", "HelloInner.java",
 				classHelloInner);
 		String scriptURL = mainPath.toString();
-		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
+		ResourceRef resourceRef = ResourceRef.forResolvedResource(scriptURL, mainPath);
 		Source script = Source.forResourceRef(resourceRef, null);
 		Project prj = Project.builder().build(script);
 		List<ResourceRef> sources = prj.getMainSourceSet().getSources();
@@ -140,7 +140,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		TestSource.createTmpFileWithContent(HiJBangPath.getParent(), "inner", "HelloInner.java",
 				classHelloInner);
 		String scriptURL = mainPath.toString();
-		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
+		ResourceRef resourceRef = ResourceRef.forResolvedResource(scriptURL, mainPath);
 		Source source = Source.forResourceRef(resourceRef, null);
 		Assertions.assertThrows(ResourceNotFoundException.class, () -> Project.builder().build(source));
 	}

--- a/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesRecursivelyMultipleFiles.java
@@ -77,7 +77,7 @@ class TestSourcesRecursivelyMultipleFiles extends BaseTest {
 		TestSource.createTmpFileWithContent(HiJBangPath.getParent(), "inner", "HelloInner.java",
 				classHelloInner);
 		String scriptURL = mainPath.toString();
-		ResourceRef resourceRef = ResourceRef.forNamedFile(scriptURL, mainPath);
+		ResourceRef resourceRef = ResourceRef.forResolvedResource(scriptURL, mainPath);
 		Source script = Source.forResourceRef(resourceRef, null);
 		Project prj = Project.builder().build(script);
 		List<ResourceRef> sources = prj.getMainSourceSet().getSources();


### PR DESCRIPTION
Turned `ResourceRef` into an interface and added `LazyResourceRef` and `LazyResourceResolver` to allow for lazy loading of resources. This is especially useful for those resources that we don't need to download locally, but where we are only interested in the original resource reference (mostly the case for URLs).