### PR TITLE
feat: add  as repo shortcut for jogamp.org maven repo

### DIFF
--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -40,6 +40,7 @@ public class DependencyUtil {
 		aliasToRepos.put("s01sonatype-snapshots", "https://s01.oss.sonatype.org/content/repositories/snapshots");
 		aliasToRepos.put("spring-snapshot", "https://repo.spring.io/snapshot");
 		aliasToRepos.put("spring-milestone", "https://repo.spring.io/milestone");
+		aliasToRepos.put("jogamp", "https://jogamp.org/deployment/maven");
 
 	}
 


### PR DESCRIPTION
Add jogamp maven repo short cut to make it easier to use processing.org maven artifacts that relies on jogamp.