### PR TITLE
fix: no exceptions on missing sibling (re)sources

### DIFF
--- a/itests/abstagsnix.java
+++ b/itests/abstagsnix.java
@@ -1,0 +1,11 @@
+
+//SOURCES Two.java
+///SOURCES /nested/*.java
+
+//FILES /res/resource.properties renamed.properties=/res/resource.properties
+//FILES META-INF/application.properties=res/resource.properties
+
+public class abstagsnix {
+    public static void main(String... args) {
+    }
+}

--- a/itests/abstagswin.java
+++ b/itests/abstagswin.java
@@ -1,0 +1,11 @@
+
+//SOURCES Two.java
+///SOURCES C:/nested/*.java
+
+//FILES C:/res/resource.properties renamed.properties=C:/res/resource.properties
+//FILES META-INF/application.properties=res/resource.properties
+
+public class abstagswin {
+    public static void main(String... args) {
+    }
+}

--- a/itests/badtags.java
+++ b/itests/badtags.java
@@ -1,0 +1,9 @@
+
+//SOURCES _missing_.java
+
+//FILES _missing_.properties renamed.properties=_missing_.properties
+
+public class badtags {
+    public static void main(String... args) {
+    }
+}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -395,16 +395,16 @@ class Docs extends BaseInfoCommand {
 			});
 		});
 
+		if (toOpen[0] == null) {
+			Util.infoMsg("No documentation files found");
+			return EXIT_OK;
+		}
 		if (!open) {
 			Util.infoMsg("Use --open to open the documentation file in the default browser.");
 			return EXIT_OK;
 		}
 		if (GraphicsEnvironment.isHeadless()) {
 			Util.infoMsg("Cannot open documentation file in browser in headless mode");
-			return EXIT_OK;
-		}
-		if (toOpen[0] == null) {
-			Util.infoMsg("No documentation file to open found");
 			return EXIT_OK;
 		}
 		try {

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -181,11 +181,29 @@ abstract class BaseInfoCommand extends BaseCommand {
 			}
 		}
 
