### PR TITLE
fix: testing that user doesn't pass folder to --cp

### DIFF
--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -97,6 +97,7 @@ class AliasAdd extends BaseAliasCommand {
 	@Override
 	public Integer doCall() {
 		scriptMixin.validate();
+		dependencyInfoMixin.validate();
 		if (name != null && !Catalog.isValidName(name)) {
 			throw new IllegalArgumentException(
 					"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -82,6 +82,7 @@ class AppInstall extends BaseCommand {
 	@Override
 	public Integer doCall() {
 		scriptMixin.validate();
+		dependencyInfoMixin.validate();
 		boolean installed = false;
 		try {
 			if (scriptMixin.scriptOrFile.equals("jbang")) {

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -14,6 +14,7 @@ public class Build extends BaseBuildCommand {
 	@Override
 	public Integer doCall() throws IOException {
 		scriptMixin.validate();
+		dependencyInfoMixin.validate();
 
 		ProjectBuilder pb = createProjectBuilderForBuild();
 		Project prj = pb.build(scriptMixin.scriptOrFile);

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -1,5 +1,7 @@
 package dev.jbang.cli;
 
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,17 @@ public class DependencyInfoMixin {
 
 	public Map<String, String> getProperties() {
 		return properties;
+	}
+
+	public void validate() {
+		if (classpaths != null) {
+			for (String cp : classpaths) {
+				if (Files.isDirectory(Paths.get(cp))) {
+					throw new IllegalArgumentException(
+							"Invalid classpath option, directories are not supported: " + cp);
+				}
+			}
+		}
 	}
 
 	public List<String> opts() {

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -132,6 +132,8 @@ public class Edit extends BaseCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
+		scriptMixin.validate(false);
+		dependencyInfoMixin.validate();
 
 		// force download sources when editing
 		Util.setDownloadSources(true);

--- a/src/main/java/dev/jbang/cli/ExportMixin.java
+++ b/src/main/java/dev/jbang/cli/ExportMixin.java
@@ -51,6 +51,7 @@ public class ExportMixin {
 
 	public void validate() {
 		scriptMixin.validate();
+		dependencyInfoMixin.validate();
 		if (nativeImage) {
 			throw new IllegalArgumentException(
 					"The `-n` and `--native` flags have been removed, use `jbang export native` instead.");

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -210,6 +210,7 @@ abstract class BaseInfoCommand extends BaseCommand {
 
 	ScriptInfo getInfo(boolean assureJdkInstalled) {
 		scriptMixin.validate();
+		dependencyInfoMixin.validate();
 
 		ProjectBuilder pb = createProjectBuilder();
 		Project prj = pb.build(scriptMixin.scriptOrFile);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -49,6 +49,9 @@ public class Run extends BaseBuildCommand {
 
 	@Override
 	public Integer doCall() throws IOException {
+		scriptMixin.validate(false);
+		dependencyInfoMixin.validate();
+
 		requireScriptArgument();
 		rewriteScriptArguments();
 

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -362,6 +362,14 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testClasspathFolder() throws IOException {
+		String arg = examplesTestFolder.resolve("helloworld.java").toAbsolutePath().toString();
+		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--cp", ".", arg);
+		Run run = (Run) pr.subcommand().commandSpec().userObject();
+		assertThrows(IllegalArgumentException.class, run::doCall);
+	}
+
+	@Test
 	void testJarViaHttps(@TempDir Path tdir) throws IOException {
 
 		String jar = "https://repo1.maven.org/maven2/io/joshworks/runnable-jar/0.2/runnable-jar-0.2.jar";


### PR DESCRIPTION
Fixes #2045

## Summary by Sourcery

Disallow users from passing directories to the --cp option by validating classpath entries and throwing an error when a directory is detected, and ensure this validation runs across all CLI commands.

Bug Fixes:
- Reject directories passed to --cp and report an illegal argument error

Enhancements:
- Introduce a shared validate() method for DependencyInfoMixin and invoke it in all relevant commands

Tests:
- Add a test to verify that passing a folder to --cp raises an IllegalArgumentException