### PR TITLE
fix: handle long command lines for .bat and .cmd

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -178,7 +178,7 @@ class AppInstall extends BaseCommand {
 		cmd.add(scriptRef);
 		cmd.addAll(runArgs);
 		CommandBuffer cb = CommandBuffer.of(cmd);
-		List<String> lines = Arrays.asList("#!/bin/sh", cb.asCommandLine(Util.Shell.bash) + " \"$@\"");
+		List<String> lines = Arrays.asList("#!/bin/sh", cb.shell(Util.Shell.bash).asCommandLine() + " \"$@\"");
 		Files.write(file, lines, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
 		if (!Util.isWindows()) {
 			Util.setExecutable(file);
@@ -193,7 +193,7 @@ class AppInstall extends BaseCommand {
 		cmd.add(scriptRef);
 		cmd.addAll(runArgs);
 		CommandBuffer cb = CommandBuffer.of(cmd);
-		List<String> lines = Arrays.asList("@echo off", cb.asCommandLine(Util.Shell.cmd) + " %*");
+		List<String> lines = Arrays.asList("@echo off", cb.shell(Util.Shell.cmd).asCommandLine() + " %*");
 		Files.write(file, lines, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
 	}
 
@@ -205,7 +205,7 @@ class AppInstall extends BaseCommand {
 		cmd.add(scriptRef);
 		cmd.addAll(runArgs);
 		CommandBuffer cb = CommandBuffer.of(cmd);
-		List<String> lines = Collections.singletonList(cb.asCommandLine(Util.Shell.powershell) + " @args");
+		List<String> lines = Collections.singletonList(cb.shell(Util.Shell.powershell).asCommandLine() + " @args");
 		Files.write(file, lines, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
 	}
 

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -261,10 +261,10 @@ public class Edit extends BaseCommand {
 
 			String[] cmd;
 			if (Util.getShell() == Shell.bash) {
-				final String editorCommand = CommandBuffer.of(optionList).asCommandLine(Shell.bash);
+				final String editorCommand = CommandBuffer.of(optionList).shell(Shell.bash).asCommandLine();
 				cmd = new String[] { "sh", "-c", editorCommand };
 			} else {
-				final String editorCommand = CommandBuffer.of(optionList).asCommandLine(Shell.cmd);
+				final String editorCommand = CommandBuffer.of(optionList).shell(Shell.cmd).asCommandLine();
 				cmd = new String[] { "cmd", "/c", editorCommand };
 			}
 			verboseMsg("Running `" + String.join(" ", cmd) + "`");

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -133,8 +133,7 @@ public abstract class CompileBuildStep implements Builder<Project> {
 
 	protected void runCompiler(List<String> optionList) throws IOException {
 		runCompiler(CommandBuffer.of(optionList)
-			.applyWindowsMaxLengthLimit(CommandBuffer.MAX_LENGTH_WINPROCBUILDER,
-					Util.getShell())
+			.applyWindowsMaxLengthLimit()
 			.asProcessBuilder()
 			.inheritIO());
 	}

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -6,7 +6,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -23,7 +22,6 @@ import org.jboss.jandex.Type;
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.MavenCoordinate;
-import dev.jbang.devkitman.Jdk;
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.Builder;
 import dev.jbang.source.Project;
@@ -57,38 +55,33 @@ public abstract class CompileBuildStep implements Builder<Project> {
 	}
 
 	protected Project compile() throws IOException {
-		Project project = ctx.getProject();
-		Jdk jdk = project.projectJdk();
-		String requestedJavaVersion = project.getJavaVersion();
-		if (requestedJavaVersion == null
-				&& project.getModuleName().isPresent()
-				&& jdk.majorVersion() < 9) {
-			// Make sure we use at least Java 9 when dealing with modules
-			requestedJavaVersion = "9+";
-			jdk = project.projectJdkManager().getOrInstallJdk(requestedJavaVersion);
-		}
+		List<String> compileCmd = getCompileCommand();
 
-		Path compileDir = ctx.getCompileDir();
-		List<String> optionList = new ArrayList<>();
-		optionList.add(getCompilerBinary(requestedJavaVersion));
-		if (project.enablePreview()) {
-			optionList.add("--enable-preview");
-			optionList.add("-source");
-			optionList.add("" + jdk.majorVersion());
-		}
-		optionList.addAll(project.getMainSourceSet().getCompileOptions());
-		String path = ctx.resolveClassPath().getClassPath();
-		if (!Util.isBlankString(path)) {
-			if (project.getModuleName().isPresent()) {
-				optionList.addAll(Arrays.asList("-p", path));
-			} else {
-				optionList.addAll(Arrays.asList("-classpath", path));
-			}
-		}
-		optionList.addAll(Arrays.asList("-d", compileDir.toAbsolutePath().toString()));
+		// add additional files
+		Project project = ctx.getProject();
+		project.getMainSourceSet().copyResourcesTo(ctx.getCompileDir());
+
+		generatePom();
+
+		Util.infoMsg(String.format("Building %s for %s...", project.getMainSource().isAgent() ? "javaagent" : "jar",
+				project.getResourceRef().getFile().getFileName().toString()));
+		Util.verboseMsg("Compile: " + String.join(" ", compileCmd));
+		runCompiler(compileCmd);
+
+		searchForMain(ctx.getCompileDir());
+
+		return project;
+	}
+
+	protected List<String> getCompileCommand() throws IOException {
+		List<String> compileCmd = new ArrayList<>();
+
+		Project project = ctx.getProject();
+		compileCmd.add(getCompilerBinary());
+		compileCmd.addAll(getCompileCommandOptions());
 
 		// add source files to compile
-		optionList.addAll(project.getMainSourceSet()
+		compileCmd.addAll(project.getMainSourceSet()
 			.getSources()
 			.stream()
 			.map(x -> x.getFile().toString())
@@ -103,24 +96,12 @@ public abstract class CompileBuildStep implements Builder<Project> {
 				// generate module-info descriptor and add it to list of files to compile
 				Path infoFile = ModuleUtil.generateModuleInfo(ctx);
 				if (infoFile != null) {
-					optionList.add(infoFile.toString());
+					compileCmd.add(infoFile.toString());
 				}
 			}
 		}
 
-		// add additional files
-		project.getMainSourceSet().copyResourcesTo(compileDir);
-
-		generatePom();
-
-		Util.infoMsg(String.format("Building %s for %s...", project.getMainSource().isAgent() ? "javaagent" : "jar",
-				project.getResourceRef().getFile().getFileName().toString()));
-		Util.verboseMsg("Compile: " + String.join(" ", optionList));
-		runCompiler(optionList);
-
-		searchForMain(compileDir);
-
-		return project;
+		return compileCmd;
 	}
 
 	private boolean hasModuleInfoFile() {
@@ -130,6 +111,10 @@ public abstract class CompileBuildStep implements Builder<Project> {
 			.stream()
 			.anyMatch(s -> s.getFile().getFileName().toString().equals("module-info.java"));
 	}
+
+	protected abstract String getCompilerBinary();
+
+	protected abstract List<String> getCompileCommandOptions() throws IOException;
 
 	protected void runCompiler(List<String> optionList) throws IOException {
 		runCompiler(CommandBuffer.of(optionList)
@@ -285,13 +270,10 @@ public abstract class CompileBuildStep implements Builder<Project> {
 		}
 	}
 
-	protected abstract String getCompilerBinary(String requestedJavaVersion);
-
 	protected abstract String getMainExtension();
 
 	protected Predicate<ClassInfo> getMainFinder() {
 		return pubClass -> (pubClass.method("main", STRINGARRAYTYPE) != null
-				||
-				pubClass.method("main") != null);
+				|| pubClass.method("main") != null);
 	}
 }

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -72,7 +72,7 @@ public class NativeBuildStep implements Builder<Project> {
 		Util.verboseMsg("native-image: " + String.join(" ", optionList));
 
 		ProcessBuilder pb = CommandBuffer.of(optionList)
-			.applyWindowsMaxLengthLimit(32000, Util.getShell())
+			.applyWindowsMaxLengthLimit()
 			.asProcessBuilder()
 			.inheritIO();
 

--- a/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/BaseCmdGenerator.java
@@ -56,6 +56,6 @@ public abstract class BaseCmdGenerator<T extends CmdGenerator> implements CmdGen
 
 	protected String generateCommandLineString(List<String> fullArgs) throws IOException {
 		CommandBuffer cb = CommandBuffer.of(fullArgs);
-		return cb.asCommandLine(shell);
+		return cb.shell(shell).asCommandLine();
 	}
 }

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -199,8 +199,9 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 
 	protected String generateCommandLineString(List<String> fullArgs) throws IOException {
 		return CommandBuffer.of(fullArgs)
-			.applyWindowsMaxLengthLimit(CommandBuffer.MAX_LENGTH_WINCLI, shell)
-			.asCommandLine(shell);
+			.shell(shell)
+			.applyWindowsMaxLengthLimit(CommandBuffer.MAX_LENGTH_WINCLI)
+			.asCommandLine();
 	}
 
 	private static void addPropertyFlags(Map<String, String> properties, String def, List<String> result) {

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -2,6 +2,9 @@ package dev.jbang.source.sources;
 
 import static dev.jbang.util.JavaUtil.resolveInJavaHome;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
@@ -11,6 +14,7 @@ import dev.jbang.devkitman.Jdk;
 import dev.jbang.source.*;
 import dev.jbang.source.AppBuilder;
 import dev.jbang.source.buildsteps.CompileBuildStep;
+import dev.jbang.util.Util;
 
 public class JavaSource extends Source {
 
@@ -68,10 +72,42 @@ public class JavaSource extends Source {
 			}
 
 			@Override
-			protected String getCompilerBinary(String requestedJavaVersion) {
-				Project prj = ctx.getProject();
-				Jdk jdk = prj.projectJdkManager().getOrInstallJdk(requestedJavaVersion);
+			protected String getCompilerBinary() {
+				Project project = ctx.getProject();
+				Jdk jdk = project.projectJdk();
+				String requestedJavaVersion = project.getJavaVersion();
+				if (requestedJavaVersion == null
+						&& project.getModuleName().isPresent()
+						&& jdk.majorVersion() < 9) {
+					// Make sure we use at least Java 9 when dealing with modules
+					requestedJavaVersion = "9+";
+					jdk = project.projectJdkManager().getOrInstallJdk(requestedJavaVersion);
+				}
 				return resolveInJavaHome("javac", jdk);
+			}
+
+			@Override
+			protected List<String> getCompileCommandOptions() throws IOException {
+				List<String> optionList = new ArrayList<>();
+
+				Project project = ctx.getProject();
+				if (project.enablePreview()) {
+					optionList.add("--enable-preview");
+					optionList.add("-source");
+					optionList.add("" + project.projectJdk().majorVersion());
+				}
+				optionList.addAll(project.getMainSourceSet().getCompileOptions());
+				String path = ctx.resolveClassPath().getClassPath();
+				if (!Util.isBlankString(path)) {
+					if (project.getModuleName().isPresent()) {
+						optionList.addAll(Arrays.asList("-p", path));
+					} else {
+						optionList.addAll(Arrays.asList("-classpath", path));
+					}
+				}
+				optionList.addAll(Arrays.asList("-d", ctx.getCompileDir().toAbsolutePath().toString()));
+
+				return optionList;
 			}
 
 			@Override

--- a/src/test/java/dev/jbang/util/TestCommandBuffer.java
+++ b/src/test/java/dev/jbang/util/TestCommandBuffer.java
@@ -4,42 +4,102 @@ import static dev.jbang.util.Util.JBANG_RUNTIME_SHELL;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
+import java.io.IOException;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import dev.jbang.BaseTest;
 
 public class TestCommandBuffer extends BaseTest {
 
 	@Test
+	@EnabledOnOs(OS.WINDOWS)
 	void testRunWinBat() {
-		if (Util.getOS() == Util.OS.windows) {
-			String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
-					"abc=def", "abc,def");
-			assertThat(out, containsString("ARG = abc def"));
-			assertThat(out, containsString("ARG = abc;def"));
-			assertThat(out, containsString("ARG = abc=def"));
-			assertThat(out, containsString("ARG = abc,def"));
-		}
+		String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
+				"abc=def", "abc,def");
+		assertThat(out, containsString("ARG = abc def"));
+		assertThat(out, containsString("ARG = abc;def"));
+		assertThat(out, containsString("ARG = abc=def"));
+		assertThat(out, containsString("ARG = abc,def"));
 	}
 
 	@Test
+	@EnabledOnOs(OS.WINDOWS)
 	void testRunWinBatFromBash() {
-		if (Util.getOS() == Util.OS.windows) {
-			environmentVariables.set(JBANG_RUNTIME_SHELL, "bash");
-			String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
-					"abc=def", "abc,def");
-			assertThat(out, containsString("ARG = abc def"));
-			assertThat(out, containsString("ARG = abc;def"));
-			assertThat(out, containsString("ARG = abc=def"));
-			assertThat(out, containsString("ARG = abc,def"));
-		}
+		environmentVariables.set(JBANG_RUNTIME_SHELL, "bash");
+		String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
+				"abc=def", "abc,def");
+		assertThat(out, containsString("ARG = abc def"));
+		assertThat(out, containsString("ARG = abc;def"));
+		assertThat(out, containsString("ARG = abc=def"));
+		assertThat(out, containsString("ARG = abc,def"));
 	}
 
 	@Test
+	@EnabledOnOs(OS.WINDOWS)
 	void testRunWinPS1() {
-		if (Util.getOS() == Util.OS.windows) {
-			String out = CommandBuffer.of("abc def", "abc;def").asCommandLine(Util.Shell.powershell);
-			assertThat(out, equalTo("'abc def' 'abc;def'"));
+		String out = CommandBuffer.of("abc def", "abc;def").shell(Util.Shell.powershell).asCommandLine();
+		assertThat(out, equalTo("'abc def' 'abc;def'"));
+	}
+
+	@Test
+	void testApplyWindowsMaxLengthLimitExe() throws IOException {
+		ProcessBuilder pb = CommandBuffer.of(argsTooLong("foo.exe"))
+			.shell(Util.Shell.cmd)
+			.applyWindowsMaxLengthLimit()
+			.asProcessBuilder();
+		assertThat(pb.command().size(), greaterThan(2));
+		assertThat(pb.command().get(1), not(anyOf(startsWith("@"), startsWith("\"@"))));
+	}
+
+	@Test
+	void testApplyWindowsMaxLengthLimitBat() throws IOException {
+		ProcessBuilder pb = CommandBuffer.of(argsTooLong("foo.bat"))
+			.shell(Util.Shell.cmd)
+			.applyWindowsMaxLengthLimit()
+			.asProcessBuilder();
+		assertThat(pb.command().size(), equalTo(2));
+		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+	}
+
+	@Test
+	void testApplyWindowsMaxLengthLimitCmd() throws IOException {
+		ProcessBuilder pb = CommandBuffer.of(argsTooLong("foo.cmd"))
+			.shell(Util.Shell.cmd)
+			.applyWindowsMaxLengthLimit()
+			.asProcessBuilder();
+		assertThat(pb.command().size(), equalTo(2));
+		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+	}
+
+	@Test
+	void testUsingArgsFileWith1Arg() throws IOException {
+		ProcessBuilder pb = CommandBuffer.of("abc").usingArgsFile().asProcessBuilder();
+		assertThat(pb.command().size(), equalTo(1));
+	}
+
+	@Test
+	void testUsingArgsFileWith3Args() throws IOException {
+		ProcessBuilder pb = CommandBuffer.of("abc", "def", "ghi").usingArgsFile().asProcessBuilder();
+		assertThat(pb.command().size(), equalTo(2));
+		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+	}
+
+	@Test
+	void testUsingArgsFileNoDup() throws IOException {
+		CommandBuffer cmd = CommandBuffer.of("abc", "def", "ghi").usingArgsFile();
+		CommandBuffer cmd2 = cmd.usingArgsFile();
+		assertThat(cmd, is(cmd2));
+	}
+
+	private String[] argsTooLong(String cmd) {
+		String[] args = new String[1000];
+		args[0] = cmd;
+		for (int i = 1; i < args.length; i++) {
+			args[i] = "argument " + i;
 		}
+		return args;
 	}
 }


### PR DESCRIPTION
On Windows when using Java's `ProcessBuilder` to run .bat or .cmd files we have to ensure that the command line does not exceed the maximum length allowed by the Windows command line.

Fixes #2033

