### PR TITLE
fix: add -t as short hand for --source-type

### DIFF
--- a/src/main/java/dev/jbang/cli/ScriptMixin.java
+++ b/src/main/java/dev/jbang/cli/ScriptMixin.java
@@ -17,7 +17,7 @@ public class ScriptMixin {
 			"--files" }, converter = CommaSeparatedConverter.class, description = "Add additional files.")
 	List<String> resources;
 
-	@CommandLine.Option(names = { "-t",
+	@CommandLine.Option(names = { "-T",
 			"--source-type" }, description = "Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown")
 	Source.Type forceType;
 

--- a/src/main/java/dev/jbang/cli/ScriptMixin.java
+++ b/src/main/java/dev/jbang/cli/ScriptMixin.java
@@ -17,7 +17,7 @@ public class ScriptMixin {
 			"--files" }, converter = CommaSeparatedConverter.class, description = "Add additional files.")
 	List<String> resources;
 
-	@CommandLine.Option(names = {
+	@CommandLine.Option(names = { "-t",
 			"--source-type" }, description = "Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown")
 	Source.Type forceType;
 


### PR DESCRIPTION
while testing the fix for #1975 I got tired of typing out `--source-type java` all the time so thought `-t` would be good to have as option.

not merging it directly as `-t` could probably be used for lot of other things ... so if other suggestions on ways we could avoid having to always fully type `--source-type` i'm all ears....otherwise lets merge it as #1975 actually is quite useful now that it actually works ;)