### PR TITLE
chore: verbose mode now way less spammy with https

### DIFF
--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,4 +1,5 @@
 handlers=java.util.logging.ConsoleHandler
 .level=INFO
+jdk.event.security.level=WARNING
 java.util.logging.ConsoleHandler.level=ALL
 java.util.logging.ConsoleHandler.formatter=dev.jbang.util.JBangFormatter


### PR DESCRIPTION
The security loggers for remote connections were generating way too many log messages. This fixes that.
