### PR TITLE
chore: enable toolchain for gradle using java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,13 @@ repositories {
 }
 
 java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(11)
+	}
 	withJavadocJar()
 	withSourcesJar()
 }
+
 
 // See https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportingExtension.html
 // Extension is provided via Gradle's `reporting-base` plugin

--- a/readme.adoc
+++ b/readme.adoc
@@ -18,9 +18,8 @@ image:https://img.shields.io/github/release/jbangdev/jbang.svg[Release,link=http
 image:https://img.shields.io/github/downloads/jbangdev/jbang/total.svg[Downloads,link=https://hanadigital.github.io/grev/?user=jbangdev&repo=jbang]
 image:https://github.com/jbangdev/jbang/workflows/ci-build/badge.svg[Build Status,link=https://github.com/jbangdev/jbang/actions]
 image:https://www.eclipse.org/che/contribute.svg[Che, link=https://che.openshift.io/f?url=https://github.com/jbangdev/jbang]
-image:https://img.shields.io/badge/Gitpod-Workspace-blue?logo=gitpod[Gitpod, link=https://gitpod.io/#https://github.com/jbangdev/jbang]
+image:https://img.shields.io/badge/Gitpod-Workspace-blue?logo=gitpodp[Gitpod, link=https://gitpod.io/#https://github.com/jbangdev/jbang]
 image:https://img.shields.io/badge/zulip-join_chat-brightgreen.svg[Chat, link=https://jbangdev.zulipchat.com/]
-image:https://sourcespy.com/shield.svg[SourceSpy, link=https://sourcespy.com/github/jbangdevjbang/]
 image:https://api.scorecard.dev/projects/github.com/jbangdev/jbang/badge[OpenSSF Scorecard,link=https://scorecard.dev/viewer/?uri=github.com/jbangdev/jbang]
 
 ifdef::env-github[]

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,9 @@ pluginManagement {
 
 plugins {
 	id "com.gradle.enterprise"
+	id "org.gradle.toolchains.foojay-resolver-convention" version "1.0.0"
 }
+
 
 
 // Configuration of com.gradle.enterprise (build scan) plugin

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 
 plugins {
 	id "com.gradle.enterprise"
-	id "org.gradle.toolchains.foojay-resolver-convention" version "1.0.0"
+	id "org.gradle.toolchains.foojay-resolver-convention" version "0.10.0"
 }
 
 


### PR DESCRIPTION
avoids me having to remember to set java version before build :) 

@quintesse seeing any issue using java 11 as default as it can compile to 8 ? 