### PR TITLE
fix: pass `app install` build options to pre-build process

### DIFF
--- a/itests/repos.java
+++ b/itests/repos.java
@@ -1,0 +1,12 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//REPOS central
+//DEPS org.mariadb.jdbc:mariadb-java-client:3.4.1.redhat-00001
+
+import static java.lang.System.*;
+
+public class repos {
+
+    public static void main(String... args) {
+        out.println("if installed is ok");
+    }
+}

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -48,11 +48,10 @@ public class App {
 }
 
 @CommandLine.Command(name = "install", description = "Install a script as a command.")
-class AppInstall extends BaseCommand {
+class AppInstall extends BaseBuildCommand {
 	private static final String jbangUrl = "https://www.jbang.dev/releases/latest/download/jbang.zip";
 
-	@CommandLine.Option(names = {
-			"--force" }, description = "Force re-installation")
+	@CommandLine.Option(names = { "--force" }, description = "Force re-installation")
 	boolean force;
 
 	@CommandLine.Option(names = { "--no-build" }, description = "Don't pre-build the code before installation")
@@ -62,22 +61,7 @@ class AppInstall extends BaseCommand {
 	String name;
 
 	@CommandLine.Mixin
-	ScriptMixin scriptMixin;
-
-	@CommandLine.Mixin
-	BuildMixin buildMixin;
-
-	@CommandLine.Mixin
-	DependencyInfoMixin dependencyInfoMixin;
-
-	@CommandLine.Mixin
-	NativeMixin nativeMixin;
-
-	@CommandLine.Mixin
 	RunMixin runMixin;
-
-	@CommandLine.Option(names = { "--enable-preview" }, description = "Activate Java preview features")
-	Boolean enablePreviewRequested;
 
 	@CommandLine.Parameters(index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
 	public List<String> userParams = new ArrayList<>();
@@ -85,6 +69,7 @@ class AppInstall extends BaseCommand {
 	@Override
 	public Integer doCall() {
 		scriptMixin.validate();
+		// dependencyInfoMixin.validate();
 		boolean installed = false;
 		try {
 			if (scriptMixin.scriptOrFile.equals("jbang")) {
@@ -100,8 +85,7 @@ class AppInstall extends BaseCommand {
 				if (name != null && !CatalogUtil.isValidName(name)) {
 					throw new IllegalArgumentException("Not a valid command name: '" + name + "'");
 				}
-				List<String> runOpts = collectRunOptions();
-				installed = install(name, scriptMixin.scriptOrFile, force, runOpts, userParams);
+				installed = install();
 			}
 			if (installed) {
 				if (AppSetup.needsSetup()) {
@@ -127,14 +111,14 @@ class AppInstall extends BaseCommand {
 		return opts;
 	}
 
-	public static boolean install(String name, String scriptRef, boolean force, List<String> runOpts,
-			List<String> runArgs) throws IOException {
+	public boolean install() throws IOException {
 		Path binDir = Settings.getConfigBinDir();
 		if (!force && name != null && existScripts(binDir, name)) {
 			Util.infoMsg("A script with name '" + name + "' already exists, use '--force' to install anyway.");
 			return false;
 		}
-		ProjectBuilder pb = Project.builder();
+		String scriptRef = scriptMixin.scriptOrFile;
+		ProjectBuilder pb = createProjectBuilder();
 		Project prj = pb.build(scriptRef);
 		if (name == null) {
 			name = CatalogUtil.nameFromRef(scriptRef);
@@ -153,6 +137,10 @@ class AppInstall extends BaseCommand {
 		installScripts(name, scriptRef, collectRunOptions(), userParams);
 		Util.infoMsg("Command installed: " + name);
 		return true;
+	}
+
+	ProjectBuilder createProjectBuilder() {
+		return createBaseProjectBuilder().mainClass(buildMixin.main);
 	}
 
 	private static boolean existScripts(Path binDir, String name) {

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -55,6 +55,9 @@ class AppInstall extends BaseCommand {
 			"--force" }, description = "Force re-installation")
 	boolean force;
 
+	@CommandLine.Option(names = { "--no-build" }, description = "Don't pre-build the code before installation")
+	boolean noBuild;
+
 	@CommandLine.Option(names = { "--name" }, description = "A name for the command")
 	String name;
 
@@ -144,8 +147,10 @@ class AppInstall extends BaseCommand {
 				&& !prj.getResourceRef().isURL()) {
 			scriptRef = prj.getResourceRef().getFile().toAbsolutePath().toString();
 		}
-		prj.codeBuilder().build();
-		installScripts(name, scriptRef, runOpts, runArgs);
+		if (!noBuild) {
+			prj.codeBuilder().build();
+		}
+		installScripts(name, scriptRef, collectRunOptions(), userParams);
 		Util.infoMsg("Command installed: " + name);
 		return true;
 	}

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -56,7 +56,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFile() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -69,7 +69,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppNativeInstallFile() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", "--native", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--native", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -82,7 +82,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallExtensionLessFile() throws Exception {
 		String src = examplesTestFolder.resolve("kubectl-example").toString();
-		CaptureResult result = checkedRun(null, "app", "install", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: kubectl-example"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -95,7 +95,7 @@ public class TestApp extends BaseTest {
 	@Test
 	@Timeout(value = 2, unit = TimeUnit.MINUTES)
 	void testAppInstallURL() throws Exception {
-		CaptureResult result = checkedRun(null, "app", "install",
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build",
 				"https://github.com/jbangdev/k8s-cli-java/blob/jbang/kubectl-example");
 		assertThat(result.err, containsString("Command installed: kubectl-example"));
 		if (Util.isWindows()) {
@@ -108,7 +108,7 @@ public class TestApp extends BaseTest {
 
 	@Test
 	void testAppInstallGVA() throws Exception {
-		CaptureResult result = checkedRun(null, "app", "install", "--name", "h2",
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name", "h2",
 				"com.h2database:h2:1.4.200");
 		assertThat(result.err, containsString("Command installed: h2"));
 		if (Util.isWindows()) {
@@ -130,14 +130,14 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFileExists() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
-		result = checkedRun(null, "app", "install", src);
+		result = checkedRun(null, "app", "install", "--no-build", src);
 		assertThat(result.err,
 				containsString("A script with name 'helloworld' already exists, use '--force' to install anyway."));
 	}
@@ -145,14 +145,14 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFileForce() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
-		result = checkedRun(null, "app", "install", "--force", src);
+		result = checkedRun(null, "app", "install", "--no-build", "--force", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		testScripts();
 	}
@@ -191,7 +191,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFileWithName() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", "--name=hello", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -206,14 +206,14 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFileWithNameExists() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", "--name=hello", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
-		result = checkedRun(null, "app", "install", "--name=hello", src);
+		result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err,
 				containsString("A script with name 'hello' already exists, use '--force' to install anyway."));
 	}
@@ -221,14 +221,14 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallFileWithNameForce() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		CaptureResult result = checkedRun(null, "app", "install", "--name=hello", src);
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
-		result = checkedRun(null, "app", "install", "--force", "--name=hello", src);
+		result = checkedRun(null, "app", "install", "--no-build", "--force", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 	}
 
@@ -236,7 +236,7 @@ public class TestApp extends BaseTest {
 	void testAppInstallAlias() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		checkedRun(null, "alias", "add", "-g", "--name=apptest", src);
-		CaptureResult result = checkedRun(null, "app", "install", "apptest");
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "apptest");
 		assertThat(result.err, containsString("Command installed: apptest"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -254,7 +254,7 @@ public class TestApp extends BaseTest {
 		checkedRun(null, "alias", "add", "-g", "--name=apptest", src);
 		checkedRun(null, "catalog", "add", "-g", "--name=testrepo",
 				jbangTempDir.resolve("jbang-catalog.json").toString());
-		CaptureResult result = checkedRun(null, "app", "install", "apptest@testrepo");
+		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "apptest@testrepo");
 		assertThat(result.err, containsString("Command installed: apptest"));
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
@@ -269,7 +269,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallInvalidName() throws Exception {
 		try {
-			checkedRun(null, "app", "install", "--name=invalid>name", "def/not/existing/file");
+			checkedRun(null, "app", "install", "--no-build", "--name=invalid>name", "def/not/existing/file");
 			Assert.fail();
 		} catch (IllegalArgumentException e) {
 			assertThat(e.getMessage(), containsString("Not a valid command name"));
@@ -279,7 +279,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppInstallInvalidRef() throws Exception {
 		try {
-			checkedRun(null, "app", "install", "def/not/existing/file");
+			checkedRun(null, "app", "install", "--no-build", "def/not/existing/file");
 			Assert.fail();
 		} catch (ExitException e) {
 			assertThat(e.getMessage(),
@@ -290,9 +290,9 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppList() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		checkedRun(null, "app", "install", "--name=hello1", src);
-		checkedRun(null, "app", "install", "--name=hello2", src);
-		checkedRun(null, "app", "install", "--name=hello3", src);
+		checkedRun(null, "app", "install", "--no-build", "--name=hello1", src);
+		checkedRun(null, "app", "install", "--no-build", "--name=hello2", src);
+		checkedRun(null, "app", "install", "--no-build", "--name=hello3", src);
 		CaptureResult result = checkedRun(null, "app", "list");
 		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		assertThat(result.normalizedOut(), equalTo("hello1\nhello2\nhello3\n"));
@@ -301,7 +301,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppUninstall() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
-		checkedRun(null, "app", "install", src);
+		checkedRun(null, "app", "install", "--no-build", src);
 		if (Util.isWindows()) {
 			assertThat(Settings.getConfigBinDir().resolve("helloworld.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("helloworld.ps1").toFile(), anExistingFile());

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -1,10 +1,7 @@
 package dev.jbang.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -22,7 +19,12 @@ import org.junit.jupiter.api.Timeout;
 
 import dev.jbang.BaseTest;
 import dev.jbang.Settings;
+import dev.jbang.dependencies.MavenRepo;
+import dev.jbang.source.Project;
+import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.Util;
+
+import picocli.CommandLine;
 
 public class TestApp extends BaseTest {
 	private static final List<String> shContents = Arrays.asList("#!/bin/sh",
@@ -64,6 +66,19 @@ public class TestApp extends BaseTest {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
 		testScripts();
+	}
+
+	@Test
+	void testAppInstallWithRepos() throws Exception {
+		String src = examplesTestFolder.resolve("repos.java").toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine()
+			.parseArgs("app", "install", "--no-build", "--fresh", "--force",
+					"--repos=https://maven.repository.redhat.com/ga/", src);
+		AppInstall app = (AppInstall) pr.subcommand().subcommand().commandSpec().userObject();
+
+		ProjectBuilder pb = app.createProjectBuilder();
+		Project prj = pb.build(src);
+		assertThat(prj.getRepositories(), hasItem(new MavenRepo("central", "https://repo1.maven.org/maven2/")));
 	}
 
 	@Test


### PR DESCRIPTION
Because "app install" pre-builds the app that it installs, it's not
enough to only copy the build options to the installed app startup
script, but they also need to be passed to the pre-build process and
that was missing.

Fixes https://github.com/jbangdev/jbang/issues/2043

also:

feat: added --no-build option to app install