### PR TITLE
fix: `JBANG_JDK_VENDOR` can again be used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ sourceSets {
 sourceSets.main.compileClasspath += sourceSets.java9.output.classesDirs;
 
 dependencies {
-	implementation 'dev.jbang:devkitman:0.1.2'
+	implementation 'dev.jbang:devkitman:0.2.0'
 
 	implementation 'org.apache.commons:commons-text:1.11.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'

--- a/src/main/java/dev/jbang/Cache.java
+++ b/src/main/java/dev/jbang/Cache.java
@@ -28,7 +28,7 @@ public class Cache {
 			if (cc == CacheClass.jdks && Util.isWindows() && jdkMan.isCurrentJdkManaged()) {
 				// We're running using a managed JDK on Windows so we can't just delete the
 				// entire folder!
-				for (Jdk jdk : jdkMan.listInstalledJdks()) {
+				for (Jdk.InstalledJdk jdk : jdkMan.listInstalledJdks()) {
 					jdkMan.uninstallJdk(jdk);
 				}
 			}

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -138,7 +138,7 @@ abstract class BaseInfoCommand extends BaseCommand {
 					Jdk jdk = assureJdkInstalled ? jdkMan.getOrInstallJdk(requestedJavaVersion)
 							: jdkMan.getJdk(requestedJavaVersion);
 					if (jdk != null && jdk.isInstalled()) {
-						availableJdkPath = jdk.home().toString();
+						availableJdkPath = ((Jdk.InstalledJdk) jdk).home().toString();
 					}
 				} catch (ExitException e) {
 					// Ignore

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -48,7 +48,9 @@ public class Jdk {
 						throw new IllegalArgumentException("JDK is not available for installation: " + versionOrId);
 					}
 				}
-				jdk.install();
+				if (!jdk.isInstalled()) {
+					((dev.jbang.devkitman.Jdk.AvailableJdk) jdk).install();
+				}
 			}
 		} else {
 			Util.infoMsg("JDK is already installed: " + jdk);
@@ -69,7 +71,7 @@ public class Jdk {
 		dev.jbang.devkitman.Jdk defaultJdk = jdkMan.getDefaultJdk();
 		int defMajorVersion = defaultJdk != null ? defaultJdk.majorVersion() : 0;
 		PrintStream out = System.out;
-		List<dev.jbang.devkitman.Jdk> jdks;
+		List<? extends dev.jbang.devkitman.Jdk> jdks;
 		if (available) {
 			jdks = jdkMan.listAvailableJdks();
 		} else {
@@ -77,7 +79,7 @@ public class Jdk {
 		}
 		List<JdkOut> jdkOuts = jdks.stream()
 			.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
-					jdk.isInstalled() ? jdk.home() : null,
+					jdk.isInstalled() ? ((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).home() : null,
 					details ? jdk.equals(defaultJdk)
 							: jdk.majorVersion() == defMajorVersion))
 			.collect(Collectors.toList());
@@ -157,7 +159,8 @@ public class Jdk {
 	public Integer uninstall(
 			@CommandLine.Parameters(paramLabel = "version", index = "0", description = "The version to install", arity = "1") String versionOrId) {
 		JdkManager jdkMan = jdkProvidersMixin.getJdkManager();
-		dev.jbang.devkitman.Jdk jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canUpdate);
+		dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getInstalledJdk(versionOrId,
+				JdkProvider.Predicates.canUpdate);
 		if (jdk == null) {
 			throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
 		}
@@ -170,7 +173,7 @@ public class Jdk {
 	public Integer home(
 			@CommandLine.Parameters(paramLabel = "versionOrId", index = "0", description = "The version of the JDK to select", arity = "0..1") String versionOrId) {
 		JdkManager jdkMan = jdkProvidersMixin.getJdkManager();
-		dev.jbang.devkitman.Jdk jdk = jdkMan.getOrInstallJdk(versionOrId);
+		dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getOrInstallJdk(versionOrId);
 		if (jdk.isInstalled()) {
 			Path home = jdk.home();
 			String homeStr = Util.pathToString(home);
@@ -191,7 +194,7 @@ public class Jdk {
 			jdk = jdkMan.getOrInstallJdk(versionOrId);
 		}
 		if (jdk.isInstalled()) {
-			Path home = jdk.home();
+			Path home = ((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).home();
 			String homeStr = Util.pathToString(home);
 			String homeOsStr = Util.pathToOsString(home);
 			PrintStream out = System.out;
@@ -237,9 +240,9 @@ public class Jdk {
 			Util.warnMsg("Cannot perform operation, the 'default' provider was not found");
 			return EXIT_INVALID_INPUT;
 		}
-		dev.jbang.devkitman.Jdk defjdk = jdkMan.getDefaultJdk();
+		dev.jbang.devkitman.Jdk.InstalledJdk defjdk = jdkMan.getDefaultJdk();
 		if (versionOrId != null) {
-			dev.jbang.devkitman.Jdk jdk = jdkMan.getOrInstallJdk(versionOrId);
+			dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getOrInstallJdk(versionOrId);
 			if (defjdk == null || (!jdk.equals(defjdk) && !Objects.equals(jdk.home(), defjdk.home()))) {
 				jdkMan.setDefaultJdk(jdk);
 			} else {

--- a/src/main/java/dev/jbang/source/Project.java
+++ b/src/main/java/dev/jbang/source/Project.java
@@ -51,7 +51,7 @@ public class Project {
 
 	// Cached values
 	private String stableId;
-	private Jdk projectJdk;
+	private Jdk.InstalledJdk projectJdk;
 
 	public static final String ATTR_PREMAIN_CLASS = "Premain-Class";
 	public static final String ATTR_AGENT_CLASS = "Agent-Class";
@@ -292,7 +292,7 @@ public class Project {
 		return jdkManager;
 	}
 
-	public Jdk projectJdk() {
+	public Jdk.InstalledJdk projectJdk() {
 		if (projectJdk == null) {
 			projectJdk = projectJdkManager().getOrInstallJdk(getJavaVersion());
 		}

--- a/src/main/java/dev/jbang/util/JavaUtil.java
+++ b/src/main/java/dev/jbang/util/JavaUtil.java
@@ -74,7 +74,9 @@ public class JavaUtil {
 				break;
 			case "jbang":
 				JBangJdkProvider p = new JBangJdkProvider();
-				p.installer(new FoojayJdkInstaller(p).remoteAccessProvider(new JBangRemoteAccessProvider()));
+				p.installer(new FoojayJdkInstaller(p, p::jdkId)
+					.distro(Util.getVendor())
+					.remoteAccessProvider(new JBangRemoteAccessProvider()));
 				provider = p;
 				break;
 			default:
@@ -179,7 +181,7 @@ public class JavaUtil {
 
 	public static String resolveInJavaHome(@Nonnull String cmd, @Nonnull Jdk jdk) {
 		if (jdk.isInstalled()) {
-			Path jdkHome = jdk.home();
+			Path jdkHome = ((Jdk.InstalledJdk) jdk).home();
 			if (Util.isWindows()) {
 				cmd = cmd + ".exe";
 			}

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -316,9 +316,8 @@ class TestJdk extends BaseTest {
 			try {
 				jdk.install(true, "13", javaDir.toPath().toString());
 			} catch (Exception e) {
-				assertInstanceOf(ExitException.class, e);
-				assertEquals("Java version in given path: " + javaDir.toPath()
-						+ " is " + 11 + " which does not match the requested version " + 13 + "", e.getMessage());
+				assertInstanceOf(IllegalArgumentException.class, e);
+				assertEquals("Linked JDK is not of the correct version: 11 instead of: 13", e.getMessage());
 			}
 			return null;
 		});


### PR DESCRIPTION
The latest version of devkitman supports setting the "distro" of the JDK to install, which allows us to use the `JBANG_JDK_VENDOR` environment variable again to select the JDK vendor. Which was a feature that was missing since the switch to devkitman. (In devkitman the term "distro" was chosen instead of "vendor".)