-		private void init(BuildContext ctx) {
-			List<String> deps = ctx.resolveClassPath().getClassPaths();
+		private void init(SourceSet ss) {
+			List<String> deps = ss.getDependencies();
 			if (!deps.isEmpty()) {
 				dependencies = deps;
 			}
+			List<RefTarget> refs = ss.getResources();
+			if (!refs.isEmpty()) {
+				files = refs.stream()
+					.map(ProjectFile::new)
+					.collect(Collectors.toList());
+			}
+			List<ResourceRef> srcs = ss.getSources();
+			if (!srcs.isEmpty()) {
+				sources = srcs.stream()
+					.map(ProjectFile::new)
+					.collect(Collectors.toList());
+			}
+			if (!ss.getCompileOptions().isEmpty()) {
+				compileOptions = ss.getCompileOptions();
+			}
+		}
+
+		private void init(BuildContext ctx) {
 			applicationJar = ctx.getJarFile() == null ? null
 					: ctx.getJarFile().toAbsolutePath().toString();
 			applicationJsa = ctx.getJsaFile() != null && Files.isRegularFile(ctx.getJsaFile())
@@ -231,28 +249,6 @@ abstract class BaseInfoCommand extends BaseCommand {
 				}
 			}
 			return docsMap;
-		}
-
-		private void init(SourceSet ss) {
-			List<String> deps = ss.getDependencies();
-			if (!deps.isEmpty()) {
-				dependencies = deps;
-			}
-			List<RefTarget> refs = ss.getResources();
-			if (!refs.isEmpty()) {
-				files = refs.stream()
-					.map(ProjectFile::new)
-					.collect(Collectors.toList());
-			}
-			List<ResourceRef> srcs = ss.getSources();
-			if (!srcs.isEmpty()) {
-				sources = srcs.stream()
-					.map(ProjectFile::new)
-					.collect(Collectors.toList());
-			}
-			if (!ss.getCompileOptions().isEmpty()) {
-				compileOptions = ss.getCompileOptions();
-			}
 		}
 
 	}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -68,10 +68,14 @@ abstract class BaseInfoCommand extends BaseCommand {
 		String originalResource;
 		String backingResource;
 		String target;
+		String error;
 
 		ProjectFile(ResourceRef ref) {
 			originalResource = ref.getOriginalResource();
 			backingResource = ref.exists() ? ref.getFile().toString() : null;
+			error = ref instanceof ResourceRef.UnresolvableResourceRef
+					? ((ResourceRef.UnresolvableResourceRef) ref).getReason()
+					: null;
 		}
 
 		ProjectFile(RefTarget ref) {
@@ -112,26 +116,20 @@ abstract class BaseInfoCommand extends BaseCommand {
 		String module;
 		Map<String, List<ProjectFile>> docs;
 
-		public ScriptInfo(BuildContext ctx, boolean assureJdkInstalled) {
-			Project prj = ctx.getProject();
+		public ScriptInfo(Project prj, Path buildDir, boolean assureJdkInstalled) {
 			originalResource = prj.getResourceRef().getOriginalResource();
 
 			if (scripts.add(originalResource)) {
 				backingResource = prj.getResourceRef().getFile().toString();
 
-				init(ctx);
+				init(prj);
 
-				applicationJar = ctx.getJarFile() == null ? null
-						: ctx.getJarFile().toAbsolutePath().toString();
-				applicationJsa = ctx.getJsaFile() != null && Files.isRegularFile(ctx.getJsaFile())
-						? ctx.getJsaFile().toAbsolutePath().toString()
-						: null;
-				nativeImage = ctx.getNativeImageFile() != null && Files.exists(ctx.getNativeImageFile())
-						? ctx.getNativeImageFile().toAbsolutePath().toString()
-						: null;
-				mainClass = prj.getMainClass();
-				module = ModuleUtil.getModuleName(prj);
-				requestedJavaVersion = prj.getJavaVersion();
+				try {
+					BuildContext ctx = BuildContext.forProject(prj, buildDir);
+					init(ctx);
+				} catch (Exception e) {
+					Util.warnMsg("Unable to obtain full information, the script probably contains errors", e);
+				}
 
 				try {
 					JdkManager jdkMan = JavaUtil.defaultJdkManager();
@@ -143,41 +141,10 @@ abstract class BaseInfoCommand extends BaseCommand {
 				} catch (ExitException e) {
 					// Ignore
 				}
-
-				List<ArtifactInfo> artifacts = ctx.resolveClassPath().getArtifacts();
-				if (artifacts.isEmpty()) {
-					resolvedDependencies = Collections.emptyList();
-				} else {
-					resolvedDependencies = artifacts
-						.stream()
-						.map(a -> a.getFile().toString())
-						.collect(Collectors.toList());
-				}
-
-				if (prj.getJavaVersion() != null) {
-					javaVersion = Integer.toString(JavaUtil.parseJavaVersion(prj.getJavaVersion()));
-				}
-
-				List<String> opts = prj.getRuntimeOptions();
-				if (!opts.isEmpty()) {
-					runtimeOptions = opts;
-				}
-
-				if (ctx.getJarFile() != null && Files.exists(ctx.getJarFile())) {
-					Project jarProject = Project.builder().build(ctx.getJarFile());
-					mainClass = jarProject.getMainClass();
-					gav = jarProject.getGav().orElse(gav);
-					module = ModuleUtil.getModuleName(jarProject);
-				}
 			}
 		}
 
-		private void init(BuildContext ctx) {
-			Project prj = ctx.getProject();
-			List<String> deps = ctx.resolveClassPath().getClassPaths();
-			if (!deps.isEmpty()) {
-				dependencies = deps;
-			}
+		private void init(Project prj) {
 			if (prj.getMainSource() == null) {
 				if (!prj.getRepositories().isEmpty()) {
 					repositories = prj.getRepositories()
@@ -199,6 +166,51 @@ abstract class BaseInfoCommand extends BaseCommand {
 			docs = getDocsMap(prj.getDocs());
 
 			module = prj.getModuleName().orElse(null);
+
+			mainClass = prj.getMainClass();
+			module = ModuleUtil.getModuleName(prj);
+			requestedJavaVersion = prj.getJavaVersion();
+
+			if (prj.getJavaVersion() != null) {
+				javaVersion = Integer.toString(JavaUtil.parseJavaVersion(prj.getJavaVersion()));
+			}
+
+			List<String> opts = prj.getRuntimeOptions();
+			if (!opts.isEmpty()) {
+				runtimeOptions = opts;
+			}
+		}
+
+		private void init(BuildContext ctx) {
+			List<String> deps = ctx.resolveClassPath().getClassPaths();
+			if (!deps.isEmpty()) {
+				dependencies = deps;
+			}
+			applicationJar = ctx.getJarFile() == null ? null
+					: ctx.getJarFile().toAbsolutePath().toString();
+			applicationJsa = ctx.getJsaFile() != null && Files.isRegularFile(ctx.getJsaFile())
+					? ctx.getJsaFile().toAbsolutePath().toString()
+					: null;
+			nativeImage = ctx.getNativeImageFile() != null && Files.exists(ctx.getNativeImageFile())
+					? ctx.getNativeImageFile().toAbsolutePath().toString()
+					: null;
+
+			List<ArtifactInfo> artifacts = ctx.resolveClassPath().getArtifacts();
+			if (artifacts.isEmpty()) {
+				resolvedDependencies = Collections.emptyList();
+			} else {
+				resolvedDependencies = artifacts
+					.stream()
+					.map(a -> a.getFile().toString())
+					.collect(Collectors.toList());
+			}
+
+			if (ctx.getJarFile() != null && Files.exists(ctx.getJarFile())) {
+				Project jarProject = Project.builder().build(ctx.getJarFile());
+				mainClass = jarProject.getMainClass();
+				gav = jarProject.getGav().orElse(gav);
+				module = ModuleUtil.getModuleName(jarProject);
+			}
 		}
 
 		/**
@@ -255,7 +267,7 @@ abstract class BaseInfoCommand extends BaseCommand {
 
 		scripts = new HashSet<>();
 
-		return new ScriptInfo(BuildContext.forProject(prj, buildDir), assureJdkInstalled);
+		return new ScriptInfo(prj, buildDir, assureJdkInstalled);
 	}
 
 	ProjectBuilder createProjectBuilder() {

--- a/src/main/java/dev/jbang/source/DocRef.java
+++ b/src/main/java/dev/jbang/source/DocRef.java
@@ -58,6 +58,7 @@ public class DocRef {
 			docRef = split[1];
 		}
 		ResourceRef ref = siblingResolver.resolve(docRef);
-		return new DocRef(docId, ref != null ? ref : ResourceRef.forUnresolvable(docRef));
+		return new DocRef(docId, ref != null ? ref
+				: ResourceRef.forUnresolvable(docRef, "not resolvable from " + siblingResolver.description()));
 	}
 }

--- a/src/main/java/dev/jbang/source/InputStreamResourceRef.java
+++ b/src/main/java/dev/jbang/source/InputStreamResourceRef.java
@@ -68,10 +68,7 @@ public class InputStreamResourceRef implements ResourceRef {
 	}
 
 	@Override
-	public int compareTo(ResourceRef o) {
-		if (o == null) {
-			return 1;
-		}
+	public int compareTo(@Nonnull ResourceRef o) {
 		return toString().compareTo(o.toString());
 	}
 

--- a/src/main/java/dev/jbang/source/InputStreamResourceRef.java
+++ b/src/main/java/dev/jbang/source/InputStreamResourceRef.java
@@ -6,22 +6,23 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import dev.jbang.util.Util;
 
 public class InputStreamResourceRef implements ResourceRef {
-	@Nonnull
+	@Nullable
 	protected final String originalResource;
 	@Nonnull
 	protected final Function<String, InputStream> streamFactory;
 
-	public InputStreamResourceRef(@Nonnull String resource,
+	public InputStreamResourceRef(@Nullable String resource,
 			@Nonnull Function<String, InputStream> streamFactory) {
 		this.originalResource = resource;
 		this.streamFactory = streamFactory;
 	}
 
-	@Nonnull
+	@Nullable
 	@Override
 	public String getOriginalResource() {
 		return originalResource;

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -330,7 +330,7 @@ public class ProjectBuilder {
 		TagReader tagReader = new TagReader.JbangProject(contents,
 				it -> PropertiesValueResolver.replaceProperties(it, getContextProperties()));
 		prj.setDescription(tagReader.getDescription().orElse(null));
-		ResourceResolver resolver1 = new SiblingResourceResolver(resourceRef, ResourceResolver.forResources());
+		ResourceResolver resolver1 = new SiblingResourceResolver(resourceRef);
 		prj.addDocs(tagReader.collectDocs(resolver1));
 		prj.setGav(tagReader.getGav().orElse(null));
 		prj.setMainClass(tagReader.getMain().orElse(null));
@@ -570,7 +570,7 @@ public class ProjectBuilder {
 	private Project updateProject(Source src, Project prj, ResourceResolver resolver) {
 		ResourceRef srcRef = src.getResourceRef();
 		if (!prj.getMainSourceSet().getSources().contains(srcRef)) {
-			ResourceResolver sibRes1 = new SiblingResourceResolver(srcRef, ResourceResolver.forResources());
+			ResourceResolver sibRes1 = new SiblingResourceResolver(srcRef);
 			SourceSet ss = prj.getMainSourceSet();
 			ss.addSource(srcRef);
 			ss.addResources(src.tagReader.collectFiles(srcRef, sibRes1));

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -541,10 +541,10 @@ public class ProjectBuilder {
 	 * @return A <code>Project</code>
 	 */
 	private Project updateProjectMain(Source src, Project prj, ResourceResolver resolver) {
-		prj.setDescription(src.tagReader.getDescription().orElse(null));
-		prj.setGav(src.tagReader.getGav().orElse(null));
-		prj.setMainClass(src.tagReader.getMain().orElse(null));
-		prj.setModuleName(src.tagReader.getModule().orElse(null));
+		prj.setDescription(src.getTagReader().getDescription().orElse(null));
+		prj.setGav(src.getTagReader().getGav().orElse(null));
+		prj.setMainClass(src.getTagReader().getMain().orElse(null));
+		prj.setModuleName(src.getTagReader().getModule().orElse(null));
 		if (prj.getMainSource() instanceof JavaSource) {
 			// todo: have way to turn these off? lets wait until someone asks and has a
 			// usecase
@@ -573,25 +573,29 @@ public class ProjectBuilder {
 			ResourceResolver sibRes1 = new SiblingResourceResolver(srcRef);
 			SourceSet ss = prj.getMainSourceSet();
 			ss.addSource(srcRef);
-			ss.addResources(src.tagReader.collectFiles(srcRef, sibRes1));
+			if (srcRef instanceof ResourceRef.UnresolvableResourceRef) {
+				Util.verboseMsg("Skipping unresolvable source: " + srcRef);
+				return prj;
+			}
+			ss.addResources(src.getTagReader().collectFiles(srcRef, sibRes1));
 			ss.addDependencies(src.collectBinaryDependencies());
 			ss.addCompileOptions(src.getCompileOptions());
 			ss.addNativeOptions(src.getNativeOptions());
-			prj.addRepositories(src.tagReader.collectRepositories());
+			prj.addRepositories(src.getTagReader().collectRepositories());
 			prj.addRuntimeOptions(src.getRuntimeOptions());
-			prj.addDocs(src.tagReader.collectDocs(sibRes1));
+			prj.addDocs(src.getTagReader().collectDocs(sibRes1));
 
-			src.tagReader.collectManifestOptions().forEach(kv -> {
+			src.getTagReader().collectManifestOptions().forEach(kv -> {
 				if (!kv.getKey().isEmpty()) {
 					prj.getManifestAttributes().put(kv.getKey(), kv.getValue() != null ? kv.getValue() : "true");
 				}
 			});
-			src.tagReader.collectAgentOptions().forEach(kv -> {
+			src.getTagReader().collectAgentOptions().forEach(kv -> {
 				if (!kv.getKey().isEmpty()) {
 					prj.getManifestAttributes().put(kv.getKey(), kv.getValue() != null ? kv.getValue() : "true");
 				}
 			});
-			String version = src.tagReader.getJavaVersion();
+			String version = src.getTagReader().getJavaVersion();
 			if (version != null && JavaUtil.checkRequestedVersion(version)) {
 				if (new JavaUtil.RequestedVersionComparator().compare(prj.getJavaVersion(), version) > 0) {
 					prj.setJavaVersion(version);
@@ -602,7 +606,7 @@ public class ProjectBuilder {
 				prj.addSubProject(new ProjectBuilder(buildRefs).build(subRef));
 			}
 			ResourceResolver sibRes2 = new SiblingResourceResolver(srcRef, resolver);
-			for (Source includedSource : src.tagReader.collectSources(srcRef, sibRes2)) {
+			for (Source includedSource : src.getTagReader().collectSources(srcRef, sibRes2)) {
 				updateProject(includedSource, prj, resolver);
 			}
 		}

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -25,7 +25,7 @@ import dev.jbang.util.Util;
  * Resolver.resolve}.
  */
 public interface ResourceRef extends Comparable<ResourceRef> {
-	ResourceRef nullRef = new UnresolvableResourceRef(null);
+	ResourceRef nullRef = new UnresolvableResourceRef(null, "null reference");
 
 	@Nullable
 	String getOriginalResource();
@@ -162,10 +162,11 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * a file or input stream.
 	 *
 	 * @param resource the resource string
+	 * @param reason   the reason why the resource cannot be resolved
 	 * @return a {@code ResourceRef} instance
 	 */
-	static ResourceRef forUnresolvable(@Nonnull String resource) {
-		return new UnresolvableResourceRef(resource);
+	static ResourceRef forUnresolvable(@Nonnull String resource, @Nonnull String reason) {
+		return new UnresolvableResourceRef(resource, reason);
 	}
 
 	/**
@@ -183,9 +184,11 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 
 	class UnresolvableResourceRef implements ResourceRef {
 		private final String resource;
+		private final String reason;
 
-		public UnresolvableResourceRef(@Nullable String resource) {
+		public UnresolvableResourceRef(@Nullable String resource, @Nonnull String reason) {
 			this.resource = resource;
+			this.reason = reason;
 		}
 
 		@Nullable
@@ -194,20 +197,37 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 			return resource;
 		}
 
+		@Nullable
+		public String getReason() {
+			return reason;
+		}
+
 		@Override
 		public boolean exists() {
 			return false;
 		}
 
+		@Nonnull
 		@Override
-		public int compareTo(ResourceRef o) {
+		public Path getFile() {
+			throw new ResourceNotFoundException(getOriginalResource(),
+					"Failed to get contents from resource '" + resource + "': " + reason);
+		}
+
+		@Override
+		public int compareTo(@Nonnull ResourceRef o) {
 			return 0;
+		}
+
+		@Override
+		public String toString() {
+			return resource + " (unresolvable)";
 		}
 	}
 
 	class WrappedResourceRef implements ResourceRef {
 		@Nonnull
-		private final ResourceRef wrappedRef;
+		protected final ResourceRef wrappedRef;
 
 		public WrappedResourceRef(@Nonnull ResourceRef wrappedRef) {
 			this.wrappedRef = wrappedRef;
@@ -231,13 +251,18 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 		}
 
 		@Override
-		public int compareTo(ResourceRef o) {
+		public int compareTo(@Nonnull ResourceRef o) {
 			return wrappedRef.compareTo(o);
 		}
 
 		@Override
 		public boolean equals(Object obj) {
 			return wrappedRef.equals(obj);
+		}
+
+		@Override
+		public String toString() {
+			return wrappedRef.toString();
 		}
 	}
 }

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -1,5 +1,6 @@
 package dev.jbang.source;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -25,7 +26,6 @@ import dev.jbang.util.Util;
  * Resolver.resolve}.
  */
 public interface ResourceRef extends Comparable<ResourceRef> {
-	ResourceRef nullRef = new UnresolvableResourceRef(null, "null reference");
 
 	@Nullable
 	String getOriginalResource();
@@ -157,6 +157,19 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	}
 
 	/**
+	 * Creates a new {@code ResourceRef} instance for a literal resource. This is
+	 * useful for cases where the resource is a literal string that represents the
+	 * contents of a resource. The literal resource is stored in memory and can be
+	 * accessed directly.
+	 *
+	 * @param literal the literal string representing the resource contents
+	 * @return a {@code ResourceRef} instance
+	 */
+	static ResourceRef forLiteral(@Nonnull String literal) {
+		return new LiteralResourceRef(literal);
+	}
+
+	/**
 	 * Creates a new {@code ResourceRef} instance that cannot be resolved. This is
 	 * useful for cases where the resource string is known but cannot be resolved to
 	 * a file or input stream.
@@ -265,4 +278,21 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 			return wrappedRef.toString();
 		}
 	}
+
+	class LiteralResourceRef extends InputStreamResourceRef {
+
+		public LiteralResourceRef(@Nonnull String literal) {
+			this(null, literal);
+		}
+
+		public LiteralResourceRef(@Nullable String resource, @Nonnull String literal) {
+			super(resource, ref -> new ByteArrayInputStream(literal.getBytes()));
+		}
+
+		@Override
+		public boolean exists() {
+			return true;
+		}
+	}
+
 }

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -9,8 +9,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
-import dev.jbang.cli.BaseCommand;
-import dev.jbang.cli.ExitException;
 import dev.jbang.source.sources.*;
 import dev.jbang.source.sources.KotlinSource;
 import dev.jbang.source.sources.MarkdownSource;
@@ -129,7 +127,7 @@ public abstract class Source {
 			Function<String, String> replaceProperties) {
 		ResourceRef resourceRef = resolver.resolve(resource);
 		if (resourceRef == null) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Could not find: " + resource);
+			resourceRef = ResourceRef.forUnresolvable(resource, "not found from " + resolver.description());
 		}
 		return forResourceRef(resourceRef, replaceProperties);
 	}

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -27,8 +28,10 @@ import dev.jbang.util.Util;
 public abstract class Source {
 
 	private final ResourceRef resourceRef;
-	private final String contents;
-	protected final TagReader tagReader;
+	private final Supplier<String> contentsSupplier;
+	private final Supplier<TagReader> tagReaderSupplier;
+	private TagReader tagReader;
+	private String contents;
 
 	public enum Type {
 		java("java", "java"), jshell("jsh", "java"),
@@ -48,37 +51,46 @@ public abstract class Source {
 		}
 	}
 
-	public Source(String contents, Function<String, String> replaceProperties) {
-		this(ResourceRef.nullRef, contents, replaceProperties);
-	}
-
 	protected Source(ResourceRef resourceRef, Function<String, String> replaceProperties) {
-		this(resourceRef, Util.readFileContent(resourceRef.getFile()), replaceProperties);
+		this.resourceRef = resourceRef;
+		this.contentsSupplier = () -> Util.readString(resourceRef.getInputStream());
+		this.tagReaderSupplier = () -> new TagReader.Extended(getContents(), replaceProperties);
 	}
 
 	protected Source(ResourceRef resourceRef, String contents, Function<String, String> replaceProperties) {
 		this.resourceRef = resourceRef;
+		this.contentsSupplier = () -> contents;
 		this.contents = contents;
-		this.tagReader = createTagReader(contents, replaceProperties);
+		this.tagReaderSupplier = () -> new TagReader.Extended(getContents(), replaceProperties);
 	}
 
-	protected TagReader createTagReader(String contents, Function<String, String> replaceProperties) {
-		return new TagReader.Extended(contents, replaceProperties);
+	protected TagReader getTagReader() {
+		if (tagReader == null) {
+			tagReader = tagReaderSupplier.get();
+		}
+		return tagReader;
+	}
+
+	protected String getContents() {
+		if (contents == null) {
+			contents = contentsSupplier.get();
+		}
+		return contents;
 	}
 
 	@Nonnull
 	public Stream<String> getTags() {
-		return tagReader.getTags();
+		return getTagReader().getTags();
 	}
 
 	public abstract @Nonnull Type getType();
 
 	protected List<String> collectBinaryDependencies() {
-		return tagReader.collectBinaryDependencies();
+		return getTagReader().collectBinaryDependencies();
 	}
 
 	protected List<String> collectSourceDependencies() {
-		return tagReader.collectSourceDependencies();
+		return getTagReader().collectSourceDependencies();
 	}
 
 	protected abstract List<String> getCompileOptions();
@@ -95,27 +107,27 @@ public abstract class Source {
 
 	@Nonnull
 	public Optional<String> getJavaPackage() {
-		if (contents != null) {
-			return Util.getSourcePackage(contents);
+		if (getContents() != null) {
+			return Util.getSourcePackage(getContents());
 		} else {
 			return Optional.empty();
 		}
 	}
 
 	public boolean isAgent() {
-		return !tagReader.collectAgentOptions().isEmpty();
+		return !getTagReader().collectAgentOptions().isEmpty();
 	}
 
 	public boolean enableCDS() {
-		return !tagReader.collectRawOptions("CDS").isEmpty();
+		return !getTagReader().collectRawOptions("CDS").isEmpty();
 	}
 
 	public boolean enablePreview() {
-		return !tagReader.collectRawOptions("PREVIEW").isEmpty();
+		return !getTagReader().collectRawOptions("PREVIEW").isEmpty();
 	}
 
 	public boolean disableIntegrations() {
-		return !tagReader.collectRawOptions("NOINTEGRATIONS").isEmpty();
+		return !getTagReader().collectRawOptions("NOINTEGRATIONS").isEmpty();
 	}
 
 	// Used only by tests

--- a/src/main/java/dev/jbang/source/SourceSet.java
+++ b/src/main/java/dev/jbang/source/SourceSet.java
@@ -140,9 +140,17 @@ public class SourceSet {
 	}
 
 	protected Stream<String> getStableIdInfo() {
-		Stream<String> srcs = sources.stream().map(src -> Util.readFileContent(src.getFile()));
-		Stream<String> ress = resources.stream().map(res -> Util.readFileContent(res.getSource().getFile()));
+		Stream<String> srcs = sources.stream().map(this::safeFileContents);
+		Stream<String> ress = resources.stream().map(res -> safeFileContents(res.getSource()));
 		return Stream.concat(srcs, ress);
+	}
+
+	private String safeFileContents(ResourceRef ref) {
+		try {
+			return Util.readFileContent(ref.getFile());
+		} catch (Exception e) {
+			return "";
+		}
 	}
 
 }

--- a/src/main/java/dev/jbang/source/TagReader.java
+++ b/src/main/java/dev/jbang/source/TagReader.java
@@ -390,13 +390,10 @@ public abstract class TagReader {
 
 		Path p = dest != null ? Paths.get(dest) : null;
 
-		if (Paths.get(src).isAbsolute()) {
-			throw new IllegalStateException(
-					"Only relative paths allowed in //FILES. Found absolute path: " + src);
-		}
-		if (p != null && p.isAbsolute()) {
-			throw new IllegalStateException(
-					"Only relative paths allowed in //FILES. Found absolute path: " + dest);
+		if (Paths.get(src).isAbsolute() || (p != null && p.isAbsolute())) {
+			ResourceRef ref = ResourceRef.forUnresolvable(src,
+					"Only relative paths allowed in //FILES. Found absolute path");
+			return RefTarget.create(ref, p);
 		}
 
 		try {

--- a/src/main/java/dev/jbang/source/TagReader.java
+++ b/src/main/java/dev/jbang/source/TagReader.java
@@ -1,7 +1,5 @@
 package dev.jbang.source;
 
-import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -20,7 +18,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
-import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.dependencies.JitPackUtil;
 import dev.jbang.dependencies.MavenCoordinate;
@@ -405,22 +402,16 @@ public abstract class TagReader {
 		try {
 			ResourceRef ref = siblingResolver.resolve(src);
 			if (ref == null) {
-				throw new ExitException(EXIT_INVALID_INPUT,
-						String.format("Could not find '%s' when resolving '%s' in %s",
-								src,
-								fileReference,
-								siblingResolver.description()));
+				ref = ResourceRef.forUnresolvable(src, "not resolvable from " + siblingResolver.description());
 			}
 			if (dest != null && dest.endsWith("/")) {
 				p = p.resolve(ref.getFile().getFileName());
 			}
 			return RefTarget.create(ref, p);
 		} catch (ResourceNotFoundException rnfe) {
-			throw new ExitException(EXIT_INVALID_INPUT, String.format("Could not find '%s' when resolving '%s' in %s",
-					rnfe.getResourceDescription(),
-					fileReference,
-					siblingResolver.description()),
-					rnfe);
+			ResourceRef ref = ResourceRef.forUnresolvable(src,
+					"error `" + rnfe.getMessage() + "' while resolving from " + siblingResolver.description());
+			return RefTarget.create(ref, p);
 		}
 	}
 

--- a/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
@@ -1,6 +1,5 @@
 package dev.jbang.source.resolvers;
 
-import java.util.Objects;
 import java.util.function.Function;
 
 import javax.annotation.Nonnull;
@@ -27,7 +26,7 @@ public class AliasResourceResolver implements ResourceResolver {
 	@Override
 	public String description() {
 		return String.format("Alias resolver from catalog %s using %s",
-				Objects.toString(catalog.getScriptBase(), "<none>"),
+				catalog != null ? catalog.getScriptBase() : "<none>",
 				resolverFactory.apply(null).description());
 	}
 

--- a/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
@@ -118,10 +118,7 @@ public class FileResourceResolver implements ResourceResolver {
 		}
 
 		@Override
-		public int compareTo(ResourceRef o) {
-			if (o == null) {
-				return 1;
-			}
+		public int compareTo(@Nonnull ResourceRef o) {
 			return toString().compareTo(o.toString());
 		}
 

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -23,10 +23,6 @@ public class GroovySource extends Source {
 		super(script, replaceProperties);
 	}
 
-	public GroovySource(String script, Function<String, String> replaceProperties) {
-		super(script, replaceProperties);
-	}
-
 	@Override
 	public @Nonnull Type getType() {
 		return Type.groovy;
@@ -34,17 +30,17 @@ public class GroovySource extends Source {
 
 	@Override
 	protected List<String> getCompileOptions() {
-		return tagReader.collectOptions("COMPILE_OPTIONS");
+		return getTagReader().collectOptions("COMPILE_OPTIONS");
 	}
 
 	@Override
 	protected List<String> getNativeOptions() {
-		return tagReader.collectOptions("NATIVE_OPTIONS");
+		return getTagReader().collectOptions("NATIVE_OPTIONS");
 	}
 
 	protected List<String> getRuntimeOptions() {
 		List<String> gopts = Collections.singletonList("-Dgroovy.grape.enable=false");
-		List<String> opts = tagReader.collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
+		List<String> opts = getTagReader().collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
 		return Util.join(gopts, opts);
 	}
 
@@ -61,7 +57,7 @@ public class GroovySource extends Source {
 	}
 
 	public String getGroovyVersion() {
-		return tagReader.collectOptions("GROOVY")
+		return getTagReader().collectOptions("GROOVY")
 			.stream()
 			.findFirst()
 			.orElse(GroovyManager.DEFAULT_GROOVY_VERSION);

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -18,10 +18,6 @@ import dev.jbang.util.Util;
 
 public class JavaSource extends Source {
 
-	public JavaSource(String script, Function<String, String> replaceProperties) {
-		super(script, replaceProperties);
-	}
-
 	public JavaSource(ResourceRef script, Function<String, String> replaceProperties) {
 		super(script, replaceProperties);
 	}
@@ -37,17 +33,17 @@ public class JavaSource extends Source {
 
 	@Override
 	protected List<String> getCompileOptions() {
-		return tagReader.collectOptions("JAVAC_OPTIONS", "COMPILE_OPTIONS");
+		return getTagReader().collectOptions("JAVAC_OPTIONS", "COMPILE_OPTIONS");
 	}
 
 	@Override
 	protected List<String> getNativeOptions() {
-		return tagReader.collectOptions("NATIVE_OPTIONS");
+		return getTagReader().collectOptions("NATIVE_OPTIONS");
 	}
 
 	@Override
 	protected List<String> getRuntimeOptions() {
-		return tagReader.collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
+		return getTagReader().collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
 	}
 
 	@Override

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -22,10 +22,6 @@ public class KotlinSource extends Source {
 		super(script, replaceProperties);
 	}
 
-	public KotlinSource(String script, Function<String, String> replaceProperties) {
-		super(script, replaceProperties);
-	}
-
 	@Override
 	public @Nonnull Type getType() {
 		return Type.kotlin;
@@ -40,17 +36,17 @@ public class KotlinSource extends Source {
 
 	@Override
 	protected List<String> getCompileOptions() {
-		return tagReader.collectOptions("COMPILE_OPTIONS");
+		return getTagReader().collectOptions("COMPILE_OPTIONS");
 	}
 
 	@Override
 	protected List<String> getNativeOptions() {
-		return tagReader.collectOptions("NATIVE_OPTIONS");
+		return getTagReader().collectOptions("NATIVE_OPTIONS");
 	}
 
 	@Override
 	protected List<String> getRuntimeOptions() {
-		return tagReader.collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
+		return getTagReader().collectOptions("JAVA_OPTIONS", "RUNTIME_OPTIONS");
 	}
 
 	@Override
@@ -59,7 +55,7 @@ public class KotlinSource extends Source {
 	}
 
 	public String getKotlinVersion() {
-		return tagReader.collectOptions("KOTLIN")
+		return getTagReader().collectOptions("KOTLIN")
 			.stream()
 			.findFirst()
 			.orElse(KotlinManager.DEFAULT_KOTLIN_VERSION);

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
@@ -528,6 +529,11 @@ public class Util {
 	 **/
 	static public String readString(Path toPath) throws IOException {
 		return new String(Files.readAllBytes(toPath));
+	}
+
+	static public String readString(InputStream is) {
+		BufferedReader br = new BufferedReader(new InputStreamReader(is));
+		return br.lines().collect(Collectors.joining("\n"));
 	}
 
 	/**

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1566,11 +1566,15 @@ public class TestRun extends BaseTest {
 		File f = examplesTestFolder.resolve("brokenresource.java").toFile();
 
 		ProjectBuilder pb = Project.builder();
+		Project prj = pb.build(f.getAbsolutePath());
 
-		ExitException root = assertThrows(ExitException.class, () -> pb.build(f.getAbsolutePath()));
+		assertThat(prj.getMainSourceSet().getResources().size(), equalTo(1));
+		assertThat(prj.getMainSourceSet().getResources().get(0).getSource().exists(), is(false));
+
+		ResourceNotFoundException root = assertThrows(ResourceNotFoundException.class,
+				() -> BuildContext.forProject(prj));
 		assertThat(root.toString(), containsString("'resourcethatdoesnotexist.properties"));
 		assertThat(root.toString(), containsString("brokenresource.java"));
-
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1567,12 +1567,13 @@ public class TestRun extends BaseTest {
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(f.getAbsolutePath());
+		BuildContext ctx = BuildContext.forProject(prj);
 
 		assertThat(prj.getMainSourceSet().getResources().size(), equalTo(1));
 		assertThat(prj.getMainSourceSet().getResources().get(0).getSource().exists(), is(false));
 
 		ResourceNotFoundException root = assertThrows(ResourceNotFoundException.class,
-				() -> BuildContext.forProject(prj));
+				() -> Project.codeBuilder(ctx).build());
 		assertThat(root.toString(), containsString("'resourcethatdoesnotexist.properties"));
 		assertThat(root.toString(), containsString("brokenresource.java"));
 	}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -73,6 +73,7 @@ import dev.jbang.source.CmdGeneratorBuilder;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.source.ResourceNotFoundException;
+import dev.jbang.source.ResourceRef;
 import dev.jbang.source.Source;
 import dev.jbang.source.buildsteps.JarBuildStep;
 import dev.jbang.source.generators.JshCmdGenerator;
@@ -864,7 +865,7 @@ public class TestRun extends BaseTest {
 
 		Path out = rootdir.resolve("content.jar");
 
-		Source src = new JavaSource("", null);
+		Source src = new JavaSource(ResourceRef.forLiteral(""), null);
 		Project prj = Project.builder().build(src);
 		prj.setMainClass("wonkabear");
 

--- a/src/test/java/dev/jbang/dependencies/TestGrape.java
+++ b/src/test/java/dev/jbang/dependencies/TestGrape.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
 import dev.jbang.source.Project;
+import dev.jbang.source.ResourceRef;
 import dev.jbang.source.Source;
 import dev.jbang.source.sources.JavaSource;
 
@@ -31,7 +32,7 @@ public class TestGrape extends BaseTest {
 				+
 				"})\n";
 
-		Source src = new JavaSource(grabBlock, null);
+		Source src = new JavaSource(ResourceRef.forLiteral(grabBlock), null);
 		Project prj = Project.builder().build(src);
 		List<String> deps = prj.getMainSourceSet().getDependencies();
 

--- a/src/test/java/dev/jbang/source/TestProject.java
+++ b/src/test/java/dev/jbang/source/TestProject.java
@@ -12,8 +12,8 @@ public class TestProject extends BaseTest {
 
 	@Test
 	void testCDS() {
-		Source source = new JavaSource("//CDS\nclass m { }", null);
-		Source source2 = new JavaSource("class m { }", null);
+		Source source = new JavaSource(ResourceRef.forLiteral("//CDS\nclass m { }"), null);
+		Source source2 = new JavaSource(ResourceRef.forLiteral("class m { }"), null);
 
 		Project prj = Project.builder().build(source);
 		Project prj2 = Project.builder().build(source2);

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.nullValue;
@@ -351,6 +352,21 @@ public class TestProjectBuilder extends BaseTest {
 		}
 		Project prj = pb.build(src);
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(3));
+		assertThat(prj.getMainSourceSet()
+			.getResources()
+			.stream()
+			.filter(rt -> rt.getSource() instanceof ResourceRef.UnresolvableResourceRef)
+			.collect(Collectors.toList()), iterableWithSize(2));
+	}
+
+	@Test
+	void testMissingFilesTags() {
+		ProjectBuilder pb = Project.builder();
+		Path src = examplesTestFolder.resolve("badtags.java");
+		Project prj = pb.build(src);
+		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(2));
+		assertThat(prj.getMainSourceSet().getSources().get(1), instanceOf(ResourceRef.UnresolvableResourceRef.class));
+		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(2));
 		assertThat(prj.getMainSourceSet()
 			.getResources()
 			.stream()

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -337,5 +338,23 @@ public class TestProjectBuilder extends BaseTest {
 		assertThat(prj.getManifestAttributes(), hasEntry("bar", "baz"));
 		assertThat(prj.getManifestAttributes(), hasEntry("baz", "nada"));
 		assertThat(prj.getManifestAttributes(), hasEntry("twom", "2"));
+	}
+
+	@Test
+	void testAbsoluteFileTags() {
+		ProjectBuilder pb = Project.builder();
+		Path src;
+		if (Util.isWindows()) {
+			src = examplesTestFolder.resolve("abstagswin.java");
+		} else {
+			src = examplesTestFolder.resolve("abstagsnix.java");
+		}
+		Project prj = pb.build(src);
+		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(3));
+		assertThat(prj.getMainSourceSet()
+			.getResources()
+			.stream()
+			.filter(rt -> rt.getSource() instanceof ResourceRef.UnresolvableResourceRef)
+			.collect(Collectors.toList()), iterableWithSize(2));
 	}
 }

--- a/src/test/java/dev/jbang/source/TestSource.java
+++ b/src/test/java/dev/jbang/source/TestSource.java
@@ -177,7 +177,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testCommentsDoesNotGetPickedUp() {
-		Source source = new JavaSource(exampleCommandsWithComments, null);
+		Source source = new JavaSource(ResourceRef.forLiteral(exampleCommandsWithComments), null);
 		Project prj = Project.builder().build(source);
 
 		assertEquals(prj.getJavaVersion(), "14+");
@@ -189,7 +189,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testFindDependencies() {
-		Source src = new JavaSource(example,
+		Source src = new JavaSource(ResourceRef.forLiteral(example),
 				it -> PropertiesValueResolver.replaceProperties(it, new Properties()));
 		Project prj = Project.builder().build(src);
 
@@ -207,7 +207,8 @@ public class TestSource extends BaseTest {
 		Properties p = new Properties();
 		p.put("log4j.version", "1.2.9");
 
-		Source src = new JavaSource(example, it -> PropertiesValueResolver.replaceProperties(it, p));
+		Source src = new JavaSource(ResourceRef.forLiteral(example),
+				it -> PropertiesValueResolver.replaceProperties(it, p));
 		Project prj = Project.builder().build(src);
 
 		List<String> dependencies = prj.getMainSourceSet().getDependencies();
@@ -296,8 +297,8 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testCDS() {
-		Source source = new JavaSource("//CDS\nclass m { }", null);
-		Source source2 = new JavaSource("class m { }", null);
+		Source source = new JavaSource(ResourceRef.forLiteral("//CDS\nclass m { }"), null);
+		Source source2 = new JavaSource(ResourceRef.forLiteral("class m { }"), null);
 
 		assertTrue(source.enableCDS());
 		assertFalse(source2.enableCDS());
@@ -306,7 +307,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testExtractJavaOptions() {
-		Source s = new JavaSource(example, null);
+		Source s = new JavaSource(ResourceRef.forLiteral(example), null);
 
 		assertEquals(Arrays.asList("--verbose", "--enable-preview"), s.getCompileOptions());
 		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
@@ -317,7 +318,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testExtractGroovyOptions() {
-		Source s = new GroovySource(groovyExample, null);
+		Source s = new GroovySource(ResourceRef.forLiteral(groovyExample), null);
 
 		assertEquals(Arrays.asList("--enable-preview"), s.getCompileOptions());
 		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
@@ -327,7 +328,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testExtractKotlinOptions() {
-		Source s = new KotlinSource(kotlinExample, null);
+		Source s = new KotlinSource(ResourceRef.forLiteral(kotlinExample), null);
 
 		assertEquals(Arrays.asList("--enable-preview"), s.getCompileOptions());
 		assertEquals(Arrays.asList("-O1"), s.getNativeOptions());
@@ -346,7 +347,7 @@ public class TestSource extends BaseTest {
 
 	@Test
 	void testGav() {
-		Source src = new JavaSource(example, null);
+		Source src = new JavaSource(ResourceRef.forLiteral(example), null);
 		String gav = Project.builder().build(src).getGav().get();
 		assertEquals("org.example:classpath", gav);
 	}

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -1,6 +1,8 @@
 package dev.jbang.source;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -11,9 +13,9 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.junit.Assume;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
@@ -141,7 +143,13 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forResolvedResource(scriptURL, mainPath);
 		Source source = Source.forResourceRef(resourceRef, null);
-		Assertions.assertThrows(ResourceNotFoundException.class, () -> Project.builder().build(source));
+		Project prj = Project.builder().build(source);
+		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(5));
+		assertThat(prj.getMainSourceSet()
+			.getSources()
+			.stream()
+			.filter(ref -> ref instanceof ResourceRef.UnresolvableResourceRef)
+			.collect(Collectors.toList()), iterableWithSize(1));
 	}
 
 }

--- a/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
+++ b/src/test/java/dev/jbang/source/TestSourcesMultipleSomeMissingFiles.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
-import dev.jbang.cli.ExitException;
 
 class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 
@@ -142,7 +141,7 @@ class TestSourcesMultipleSomeMissingFiles extends BaseTest {
 		String scriptURL = mainPath.toString();
 		ResourceRef resourceRef = ResourceRef.forResolvedResource(scriptURL, mainPath);
 		Source source = Source.forResourceRef(resourceRef, null);
-		Assertions.assertThrows(ExitException.class, () -> Project.builder().build(source));
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> Project.builder().build(source));
 	}
 
 }

--- a/src/test/resources/wiremock/__files/documentation_guide_latest_faq.html-0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd.txt
+++ b/src/test/resources/wiremock/__files/documentation_guide_latest_faq.html-0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd.txt
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>FAQ :: JBang</title>
+    <link rel="prev" href="caching.html">
+    <link rel="next" href="cli/jbang.html">
+    <meta name="generator" content="Antora 3.0.0">
+    <link rel="stylesheet" href="../../_/css/site.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"/>    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156530423-2"></script>
+    <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','UA-156530423-2')</script>
+    <script>var uiRootPath = '../../_'</script>
+  </head>
+  <body class="article">
+<header class="header">
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="https://jbang.dev">JBang</a>
+      <button class="navbar-burger" data-target="topbar-nav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <div id="topbar-nav" class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="/appstore">AppStore</a>
+        <a class="navbar-item" href="/try">Try</a>
+        <a class="navbar-item" href="/download">Download</a>
+                <a class="navbar-item" href="/documentation">Documentation</a>
+      </div>
+    </div>
+    <div class="navbar-item hide-for-print">
+        <input id="search-input" type="text" placeholder="Search (by Algolia)">
+      </div>
+  </nav>
+</header>
+<div class="body">
+<div class="nav-container" data-component="guide" data-version="latest">
+  <aside class="nav">
+    <div class="panels">
+<div class="nav-panel-menu is-active" data-panel="menu">
+  <nav class="nav-menu">
+    <h3 class="title"><a href="index.html">JBang</a></h3>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="0">
+<ul class="nav-list">
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="index.html">Intro</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="installation.html">Installation</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="usage.html">Usage</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="dependencies.html">Dependencies</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="javaversions.html">Java Versions</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="organizing.html">File Organization</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="running.html">Running</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="debugging.html">Debugging</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="editing.html">Editing</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="exporting.html">Exporting</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="install.html">Install Apps</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="templates.html">Templates</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="alias_catalogs.html">Aliases &amp; Catalogs</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="integration.html">Integration</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="configuration.html">Configuration</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="caching.html">Caching</a>
+  </li>
+  <li class="nav-item is-current-page" data-depth="1">
+    <a class="nav-link" href="faq.html">FAQ</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="0">
+<ul class="nav-list">
+  <li class="nav-item" data-depth="1">
+    <button class="nav-item-toggle"></button>
+    <span class="nav-text">CLI Reference</span>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="2">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang.html">jbang</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-run.html">run</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-build.html">build</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-edit.html">edit</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-init.html">init</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-alias.html">alias</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-template.html">template</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-catalog.html">catalog</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-update.html">update</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-trust.html">trust</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-cache.html">cache</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-cache-clear.html">clear</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-completion.html">completion</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-jdk.html">jdk</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-default.html">default</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-home.html">home</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-install.html">install</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-java-env.html">java-env, env</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-uninstall.html">uninstall</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-version.html">version</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-wrapper.html">wrapper</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-wrapper-install.html">install</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-info.html">info</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-tools.html">tools</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-classpath.html">classpath</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-jar.html">jar</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-app.html">app</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-install.html">install</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-uninstall.html">uninstall</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-setup.html">setup</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-export.html">export</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-portable.html">portable</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-local.html">local</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-mavenrepo.html">mavenrepo</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-native.html">native</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-fatjar.html">fatjar</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-jlink.html">jlink</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-gradle.html">gradle</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-maven.html">maven</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-config.html">config</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-get.html">get</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-set.html">set</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-unset.html">unset</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-list.html">list</a>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </nav>
+</div>
+<div class="nav-panel-explore" data-panel="explore">
+  <div class="context">
+    <span class="title">JBang</span>
+    <span class="version">latest</span>
+  </div>
+  <ul class="components">
+    <li class="component is-current">
+      <a class="title" href="index.html">JBang</a>
+      <ul class="versions">
+        <li class="version is-current is-latest">
+          <a href="index.html">latest</a>
+        </li>
+      </ul>
+    </li>
+    <li class="component">
+      <a class="title" href="../../jbang-idea/latest/index.html">JBang Idea Plugin</a>
+      <ul class="versions">
+        <li class="version is-latest">
+          <a href="../../jbang-idea/latest/index.html">latest</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+    </div>
+  </aside>
+</div>
+<main class="article">
+<div class="toolbar" role="navigation">
+<button class="nav-toggle"></button>
+  <a href="index.html" class="home-link"></a>
+<nav class="breadcrumbs" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="index.html">JBang</a></li>
+    <li><a href="faq.html">FAQ</a></li>
+  </ul>
+</nav>
+  <div class="edit-this-page"><a href="https://github.com/jbangdev/jbang/edit/main/docs/modules/ROOT/pages/faq.adoc">Edit this Page</a></div>
+  </div>
+  <div class="content">
+<aside class="toc sidebar" data-title="Contents" data-levels="2">
+  <div class="toc-menu"></div>
+</aside>
+<article class="doc">
+<h1 class="page">FAQ</h1>
+<div id="preamble">
+<div class="sectionbody">
+<div class="qlist qanda">
+<ol>
+<li>
+<p><em>Why the name j&#8217;bang?</em></p>
+<p>  I was reading up on how to use the new shebang (#!) feature support in Java 10 and came up with the idea of port <code>kscript</code> to Java and needed a name.
+From there came j&#8217;bang which is a "bad" spelling of how shebang is pronounced in French.</p>
+</li>
+<li>
+<p><em>Why use gradle resource locators rather than ?</em></p>
+<p>kscript used it and it&#8217;s nice as it is a one-liner and easily parsable.</p>
+</li>
+<li>
+<p><em>How does this compare to ?</em></p>
+<p>After doing <code>jbang</code> I&#8217;ve learned about similar projects and thought it would be nice with some comparison;</p>
+<div class="paragraph">
+<p><a href="https://github.com/scijava/jgo">jgo</a>: an alternative way to launch jars using maven coordinates. Implemented in python, depends on Java and Maven to be available. Not really for scripting but a novel way to launch java apps already packaged as a maven dependency.</p>
+</div>
+</li>
+<li>
+<p><em>Why is JBang scripting examples using lower case class names ?</em></p>
+<p>JBang works with any valid Java class names including Java&#8217;s standard camel case conventions. The scripting examples are using lower case because the scripts can be used as a command line tool. i.e. <code>./hello.java</code>. Just like people are used to Java using camel case for class names, they are also used to using lower case for command line tools. So JBang is just following the convention most relevant for the scripting use case. Thus <code>helloworld.java</code> instead of <code>HelloWorld.java</code>; but if you prefer the latter you can always use it.</p>
+</li>
+<li>
+<p><em>Why would I use Java to write scripts ? Java sucks for that&#8230;&#8203; Use groovy, kotlin, scala, etc. instead!</em></p>
+<p>  Well, does it really suck ? With Java 8 streams, static imports and greatly improved standard java libraries it is very close to what kscript and grape look like.
+With the following advantages:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>works with plain Java without installing additional compiler/build tools</p>
+</li>
+<li>
+<p>all IDE&#8217;s support editing .java files very well, content assist, etc.</p>
+</li>
+<li>
+<p>great debugging</p>
+<div class="paragraph">
+<p>And to be honest I built <code>jbang</code> just to see if I could and get my Java skills refreshed for the newer features in the language.
+Use it at your own risk :)</p>
+</div>
+</li>
+</ul>
+</div>
+</li>
+<li>
+<p><em>Why not use normal shebang(<code>#!</code>) in the header ?</em></p>
+<p>  You can use normal shebang (<code>#!/usr/bin/env jbang</code>) and the Java 10+ launcher (<code>java test.java</code>) will actually work with it from the command line.
+However the Java compiler will still not accept it (<code>javac test.java</code> with shebang fails.) This is thus not recommended, as
+many tools, code formatters ([example](<a href="https://github.com/google/google-java-format/issues/1214)" class="bare">https://github.com/google/google-java-format/issues/1214)</a>), and especially IDE&#8217;s will start complaining about syntax errors as they don&#8217;t ignore the first line in this case.</p>
+<div class="paragraph">
+<p>By using the <code>//</code> form it is treated as both a bash/shell file AND a valid java file and thus works everywhere a java file will work.</p>
+</div>
+<div class="paragraph">
+<p>It&#8217;s worth noting that Go <a href="https://golangcookbook.com/chapters/running/shebang/">uses a similar approach</a> which is also where I learned it from.</p>
+</div>
+</li>
+<li>
+<p><em>HELP! My code formatter keeps breaking my <code>//</code> directives!</em></p>
+<p>When using automated code formatting tools, some care and configuration must be made to prevent the tooling from rewriting and preventing <code>jbang</code> from working as expected.</p>
+<div class="paragraph">
+<p>Use the following configuration blocks to correctly configure your tool:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 1. Configuration Tool Settings:</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Formatting Tool</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Configuration</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Google Java Format</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">see <a href="https://github.com/google/google-java-format/issues/1215">#1215</a> &amp; <a href="https://github.com/google/google-java-format/issues/1214">#1214</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Clang Format</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-none hljs">CommentPragmas:  '^[^ ]'</code></pre>
+</div>
+</div></div></td>
+</tr>
+</tbody>
+</table>
+</li>
+</ol>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="article-presentations"><a class="anchor" href="#article-presentations"></a>Article &amp; Presentations</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p><a href="https://adambien.blog/roller/abien/entry/java_cli_apps_builds_and">Java CLI Apps, Builds and jbang&#8212;&#8203;airhacks.fm podcast</a> - Adam Bien</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.infoq.com/news/2020/10/scripting-java-jbang">Scripting Java with a jBang</a> - InfoQ - Alex Blewitt</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=-c9CIT9RfOQ&amp;t=123s">jbang: Unleash the power of Java for shell scripting</a> - DevNation Tech Talk - Max Rydahl Andersen</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=A9YeRPSCdVU&amp;t=5s">Creating java code and simplifying execution with JBang</a> - Daniel Persson</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=3JopX_mtFiY&amp;t=14s">Quarkus Insights #16: Quarkus with JBang</a> - Quarkus Insights</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=gVL-CFEOGs8">jbang, a better Java?</a> - Swiss JUG - Max Rydahl Andersen</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=X4x2jM3Y0uE">JBang - Using Java to make Java better?</a> - Virtual JUG - Max Rydahl Andersen</p>
+</div>
+<div class="paragraph">
+<p><a href="https://blogs.oracle.com/developers/self-contained-jdbc-scripts-with-groovy-and-jbang">Self contained JDBC scripts with Groovy and jbang</a> - Andres Almiray</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=FzKRqvZv-Ro">Neo4j quickie - jbang and the command line</a> - Gerrit Meier</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.youtube.com/watch?v=RgHNOH2_itw&amp;t=300s">Monday Java Lunch &amp; Learn. This week we&#8217;ll be learning what jbang is and how to use it</a> - Matthew Gilliard</p>
+</div>
+<div class="paragraph">
+<p><a href="https://www.twilio.com/blog/cli-app-java-jbang-picocli">How to build a CLI app in Java using jbang and picocli</a> - Matthew Gilliard</p>
+</div>
+<div class="paragraph">
+<p><a href="https://javastreets.com/blog/java-jbang-textmate.html">Faster Feedback with Java, JBang, and TextMate</a> - Manik Magar</p>
+</div>
+<div class="paragraph">
+<p><a href="http://www.mastertheboss.com/java/java-scripting-with-jbang/"> JBang: Create Java scripts like a pro</a> - Francesco Marchioni</p>
+</div>
+<div class="paragraph">
+<p><a href="http://www.mastertheboss.com/java/jbang-vs-jshell/"> 6 things you can do with JBang but you can’t with Shell</a> - Francesco Marchioni</p>
+</div>
+</div>
+</div>
+<nav class="pagination">
+  <span class="prev"><a href="caching.html">Caching</a></span>
+  <span class="next"><a href="cli/jbang.html">jbang</a></span>
+</nav>
+</article>
+  </div>
+</main>
+</div>
+<footer class="footer">
+  <div class="page__footer-follow">
+    <ul class="social-icons">
+      <li><strong>Follow:</strong></li>
+      <li><a href="https://twitter.com/jbangdev" rel="nofollow noopener noreferrer"><i
+            class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
+      <li><a href="https://github.com/jbangdev" rel="nofollow noopener noreferrer"><i class="fab fa-fw fa-github"
+            aria-hidden="true"></i> GitHub</a></li>
+      <li><a href="/feed.xml"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> Feed</a></li>
+    </ul>
+  </div>
+  <div class="page__footer-copyright">© 2021 JBang Documentation. Powered by <a href="https://antora.org" rel="nofollow">Antora</a>
+    &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.
+  </div>
+</footer><script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script>
+var search = docsearch({
+  appId: '4EJ1Y6VISV',
+  apiKey: '7ab0733177a5304fe689e52ed96d5cb8',
+  indexName: 'jbangdev',
+  inputSelector: '#search-input',
+  autocompleteOptions: { hint: false, keyboardShortcuts: ['s'] },
+  algoliaOptions: { hitsPerPage: 10 }
+}).autocomplete
+search.on('autocomplete:closed', function () { search.autocomplete.setVal() })
+</script>
+<script>
+window.addEventListener('load', function focusSearchInput () {
+  window.removeEventListener('load', focusSearchInput)
+  document.querySelector('#search-input').focus()
+})
+</script>
+<script src="../../_/js/site.js"></script>
+<script async src="../../_/js/vendor/highlight.js"></script>
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"rayId":"955eed9918c82f82","version":"2025.6.2","serverTiming":{"name":{"cfExtPri":true,"cfEdge":true,"cfOrigin":true,"cfL4":true,"cfSpeedBrain":true,"cfCacheStatus":true}},"token":"7751df529a8847fab0e3b0c550b186fa","b":1}' crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/test/resources/wiremock/__files/documentation_guide_latest_index.html-b87100f8-545d-48df-af7a-68756abdf751.txt
+++ b/src/test/resources/wiremock/__files/documentation_guide_latest_index.html-b87100f8-545d-48df-af7a-68756abdf751.txt
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Intro :: JBang</title>
+    <link rel="next" href="installation.html">
+    <meta name="generator" content="Antora 3.0.0">
+    <link rel="stylesheet" href="../../_/css/site.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"/>    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-156530423-2"></script>
+    <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','UA-156530423-2')</script>
+    <script>var uiRootPath = '../../_'</script>
+  </head>
+  <body class="article">
+<header class="header">
+  <nav class="navbar">
+    <div class="navbar-brand">
+      <a class="navbar-item" href="https://jbang.dev">JBang</a>
+      <button class="navbar-burger" data-target="topbar-nav">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <div id="topbar-nav" class="navbar-menu">
+      <div class="navbar-end">
+        <a class="navbar-item" href="/appstore">AppStore</a>
+        <a class="navbar-item" href="/try">Try</a>
+        <a class="navbar-item" href="/download">Download</a>
+                <a class="navbar-item" href="/documentation">Documentation</a>
+      </div>
+    </div>
+    <div class="navbar-item hide-for-print">
+        <input id="search-input" type="text" placeholder="Search (by Algolia)">
+      </div>
+  </nav>
+</header>
+<div class="body">
+<div class="nav-container" data-component="guide" data-version="latest">
+  <aside class="nav">
+    <div class="panels">
+<div class="nav-panel-menu is-active" data-panel="menu">
+  <nav class="nav-menu">
+    <h3 class="title"><a href="index.html">JBang</a></h3>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="0">
+<ul class="nav-list">
+  <li class="nav-item is-current-page" data-depth="1">
+    <a class="nav-link" href="index.html">Intro</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="installation.html">Installation</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="usage.html">Usage</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="dependencies.html">Dependencies</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="javaversions.html">Java Versions</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="organizing.html">File Organization</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="running.html">Running</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="debugging.html">Debugging</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="editing.html">Editing</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="exporting.html">Exporting</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="install.html">Install Apps</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="templates.html">Templates</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="alias_catalogs.html">Aliases &amp; Catalogs</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="integration.html">Integration</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="configuration.html">Configuration</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="caching.html">Caching</a>
+  </li>
+  <li class="nav-item" data-depth="1">
+    <a class="nav-link" href="faq.html">FAQ</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="0">
+<ul class="nav-list">
+  <li class="nav-item" data-depth="1">
+    <button class="nav-item-toggle"></button>
+    <span class="nav-text">CLI Reference</span>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="2">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang.html">jbang</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-run.html">run</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-build.html">build</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-edit.html">edit</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-init.html">init</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-alias.html">alias</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-alias-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-template.html">template</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-template-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-catalog.html">catalog</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-update.html">update</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-catalog-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-trust.html">trust</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-add.html">add</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-trust-remove.html">remove</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-cache.html">cache</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-cache-clear.html">clear</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-completion.html">completion</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-jdk.html">jdk</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-default.html">default</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-home.html">home</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-install.html">install</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-java-env.html">java-env, env</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-jdk-uninstall.html">uninstall</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <a class="nav-link" href="cli/jbang-version.html">version</a>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-wrapper.html">wrapper</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-wrapper-install.html">install</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-info.html">info</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-tools.html">tools</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-classpath.html">classpath</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-info-jar.html">jar</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-app.html">app</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-install.html">install</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-list.html">list</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-uninstall.html">uninstall</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-app-setup.html">setup</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-export.html">export</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-portable.html">portable</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-local.html">local</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-mavenrepo.html">mavenrepo</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-native.html">native</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-fatjar.html">fatjar</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-jlink.html">jlink</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-gradle.html">gradle</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-export-maven.html">maven</a>
+  </li>
+</ul>
+  </li>
+  <li class="nav-item" data-depth="3">
+    <button class="nav-item-toggle"></button>
+    <a class="nav-link" href="cli/jbang-config.html">config</a>
+<ul class="nav-list">
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-get.html">get</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-set.html">set</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-unset.html">unset</a>
+  </li>
+  <li class="nav-item" data-depth="4">
+    <a class="nav-link" href="cli/jbang-config-list.html">list</a>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+  </nav>
+</div>
+<div class="nav-panel-explore" data-panel="explore">
+  <div class="context">
+    <span class="title">JBang</span>
+    <span class="version">latest</span>
+  </div>
+  <ul class="components">
+    <li class="component is-current">
+      <a class="title" href="index.html">JBang</a>
+      <ul class="versions">
+        <li class="version is-current is-latest">
+          <a href="index.html">latest</a>
+        </li>
+      </ul>
+    </li>
+    <li class="component">
+      <a class="title" href="../../jbang-idea/latest/index.html">JBang Idea Plugin</a>
+      <ul class="versions">
+        <li class="version is-latest">
+          <a href="../../jbang-idea/latest/index.html">latest</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+    </div>
+  </aside>
+</div>
+<main class="article">
+<div class="toolbar" role="navigation">
+<button class="nav-toggle"></button>
+  <a href="index.html" class="home-link is-current"></a>
+<nav class="breadcrumbs" aria-label="breadcrumbs">
+  <ul>
+    <li><a href="index.html">JBang</a></li>
+    <li><a href="index.html">Intro</a></li>
+  </ul>
+</nav>
+  <div class="edit-this-page"><a href="https://github.com/jbangdev/jbang/edit/main/docs/modules/ROOT/pages/index.adoc">Edit this Page</a></div>
+  </div>
+  <div class="content">
+<aside class="toc sidebar" data-title="Contents" data-levels="2">
+  <div class="toc-menu"></div>
+</aside>
+<article class="doc">
+<h1 class="page">Intro</h1>
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p><span class="image"><img src="_images/jbang_logo.svg" alt="JBang Logo" title="JBang Logo"></span></p>
+</div>
+<div class="paragraph">
+<p>Want to learn, explore or use Java instantly without setup ?</p>
+</div>
+<div class="paragraph">
+<p>Do you like Java but use python, groovy, kotlin or similar languages for scripts, experimentation and exploration ?</p>
+</div>
+<div class="paragraph">
+<p>Ever wanted to just be able to run java from anywhere without any or very minimal setup ?
+Ever tried out Java 11+ support for running <code>.java</code> files directly in your shell but felt it was a bit too cumbersome ?</p>
+</div>
+<div class="paragraph">
+<p>Then try <code>jbang</code> which lets you do this:</p>
+</div>
+<div class="paragraph">
+<p><span class="image"><a class="image" href="https://asciinema.org/a/4AiobRxUwPUPztCtrDYcmoKjs?autoplay=true&amp;theme=solarized-dark"><img src="https://asciinema.org/a/4AiobRxUwPUPztCtrDYcmoKjs.svg" alt="4AiobRxUwPUPztCtrDYcmoKjs"></a></span></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ jbang init --template=cli hello.java
+$ jbang hello.java Max!
+[jbang] Resolving dependencies...
+[jbang]     Resolving info.picocli:picocli:4.6.3...Done
+[jbang] Dependencies resolved
+[jbang] Building jar...
+Hello Max!
+$ jbang hello.java -h
+Usage: hello [-hV] &lt;greeting&gt;
+hello made with jbang
+      &lt;greeting&gt;   The greeting to print
+  -h, --help       Show this help message and exit.
+  -V, --version    Print version information and exit.</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Instant app generated built using java and picocli as a dependency that was fetched as needed for the compilation and execution.</p>
+</div>
+<div class="paragraph">
+<p>JBang goes beyond more than just easy scripting; you can use <code>jbang</code> to launch any kind of java application or library packaged as a jar available locally, via http/https download or in a Maven repository.</p>
+</div>
+<!-- toc disabled -->
+</div>
+</div>
+<div class="sect1">
+<h2 id="features"><a class="anchor" href="#features"></a>Features</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><code>.java</code> Scripting for Java 8 and upwards</p>
+</li>
+<li>
+<p><code>.jsh</code> via JShell from Java 9 and upwards</p>
+</li>
+<li>
+<p><code>.kt</code> via kotlinc (EXPERIMENTAL)</p>
+</li>
+<li>
+<p><code>.groovy</code> via groovyc (EXPERIMENTAL)</p>
+</li>
+<li>
+<p>Extract codeblocks from Markdown files (<code>.md</code>) (EXPERIMENTAL)</p>
+</li>
+<li>
+<p>Works on <span class="icon"><i class="fa fa-windows"></i></span> Windows, <span class="icon"><i class="fa fa-apple"></i></span> OSX and <span class="icon"><i class="fa fa-linux"></i></span> Linux and AIX</p>
+</li>
+<li>
+<p>Install using curl, power shell, SDKMan (<span class="icon"><i class="fa fa-apple"></i></span>/<span class="icon"><i class="fa fa-linux"></i></span>), Homebrew (<span class="icon"><i class="fa fa-apple"></i></span>), Chocolatey (<span class="icon"><i class="fa fa-windows"></i></span>) or Scoop (<span class="icon"><i class="fa fa-windows"></i></span>)</p>
+</li>
+<li>
+<p>If needed will automatically install Java and even a Java editor (vscodium) for editing</p>
+</li>
+<li>
+<p>Installation of scripts to user <code>PATH</code></p>
+</li>
+<li>
+<p>Include multiple files and sources</p>
+</li>
+<li>
+<p>Dependency declarations using <code>//DEPS &lt;gav&gt;</code> for automatic dependency resolution</p>
+</li>
+<li>
+<p>Control compile and runtime options with <code>//COMPILE_OPTIONS &lt;flags&gt;</code>, <code>//NATIVE_OPTIONS &lt;flags&gt;</code> and <code>//RUNTIME_OPTIONS &lt;flags&gt;</code></p>
+</li>
+<li>
+<p>Compiled jar and Dependency resolution caching</p>
+</li>
+<li>
+<p>native-image generation (<code>--native</code>)</p>
+</li>
+<li>
+<p>Launch with debug enabled for instant debugging from your favorite IDE</p>
+</li>
+<li>
+<p>Transparent launch of JavaFX Applications on Java 8 and higher</p>
+</li>
+<li>
+<p>Can be used for writing plugins to other cli&#8217;s like <code>kubectl</code></p>
+</li>
+<li>
+<p>Init templates to get started easily (<code>jbang init -t cli hello.java</code>)</p>
+</li>
+<li>
+<p>Generate gradle and IDE config with dependencies for easy editing in your favorite IDE (<code>jbang edit myfile.java</code>)</p>
+</li>
+<li>
+<p>Maven and Gradle plugins for easy integration with your favorite build tool</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>To use it install <code>jbang</code> and run <code>jbang yourscript.java</code></p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="requirements"><a class="anchor" href="#requirements"></a>Requirements</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Tested and verified to use on OSX, Linux, AIX, Windows (incl. command.exe, cygwin and mingw shells).</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
+<td class="icon">
+<i class="fa icon-note" title="Note"></i>
+</td>
+<td class="content">
+<div class="paragraph">
+<p>AIX requires the GNU <code>readlink</code> tool from the GNU coreutils to be available
+in the PATH when running <code>jbang</code>.  This is not supplied by default with AIX.
+Prebuilt versions can be obtained via the IBM AIX toolbox at
+<a href="https://www.ibm.com/support/pages/aix-toolbox-linux-applications-downloads-alpha" class="bare">https://www.ibm.com/support/pages/aix-toolbox-linux-applications-downloads-alpha</a>
+or elsewhere.</p>
+</div>
+</td>
+</tr>
+</table>
+</div>
+</div>
+</div>
+<nav class="pagination">
+  <span class="next"><a href="installation.html">Installation</a></span>
+</nav>
+</article>
+  </div>
+</main>
+</div>
+<footer class="footer">
+  <div class="page__footer-follow">
+    <ul class="social-icons">
+      <li><strong>Follow:</strong></li>
+      <li><a href="https://twitter.com/jbangdev" rel="nofollow noopener noreferrer"><i
+            class="fab fa-fw fa-twitter-square" aria-hidden="true"></i> Twitter</a></li>
+      <li><a href="https://github.com/jbangdev" rel="nofollow noopener noreferrer"><i class="fab fa-fw fa-github"
+            aria-hidden="true"></i> GitHub</a></li>
+      <li><a href="/feed.xml"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> Feed</a></li>
+    </ul>
+  </div>
+  <div class="page__footer-copyright">© 2021 JBang Documentation. Powered by <a href="https://antora.org" rel="nofollow">Antora</a>
+    &amp; <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.
+  </div>
+</footer><script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script>
+var search = docsearch({
+  appId: '4EJ1Y6VISV',
+  apiKey: '7ab0733177a5304fe689e52ed96d5cb8',
+  indexName: 'jbangdev',
+  inputSelector: '#search-input',
+  autocompleteOptions: { hint: false, keyboardShortcuts: ['s'] },
+  algoliaOptions: { hitsPerPage: 10 }
+}).autocomplete
+search.on('autocomplete:closed', function () { search.autocomplete.setVal() })
+</script>
+<script>
+window.addEventListener('load', function focusSearchInput () {
+  window.removeEventListener('load', focusSearchInput)
+  document.querySelector('#search-input').focus()
+})
+</script>
+<script src="../../_/js/site.js"></script>
+<script async src="../../_/js/vendor/highlight.js"></script>
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"rayId":"955eeda1bf43cbc3","version":"2025.6.2","serverTiming":{"name":{"cfExtPri":true,"cfEdge":true,"cfOrigin":true,"cfL4":true,"cfSpeedBrain":true,"cfCacheStatus":true}},"token":"7751df529a8847fab0e3b0c550b186fa","b":1}' crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/test/resources/wiremock/mappings/documentation_guide_latest_faq.html-0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd.json
+++ b/src/test/resources/wiremock/mappings/documentation_guide_latest_faq.html-0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd.json
@@ -1,0 +1,39 @@
+{
+  "id" : "0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd",
+  "name" : "documentation_guide_latest_faq.html",
+  "request" : {
+    "url" : "/documentation/guide/latest/faq.html",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "documentation_guide_latest_faq.html-0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd.txt",
+    "headers" : {
+      "expires" : "Thu, 26 Jun 2025 18:57:14 GMT",
+      "Server" : "cloudflare",
+      "x-fastly-request-id" : "f6ab6f7e878538563d4bb02880f1cf76b8881c87",
+      "vary" : "Accept-Encoding",
+      "Server-Timing" : [ "cfCacheStatus;desc=\"DYNAMIC\"", "cfOrigin;dur=116,cfEdge;dur=74", "cfL4;desc=\"?proto=TCP&rtt=19045&min_rtt=18939&rtt_var=5491&sent=6&recv=7&lost=0&retrans=0&sent_bytes=3108&recv_bytes=739&delivery_rate=222710&cwnd=252&unsent_bytes=0&cid=5295f5ee8dec24c2&ts=224&x=0\"" ],
+      "x-served-by" : "cache-mad22067-MAD",
+      "x-cache-hits" : "0",
+      "via" : "1.1 varnish",
+      "last-modified" : "Sun, 22 Jun 2025 15:24:37 GMT",
+      "x-proxy-cache" : "MISS",
+      "Report-To" : "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=Jfsxvt3mv%2FKFweSSQvHZ6rAS2VVOFUniTs0DD4GIpdvqaZRr0%2BElGIcB9tQcNRPAO7bfbI9g9W5IKZZcwQWOzvpbtOIzIncnpEDPx032A83TcwEG5N8pk99ziygcinE%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
+      "Age" : "0",
+      "Content-Type" : "text/html; charset=utf-8",
+      "CF-RAY" : "955eed9918c82f82-MAD",
+      "cf-cache-status" : "DYNAMIC",
+      "Date" : "Thu, 26 Jun 2025 18:57:03 GMT",
+      "x-github-request-id" : "D4A8:45F2A:33B03:364E0:685D95B1",
+      "access-control-allow-origin" : "*",
+      "NEL" : "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}",
+      "Cache-Control" : "max-age=600",
+      "x-timer" : "S1750964223.972421,VS0,VE112",
+      "x-cache" : "HIT"
+    }
+  },
+  "uuid" : "0ca4eab8-d4c2-4b99-a7f4-78d08519dcbd",
+  "persistent" : true,
+  "insertionIndex" : 31
+}

--- a/src/test/resources/wiremock/mappings/documentation_guide_latest_index.html-b87100f8-545d-48df-af7a-68756abdf751.json
+++ b/src/test/resources/wiremock/mappings/documentation_guide_latest_index.html-b87100f8-545d-48df-af7a-68756abdf751.json
@@ -1,0 +1,40 @@
+{
+  "id" : "b87100f8-545d-48df-af7a-68756abdf751",
+  "name" : "documentation_guide_latest_index.html",
+  "request" : {
+    "url" : "/documentation/guide/latest/index.html",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName" : "documentation_guide_latest_index.html-b87100f8-545d-48df-af7a-68756abdf751.txt",
+    "headers" : {
+      "expires" : "Thu, 26 Jun 2025 18:57:15 GMT",
+      "Server" : "cloudflare",
+      "x-fastly-request-id" : "6fe247cb54709c82d56c37e2d690114505b0d2dd",
+      "vary" : "Accept-Encoding",
+      "Server-Timing" : [ "cfCacheStatus;desc=\"DYNAMIC\"", "cfOrigin;dur=109,cfEdge;dur=34", "cfL4;desc=\"?proto=TCP&rtt=17342&min_rtt=16973&rtt_var=5504&sent=6&recv=7&lost=0&retrans=0&sent_bytes=3110&recv_bytes=741&delivery_rate=219933&cwnd=252&unsent_bytes=0&cid=996103d570a49dd9&ts=168&x=0\"" ],
+      "x-served-by" : "cache-mad2200085-MAD",
+      "x-cache-hits" : "0",
+      "via" : "1.1 varnish",
+      "last-modified" : "Sun, 22 Jun 2025 15:24:37 GMT",
+      "x-proxy-cache" : "MISS",
+      "Report-To" : "{\"endpoints\":[{\"url\":\"https:\\/\\/a.nel.cloudflare.com\\/report\\/v4?s=CSEQ177h8tbIeXcAwJ%2FhneDlaFQ8kCrrnDs0MYFh9FDlptOqoSmb2d7hrfh9KCLjHKU8nmmISMsXNq%2FeXglDlbkQ2fJ2VR9tRWU%2FFalQbsmHfeYgd2ghAYQoHKtzf0Q%3D\"}],\"group\":\"cf-nel\",\"max_age\":604800}",
+      "Age" : "0",
+      "Content-Type" : "text/html; charset=utf-8",
+      "CF-RAY" : "955eeda1bf43cbc3-MAD",
+      "x-origin-cache" : "HIT",
+      "cf-cache-status" : "DYNAMIC",
+      "Date" : "Thu, 26 Jun 2025 18:57:04 GMT",
+      "x-github-request-id" : "6D73:144AE9:2961D:2BF8F:685D95B1",
+      "access-control-allow-origin" : "*",
+      "NEL" : "{\"success_fraction\":0,\"report_to\":\"cf-nel\",\"max_age\":604800}",
+      "Cache-Control" : "max-age=600",
+      "x-timer" : "S1750964224.309867,VS0,VE108",
+      "x-cache" : "HIT"
+    }
+  },
+  "uuid" : "b87100f8-545d-48df-af7a-68756abdf751",
+  "persistent" : true,
+  "insertionIndex" : 32
+}

--- a/src/test/resources/wiremock/mappings/notthere-8c678d14-2b7d-40dc-a8a0-62ba46b4af6e.json
+++ b/src/test/resources/wiremock/mappings/notthere-8c678d14-2b7d-40dc-a8a0-62ba46b4af6e.json
@@ -1,0 +1,23 @@
+{
+  "id" : "8c678d14-2b7d-40dc-a8a0-62ba46b4af6e",
+  "name" : "notthere",
+  "request" : {
+    "url" : "/notthere",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 404,
+    "body" : "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<html><head>\n<title>404 Not Found</title>\n</head><body>\n<h1>Not Found</h1>\n<p>The requested URL was not found on this server.</p>\n</body></html>\n",
+    "headers" : {
+      "X-Varnish" : "15992699722",
+      "Server" : "Apache",
+      "Age" : "0",
+      "Date" : "Thu, 26 Jun 2025 18:57:04 GMT",
+      "Via" : "1.1 webcache2 (Varnish/trunk)",
+      "Content-Type" : "text/html; charset=iso-8859-1"
+    }
+  },
+  "uuid" : "8c678d14-2b7d-40dc-a8a0-62ba46b4af6e",
+  "persistent" : true,
+  "insertionIndex" : 33
+}


### PR DESCRIPTION
We used to throw exceptions when sibling sources or resources were
missing or if an error occurred while resolving them. But this makes it
difficult to use the `jbang info` command on a source that has missing
siblings. So now we no longer throw exceptions, but use the special
`UnresolvableResourceRef` to indicate that the resource could not be
resolved. This allows the `jbang info` command to still work and show
information about the source, even if some of its siblings are missing.

Fixes https://github.com/jbangdev/jbang/issues/2069