### PR TITLE
fix: jdkproviders were being set to the wrong value

### DIFF
--- a/src/main/resources/jbang.properties
+++ b/src/main/resources/jbang.properties
@@ -1,6 +1,5 @@
 format=text
 init.template=hello
-jdkproviders=current,default,javahome,path,jbang
 run.debug=4004
 run.jfr=filename={baseName}.jfr
 wrapper.install.dir=.


### PR DESCRIPTION
But it shouldn't have been set to any value in the first place. If no value is set in the config it will default to a list of providers defined by devkitman.

Fixes #2057
