### PR TITLE
refactor: Migrate Hamcrest assertions to AssertJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ dependencies {
 	implementation 'org.codejive:java-properties:0.0.7'
 
 	implementation "org.slf4j:slf4j-nop:1.7.30"
+	java9Implementation "org.assertj:assertj-core:3.27.3"
 	implementation "org.slf4j:jcl-over-slf4j:1.7.30"
 	implementation "org.jboss:jandex:2.2.3.Final"
 
@@ -342,6 +343,10 @@ testing {
 	suites {
 		test {
 			useJUnitJupiter()
+
+			dependencies {
+				implementation "org.assertj:assertj-core:3.x"
+			}
 		}
 
 		integrationTest(JvmTestSuite) {

--- a/src/test/java/dev/jbang/TestConfiguration.java
+++ b/src/test/java/dev/jbang/TestConfiguration.java
@@ -1,7 +1,6 @@
 package dev.jbang;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -36,7 +35,7 @@ public class TestConfiguration extends BaseTest {
 	public void testValues() {
 		Configuration cfg = Configuration.create();
 		cfg.put("foo", "bar");
-		assertThat(cfg.get("foo"), equalTo("bar"));
+		assertThat(cfg.get("foo")).isEqualTo("bar");
 	}
 
 	@Test
@@ -44,7 +43,7 @@ public class TestConfiguration extends BaseTest {
 		Configuration fallback = Configuration.create();
 		fallback.put("foo", "bar");
 		Configuration cfg = Configuration.create(fallback);
-		assertThat(cfg.get("foo"), equalTo("bar"));
+		assertThat(cfg.get("foo")).isEqualTo("bar");
 	}
 
 	@Test
@@ -53,7 +52,7 @@ public class TestConfiguration extends BaseTest {
 		fallback.put("foo", "bar");
 		Configuration cfg = Configuration.create(fallback);
 		cfg.put("foo", "baz");
-		assertThat(cfg.get("foo"), equalTo("baz"));
+		assertThat(cfg.get("foo")).isEqualTo("baz");
 	}
 
 	@Test
@@ -62,7 +61,7 @@ public class TestConfiguration extends BaseTest {
 		fallback.put("foo", "bar");
 		Configuration cfg = Configuration.create(fallback);
 		cfg.put("foo", null);
-		assertThat(cfg.get("foo"), nullValue());
+		assertThat(cfg.get("foo")).isNull();
 	}
 
 	@Test
@@ -76,34 +75,34 @@ public class TestConfiguration extends BaseTest {
 		Path cfgFile = jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS);
 		Configuration.write(cfgFile, cfg.flatten());
 		Configuration cfg2 = Configuration.read(cfgFile);
-		assertThat(cfg2.get("foo"), equalTo("abc"));
-		assertThat(cfg2.get("bar"), equalTo("ghi"));
-		assertThat(cfg2.get("baz"), equalTo("jkl"));
+		assertThat(cfg2.get("foo")).isEqualTo("abc");
+		assertThat(cfg2.get("bar")).isEqualTo("ghi");
+		assertThat(cfg2.get("baz")).isEqualTo("jkl");
 	}
 
 	@Test
 	public void testReadAndGetConfig() throws IOException {
 		Path cfgFile = jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS);
 		Configuration cfgRead = Configuration.read(cfgFile);
-		assertThat(cfgRead.getStoreRef(), nullValue());
+		assertThat(cfgRead.getStoreRef()).isNull();
 		Configuration cfgGet = Configuration.get(cfgFile);
-		assertThat(cfgGet.getStoreRef(), notNullValue());
-		assertThat(cfgGet.getStoreRef(), equalTo(ResourceRef.forResource(cfgFile.toString())));
+		assertThat(cfgGet.getStoreRef()).isNotNull();
+		assertThat(cfgGet.getStoreRef()).isEqualTo(ResourceRef.forResource(cfgFile.toString()));
 	}
 
 	@Test
 	public void testDefaults() {
 		Configuration cfg = Configuration.defaults();
-		assertThat(cfg.get("init.template"), equalTo("hello"));
-		assertThat(cfg.get("run.debug"), equalTo("4004"));
+		assertThat(cfg.get("init.template")).isEqualTo("hello");
+		assertThat(cfg.get("run.debug")).isEqualTo("4004");
 	}
 
 	@Test
 	public void testInstance() {
 		Configuration cfg = Configuration.instance();
-		assertThat(cfg.get("foo"), equalTo("baz"));
-		assertThat(cfg.get("init.template"), equalTo("bye"));
-		assertThat(cfg.get("run.debug"), equalTo("4004"));
+		assertThat(cfg.get("foo")).isEqualTo("baz");
+		assertThat(cfg.get("init.template")).isEqualTo("bye");
+		assertThat(cfg.get("run.debug")).isEqualTo("4004");
 	}
 
 	@Test
@@ -113,7 +112,7 @@ public class TestConfiguration extends BaseTest {
 		try {
 			Files.write(Util.getCwd().resolve("explicit-config"), config.getBytes());
 			Configuration cfg = Configuration.instance();
-			assertThat(cfg.get("foo"), equalTo("explicit"));
+			assertThat(cfg.get("foo")).isEqualTo("explicit");
 		} finally {
 			environmentVariables.clear("JBANG_CONFIG");
 		}
@@ -123,7 +122,7 @@ public class TestConfiguration extends BaseTest {
 	public void testCommandDefaults() {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("init", "dummy");
 		Init init = (Init) pr.subcommand().commandSpec().userObject();
-		assertThat(init.initTemplate, equalTo("bye"));
+		assertThat(init.initTemplate).isEqualTo("bye");
 	}
 
 	@Test
@@ -131,7 +130,7 @@ public class TestConfiguration extends BaseTest {
 		environmentVariables.clear("JBANG_EDITOR");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("edit", "dummy");
 		Edit edit = (Edit) pr.subcommand().commandSpec().userObject();
-		assertThat(edit.editor.get(), equalTo("someeditor.cfg"));
+		assertThat(edit.editor.get()).isEqualTo("someeditor.cfg");
 	}
 
 	@Test
@@ -139,7 +138,7 @@ public class TestConfiguration extends BaseTest {
 		environmentVariables.set("JBANG_EDITOR", "someeditor.env");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("edit", "dummy");
 		Edit edit = (Edit) pr.subcommand().commandSpec().userObject();
-		assertThat(edit.editor.get(), equalTo("someeditor.env"));
+		assertThat(edit.editor.get()).isEqualTo("someeditor.env");
 	}
 
 	@Test
@@ -147,7 +146,7 @@ public class TestConfiguration extends BaseTest {
 		environmentVariables.clear("JBANG_EDITOR");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("edit", "--open", "dummy");
 		Edit edit = (Edit) pr.subcommand().commandSpec().userObject();
-		assertThat(edit.editor.get(), equalTo("someeditor.cfg"));
+		assertThat(edit.editor.get()).isEqualTo("someeditor.cfg");
 	}
 
 	@Test
@@ -155,23 +154,27 @@ public class TestConfiguration extends BaseTest {
 		environmentVariables.set("JBANG_EDITOR", "someeditor.env");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("edit", "--open", "dummy");
 		Edit edit = (Edit) pr.subcommand().commandSpec().userObject();
-		assertThat(edit.editor.get(), equalTo("someeditor.env"));
+		assertThat(edit.editor.get()).isEqualTo("someeditor.env");
 	}
 
 	@Test
 	public void testCommandFallbacks() {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "dummy");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
-		assertThat(run.runMixin.debugString, is(nullValue()));
-		assertThat(run.runMixin.flightRecorderString, emptyOrNullString());
+		assertThat(run.runMixin.debugString).isNull();
+		assertThat(run.runMixin.flightRecorderString).isNullOrEmpty();
 	}
 
 	@Test
 	public void testCommandFallbacks2() {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--jfr", "--debug", "dummy");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
-		assertThat(run.runMixin.debugString, allOf(hasEntry("address", "4004"), is(aMapWithSize(1))));
-		assertThat(run.runMixin.flightRecorderString, equalTo("dummyjfr.cfg"));
+		assertThat(run.runMixin.debugString)
+			.satisfies(
+				arg -> assertThat(arg).containsEntry("address", "4004"),
+				arg -> assertThat(arg).hasSize(1)
+			);
+		assertThat(run.runMixin.flightRecorderString).isEqualTo("dummyjfr.cfg");
 	}
 
 }

--- a/src/test/java/dev/jbang/TestImplicitAlias.java
+++ b/src/test/java/dev/jbang/TestImplicitAlias.java
@@ -18,17 +18,15 @@ public class TestImplicitAlias extends BaseTest {
 
 	@Test
 	public void testGitImplicitCatalog() {
-		assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev").get(),
-				Matchers.equalTo("https://github.com/jbangdev/jbang-catalog/blob/HEAD/jbang-catalog.json"));
-		assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev/jbang-examples").get(),
-				Matchers.equalTo("https://github.com/jbangdev/jbang-examples/blob/HEAD/jbang-catalog.json"));
+		org.assertj.core.api.Assertions.assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev").get()).isEqualTo("https://github.com/jbangdev/jbang-catalog/blob/HEAD/jbang-catalog.json");
+		org.assertj.core.api.Assertions.assertThat(ImplicitCatalogRef.resolveImplicitCatalogUrl("jbangdev/jbang-examples").get()).isEqualTo("https://github.com/jbangdev/jbang-examples/blob/HEAD/jbang-catalog.json");
 	}
 
 	@Test
 	public void testImplictURLAlias() {
 
 		Alias url = Alias.get("tree@xam.dk");
-		assertThat(url.scriptRef, Matchers.equalTo("tree/main.java"));
+		org.assertj.core.api.Assertions.assertThat(url.scriptRef).isEqualTo("tree/main.java");
 
 	}
 
@@ -36,14 +34,14 @@ public class TestImplicitAlias extends BaseTest {
 	public void testImplictExplicitURLAlias() {
 
 		Alias url = Alias.get("tree@https://xam.dk");
-		assertThat(url.scriptRef, Matchers.equalTo("tree/main.java"));
+		org.assertj.core.api.Assertions.assertThat(url.scriptRef).isEqualTo("tree/main.java");
 
 	}
 
 	// @Test needs fixing to not generate absolute paths but instead relative paths.
 	public void testFileURLAlias() throws Exception {
 
-		assertThat(jbangTempDir.resolve("inner").toFile().mkdirs(), Matchers.is(true));
+		org.assertj.core.api.Assertions.assertThat(jbangTempDir.resolve("inner").toFile().mkdirs()).isEqualTo(true);
 
 		Files.copy(examplesTestFolder.resolve("helloworld.java"), jbangTempDir.resolve("inner/helloworld.java"));
 		String src = jbangTempDir.resolve("inner/helloworld.java").toString();
@@ -56,7 +54,7 @@ public class TestImplicitAlias extends BaseTest {
 
 		Alias alias = Alias.get(url);
 
-		assertThat(alias.scriptRef, Matchers.equalTo("helloworld.java"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("helloworld.java");
 
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -121,7 +121,7 @@ public class TestAlias extends BaseTest {
 	@Test
 	void testReadFromFile() throws IOException {
 		clearSettingsCaches();
-		assertThat(Alias.get("one"), notNullValue());
+		org.assertj.core.api.Assertions.assertThat(Alias.get("one")).isNotNull();
 	}
 
 	@Test
@@ -129,11 +129,11 @@ public class TestAlias extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias alias = Alias.get("name");
-		assertThat(alias.scriptRef, is("test.java"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("test.java");
 	}
 
 	@Test
@@ -141,7 +141,7 @@ public class TestAlias extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("alias", "add",
 					"-f", cwd.toString(),
@@ -159,29 +159,28 @@ public class TestAlias extends BaseTest {
 					"--java", "999",
 					testFile.toString(),
 					"aap", "noot", "mies");
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias alias = Alias.get("name");
-		assertThat(alias.scriptRef, is("test.java"));
-		assertThat(alias.description, is("desc"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("test.java");
+		org.assertj.core.api.Assertions.assertThat(alias.description).isEqualTo("desc");
 		assertThat(alias.runtimeOptions, iterableWithSize(1));
-		assertThat(alias.runtimeOptions, contains("jopts"));
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).containsExactly("jopts");
 		assertThat(alias.dependencies, iterableWithSize(1));
-		assertThat(alias.dependencies, contains("deps"));
+		org.assertj.core.api.Assertions.assertThat(alias.dependencies).containsExactly("deps");
 		assertThat(alias.repositories, iterableWithSize(1));
-		assertThat(alias.repositories, contains("repos"));
+		org.assertj.core.api.Assertions.assertThat(alias.repositories).containsExactly("repos");
 		assertThat(alias.classpaths, iterableWithSize(1));
-		assertThat(alias.classpaths, contains("cps"));
-		assertThat(alias.properties, aMapWithSize(1));
-		assertThat(alias.properties, hasEntry("prop", "val"));
-		assertThat(alias.mainClass, is("mainclass"));
+		org.assertj.core.api.Assertions.assertThat(alias.classpaths).containsExactly("cps");
+		org.assertj.core.api.Assertions.assertThat(alias.properties).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.properties).containsEntry("prop", "val");
+		org.assertj.core.api.Assertions.assertThat(alias.mainClass).isEqualTo("mainclass");
 		assertThat(alias.compileOptions, iterableWithSize(1));
-		assertThat(alias.compileOptions, contains("copts"));
-		assertThat(alias.nativeImage, is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).containsExactly("copts");
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isEqualTo(Boolean.TRUE);
 		assertThat(alias.nativeOptions, iterableWithSize(1));
-		assertThat(alias.nativeOptions, contains("nopts"));
-		assertThat(alias.javaVersion, is("999"));
-		assertThat(alias.arguments, contains("aap", "noot", "mies"));
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).containsExactly("nopts");
+		org.assertj.core.api.Assertions.assertThat(alias.javaVersion).isEqualTo("999");
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).containsExactly("aap", "noot", "mies");
 	}
 
 	@Test
@@ -191,7 +190,7 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, "// Test file".getBytes());
 		Path catFile = Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON);
 		Files.write(catFile, "".getBytes());
-		assertThat(Files.size(catFile), is(0L));
+		org.assertj.core.api.Assertions.assertThat(Files.size(catFile)).isEqualTo(0L);
 		JBang.getCommandLine()
 			.execute("alias", "add",
 					"--name=name",
@@ -209,27 +208,27 @@ public class TestAlias extends BaseTest {
 					"aap", "noot", "mies");
 		assertThat(Files.size(catFile), not(is(0L)));
 		Alias alias = Alias.get("name");
-		assertThat(alias.scriptRef, is("test.java"));
-		assertThat(alias.description, is("desc"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("test.java");
+		org.assertj.core.api.Assertions.assertThat(alias.description).isEqualTo("desc");
 		assertThat(alias.runtimeOptions, iterableWithSize(1));
-		assertThat(alias.runtimeOptions, contains("jopts"));
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).containsExactly("jopts");
 		assertThat(alias.dependencies, iterableWithSize(1));
-		assertThat(alias.dependencies, contains("deps"));
+		org.assertj.core.api.Assertions.assertThat(alias.dependencies).containsExactly("deps");
 		assertThat(alias.repositories, iterableWithSize(1));
-		assertThat(alias.repositories, contains("repos"));
+		org.assertj.core.api.Assertions.assertThat(alias.repositories).containsExactly("repos");
 		assertThat(alias.classpaths, iterableWithSize(1));
-		assertThat(alias.classpaths, contains("cps"));
-		assertThat(alias.properties, aMapWithSize(1));
-		assertThat(alias.properties, hasEntry("prop", "val"));
+		org.assertj.core.api.Assertions.assertThat(alias.classpaths).containsExactly("cps");
+		org.assertj.core.api.Assertions.assertThat(alias.properties).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.properties).containsEntry("prop", "val");
 		assertThat(alias.arguments, iterableWithSize(3));
-		assertThat(alias.mainClass, is("mainclass"));
+		org.assertj.core.api.Assertions.assertThat(alias.mainClass).isEqualTo("mainclass");
 		assertThat(alias.compileOptions, iterableWithSize(1));
-		assertThat(alias.compileOptions, contains("copts"));
-		assertThat(alias.nativeImage, is(nullValue()));
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).containsExactly("copts");
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isNull();
 		assertThat(alias.nativeOptions, iterableWithSize(1));
-		assertThat(alias.nativeOptions, contains("nopts"));
-		assertThat(alias.javaVersion, is("999"));
-		assertThat(alias.arguments, contains("aap", "noot", "mies"));
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).containsExactly("nopts");
+		org.assertj.core.api.Assertions.assertThat(alias.javaVersion).isEqualTo("999");
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).containsExactly("aap", "noot", "mies");
 	}
 
 	@Test
@@ -238,11 +237,11 @@ public class TestAlias extends BaseTest {
 		Path sub = Files.createDirectory(cwd.resolve("sub"));
 		Path testFile = sub.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias name = Alias.get("name");
-		assertThat(name.scriptRef, is(Paths.get("sub/test.java").toString()));
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo(Paths.get("sub/test.java").toString());
 	}
 
 	@Test
@@ -252,12 +251,12 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, ("// Test file \n" +
 				"//DESCRIPTION Description of the script inside the script")
 			.getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias name = Alias.get("name");
-		assertThat(name.scriptRef, is("test.java"));
-		assertThat(name.description, is("Description of the script inside the script"));
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo("test.java");
+		org.assertj.core.api.Assertions.assertThat(name.description).isEqualTo("Description of the script inside the script");
 	}
 
 	@Test
@@ -267,15 +266,15 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, ("// Test file \n" +
 				"//DESCRIPTION Description of the script inside the script")
 			.getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("alias", "add", "-f", cwd.toString(), "--name=name",
 					"--description", "Description of the script in arguments", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias name = Alias.get("name");
-		assertThat(name.scriptRef, is("test.java"));
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo("test.java");
 		// The argument has more precedance than the description tag in the script
-		assertThat(name.description, is("Description of the script in arguments"));
+		org.assertj.core.api.Assertions.assertThat(name.description).isEqualTo("Description of the script in arguments");
 	}
 
 	@Test
@@ -287,13 +286,12 @@ public class TestAlias extends BaseTest {
 				"//DESCRIPTION description second tag\n" +
 				"//DESCRIPTION description third tag")
 			.getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias name = Alias.get("name");
-		assertThat(name.scriptRef, is("test.java"));
-		assertThat(name.description,
-				is("Description first tag\ndescription second tag\ndescription third tag"));
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo("test.java");
+		org.assertj.core.api.Assertions.assertThat(name.description).isEqualTo("Description first tag\ndescription second tag\ndescription third tag");
 	}
 
 	@Test
@@ -301,13 +299,12 @@ public class TestAlias extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, ("// Test file \n").getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias name = Alias.get("name");
-		assertThat(name.scriptRef, is("test.java"));
-		assertThat(name.description,
-				nullValue());
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo("test.java");
+		org.assertj.core.api.Assertions.assertThat(name.description).isNull();
 	}
 
 	@Test
@@ -320,10 +317,10 @@ public class TestAlias extends BaseTest {
 		Files.createDirectory(hiddenJBangPath);
 		Files.createFile(Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR, Catalog.JBANG_CATALOG_JSON));
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		Catalog catalog = Catalog.get(hiddenJBangPath);
 		Alias name = catalog.aliases.get("name");
-		assertThat(name.scriptRef, is(Paths.get("../sub/test.java").toString()));
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo(Paths.get("../sub/test.java").toString());
 	}
 
 	@Test
@@ -334,8 +331,8 @@ public class TestAlias extends BaseTest {
 		JBang.getCommandLine().execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
 		Alias one = Alias.get("one");
 		Alias name = Alias.get("name");
-		assertThat(one.scriptRef, is("http://dummy"));
-		assertThat(name.scriptRef, is("test.java"));
+		org.assertj.core.api.Assertions.assertThat(one.scriptRef).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(name.scriptRef).isEqualTo("test.java");
 	}
 
 	@Test
@@ -351,8 +348,7 @@ public class TestAlias extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo");
 		}
 	}
 
@@ -372,164 +368,164 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile, "// Test file".getBytes());
 		Path testFile2 = cwd.resolve("test2.java");
 		Files.write(testFile2, "// Test file 2".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		int exitCode = JBang.getCommandLine()
 			.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
+		org.assertj.core.api.Assertions.assertThat(exitCode).isEqualTo(BaseCommand.EXIT_OK);
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Alias alias = Alias.get("name");
-		assertThat(alias.scriptRef, is("test.java"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("test.java");
 		exitCode = JBang.getCommandLine()
 			.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		org.assertj.core.api.Assertions.assertThat(exitCode).isEqualTo(BaseCommand.EXIT_INVALID_INPUT);
 		exitCode = JBang.getCommandLine()
 			.execute("alias", "add", "-f", cwd.toString(), "--name=name", "--force", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(exitCode).isEqualTo(BaseCommand.EXIT_OK);
 		alias = Alias.get("name");
-		assertThat(alias.scriptRef, is("test2.java"));
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("test2.java");
 	}
 
 	@Test
 	void testGetAliasNone() throws IOException {
 		Alias alias = Alias.get("dummy-alias!");
-		assertThat(alias, nullValue());
+		org.assertj.core.api.Assertions.assertThat(alias).isNull();
 	}
 
 	@Test
 	void testGetAliasOne() throws IOException {
 		Alias alias = Alias.get("one");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy"));
-		assertThat(alias.resolve(), equalTo("http://dummy"));
-		assertThat(alias.arguments, nullValue());
-		assertThat(alias.runtimeOptions, nullValue());
-		assertThat(alias.properties, nullValue());
-		assertThat(alias.compileOptions, nullValue());
-		assertThat(alias.nativeImage, nullValue());
-		assertThat(alias.nativeOptions, nullValue());
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.resolve()).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.properties).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).isNull();
 	}
 
 	@Test
 	void testGetAliasTwo() throws IOException {
 		Alias alias = Alias.get("two");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy"));
-		assertThat(alias.resolve(), equalTo("http://dummy"));
-		assertThat(alias.description, equalTo("twodesc"));
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.resolve()).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.description).isEqualTo("twodesc");
 		assertThat(alias.arguments, iterableWithSize(1));
-		assertThat(alias.arguments, contains("2"));
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).containsExactly("2");
 		assertThat(alias.runtimeOptions, iterableWithSize(1));
-		assertThat(alias.runtimeOptions, contains("--two"));
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).containsExactly("--two");
 		assertThat(alias.sources, iterableWithSize(1));
-		assertThat(alias.sources, contains("twosrc"));
+		org.assertj.core.api.Assertions.assertThat(alias.sources).containsExactly("twosrc");
 		assertThat(alias.resources, iterableWithSize(1));
-		assertThat(alias.resources, contains("twofiles"));
+		org.assertj.core.api.Assertions.assertThat(alias.resources).containsExactly("twofiles");
 		assertThat(alias.dependencies, iterableWithSize(1));
-		assertThat(alias.dependencies, contains("twodep"));
+		org.assertj.core.api.Assertions.assertThat(alias.dependencies).containsExactly("twodep");
 		assertThat(alias.repositories, iterableWithSize(1));
-		assertThat(alias.repositories, contains("tworepo"));
+		org.assertj.core.api.Assertions.assertThat(alias.repositories).containsExactly("tworepo");
 		assertThat(alias.classpaths, iterableWithSize(1));
-		assertThat(alias.classpaths, contains("twocp"));
-		assertThat(alias.properties, aMapWithSize(1));
-		assertThat(alias.properties, hasEntry("two", "2"));
-		assertThat(alias.javaVersion, equalTo("twojava"));
-		assertThat(alias.mainClass, equalTo("twomain"));
-		assertThat(alias.moduleName, equalTo("twomodule"));
+		org.assertj.core.api.Assertions.assertThat(alias.classpaths).containsExactly("twocp");
+		org.assertj.core.api.Assertions.assertThat(alias.properties).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.properties).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(alias.javaVersion).isEqualTo("twojava");
+		org.assertj.core.api.Assertions.assertThat(alias.mainClass).isEqualTo("twomain");
+		org.assertj.core.api.Assertions.assertThat(alias.moduleName).isEqualTo("twomodule");
 		assertThat(alias.compileOptions, iterableWithSize(1));
-		assertThat(alias.compileOptions, contains("--ctwo"));
-		assertThat(alias.nativeImage, is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).containsExactly("--ctwo");
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isEqualTo(Boolean.TRUE);
 		assertThat(alias.nativeOptions, iterableWithSize(1));
-		assertThat(alias.nativeOptions, contains("--ntwo"));
-		assertThat(alias.jfr, equalTo("twojfr"));
-		assertThat(alias.debug, aMapWithSize(1));
-		assertThat(alias.debug, hasEntry("twod", "2"));
-		assertThat(alias.cds, is(Boolean.TRUE));
-		assertThat(alias.interactive, is(Boolean.TRUE));
-		assertThat(alias.enablePreview, is(Boolean.TRUE));
-		assertThat(alias.enableAssertions, is(Boolean.TRUE));
-		assertThat(alias.enableSystemAssertions, is(Boolean.TRUE));
-		assertThat(alias.manifestOptions, aMapWithSize(1));
-		assertThat(alias.manifestOptions, hasEntry("twom", "2"));
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).containsExactly("--ntwo");
+		org.assertj.core.api.Assertions.assertThat(alias.jfr).isEqualTo("twojfr");
+		org.assertj.core.api.Assertions.assertThat(alias.debug).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.debug).containsEntry("twod", "2");
+		org.assertj.core.api.Assertions.assertThat(alias.cds).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(alias.interactive).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(alias.enablePreview).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(alias.enableAssertions).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(alias.enableSystemAssertions).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(alias.manifestOptions).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.manifestOptions).containsEntry("twom", "2");
 		assertThat(alias.javaAgents, iterableWithSize(1));
-		assertThat(alias.javaAgents, contains(new Alias.JavaAgent("twojag", "twoopts")));
+		org.assertj.core.api.Assertions.assertThat(alias.javaAgents).containsExactly(new Alias.JavaAgent("twojag", "twoopts"));
 	}
 
 	@Test
 	void testGetAliasFour() throws IOException {
 		Alias alias = Alias.get("four");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy"));
-		assertThat(alias.resolve(), equalTo("http://dummy"));
-		assertThat(alias.description, equalTo("fourdesc"));
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.resolve()).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.description).isEqualTo("fourdesc");
 		assertThat(alias.arguments, iterableWithSize(1));
-		assertThat(alias.arguments, contains("4"));
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).containsExactly("4");
 		assertThat(alias.runtimeOptions, iterableWithSize(1));
-		assertThat(alias.runtimeOptions, contains("--four"));
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).containsExactly("--four");
 		assertThat(alias.sources, iterableWithSize(1));
-		assertThat(alias.sources, contains("foursrc"));
+		org.assertj.core.api.Assertions.assertThat(alias.sources).containsExactly("foursrc");
 		assertThat(alias.resources, iterableWithSize(1));
-		assertThat(alias.resources, contains("fourfiles"));
+		org.assertj.core.api.Assertions.assertThat(alias.resources).containsExactly("fourfiles");
 		assertThat(alias.dependencies, iterableWithSize(1));
-		assertThat(alias.dependencies, contains("fourdep"));
+		org.assertj.core.api.Assertions.assertThat(alias.dependencies).containsExactly("fourdep");
 		assertThat(alias.repositories, iterableWithSize(1));
-		assertThat(alias.repositories, contains("fourrepo"));
+		org.assertj.core.api.Assertions.assertThat(alias.repositories).containsExactly("fourrepo");
 		assertThat(alias.classpaths, iterableWithSize(1));
-		assertThat(alias.classpaths, contains("fourcp"));
-		assertThat(alias.properties, aMapWithSize(1));
-		assertThat(alias.properties, hasEntry("four", "4"));
-		assertThat(alias.javaVersion, equalTo("fourjava"));
-		assertThat(alias.mainClass, equalTo("fourmain"));
-		assertThat(alias.moduleName, equalTo("fourmodule"));
+		org.assertj.core.api.Assertions.assertThat(alias.classpaths).containsExactly("fourcp");
+		org.assertj.core.api.Assertions.assertThat(alias.properties).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.properties).containsEntry("four", "4");
+		org.assertj.core.api.Assertions.assertThat(alias.javaVersion).isEqualTo("fourjava");
+		org.assertj.core.api.Assertions.assertThat(alias.mainClass).isEqualTo("fourmain");
+		org.assertj.core.api.Assertions.assertThat(alias.moduleName).isEqualTo("fourmodule");
 		assertThat(alias.compileOptions, iterableWithSize(1));
-		assertThat(alias.compileOptions, contains("--cfour"));
-		assertThat(alias.nativeImage, is(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).containsExactly("--cfour");
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isEqualTo(Boolean.FALSE);
 		assertThat(alias.nativeOptions, iterableWithSize(1));
-		assertThat(alias.nativeOptions, contains("--nfour"));
-		assertThat(alias.jfr, equalTo("fourjfr"));
-		assertThat(alias.debug, aMapWithSize(1));
-		assertThat(alias.debug, hasEntry("fourd", "4"));
-		assertThat(alias.cds, is(Boolean.FALSE));
-		assertThat(alias.interactive, is(Boolean.FALSE));
-		assertThat(alias.enablePreview, is(Boolean.FALSE));
-		assertThat(alias.enableAssertions, is(Boolean.FALSE));
-		assertThat(alias.enableSystemAssertions, is(Boolean.FALSE));
-		assertThat(alias.manifestOptions, aMapWithSize(1));
-		assertThat(alias.manifestOptions, hasEntry("fourm", "4"));
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).containsExactly("--nfour");
+		org.assertj.core.api.Assertions.assertThat(alias.jfr).isEqualTo("fourjfr");
+		org.assertj.core.api.Assertions.assertThat(alias.debug).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.debug).containsEntry("fourd", "4");
+		org.assertj.core.api.Assertions.assertThat(alias.cds).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(alias.interactive).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(alias.enablePreview).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(alias.enableAssertions).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(alias.enableSystemAssertions).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(alias.manifestOptions).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.manifestOptions).containsEntry("fourm", "4");
 		assertThat(alias.javaAgents, iterableWithSize(1));
-		assertThat(alias.javaAgents, contains(new Alias.JavaAgent("fourjag", "fouropts")));
+		org.assertj.core.api.Assertions.assertThat(alias.javaAgents).containsExactly(new Alias.JavaAgent("fourjag", "fouropts"));
 	}
 
 	@Test
 	void testGetAliasFive() throws IOException {
 		Alias alias = Alias.get("five");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy"));
-		assertThat(alias.resolve(), equalTo("http://dummy"));
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("http://dummy");
+		org.assertj.core.api.Assertions.assertThat(alias.resolve()).isEqualTo("http://dummy");
 		assertThat(alias.arguments, iterableWithSize(1));
-		assertThat(alias.arguments, contains("3"));
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).containsExactly("3");
 		assertThat(alias.runtimeOptions, iterableWithSize(1));
-		assertThat(alias.runtimeOptions, contains("--three"));
-		assertThat(alias.properties, aMapWithSize(1));
-		assertThat(alias.properties, hasEntry("three", "3"));
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).containsExactly("--three");
+		org.assertj.core.api.Assertions.assertThat(alias.properties).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(alias.properties).containsEntry("three", "3");
 		assertThat(alias.compileOptions, iterableWithSize(1));
-		assertThat(alias.compileOptions, contains("--cthree"));
-		assertThat(alias.nativeImage, is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).containsExactly("--cthree");
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isEqualTo(Boolean.TRUE);
 		assertThat(alias.nativeOptions, iterableWithSize(1));
-		assertThat(alias.nativeOptions, contains("--nthree"));
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).containsExactly("--nthree");
 	}
 
 	@Test
 	void testGetAliasGav() throws IOException {
 		Alias alias = Alias.get("gav");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("org.example:artifact:version"));
-		assertThat(alias.resolve(), equalTo("org.example:artifact:version"));
-		assertThat(alias.arguments, nullValue());
-		assertThat(alias.runtimeOptions, nullValue());
-		assertThat(alias.properties, nullValue());
-		assertThat(alias.compileOptions, nullValue());
-		assertThat(alias.nativeImage, nullValue());
-		assertThat(alias.nativeOptions, nullValue());
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("org.example:artifact:version");
+		org.assertj.core.api.Assertions.assertThat(alias.resolve()).isEqualTo("org.example:artifact:version");
+		org.assertj.core.api.Assertions.assertThat(alias.arguments).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.runtimeOptions).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.properties).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.compileOptions).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.nativeImage).isNull();
+		org.assertj.core.api.Assertions.assertThat(alias.nativeOptions).isNull();
 	}
 
 	@Test
@@ -538,7 +534,7 @@ public class TestAlias extends BaseTest {
 			Alias.get("eight");
 			fail();
 		} catch (RuntimeException ex) {
-			assertThat(ex.getMessage(), containsString("seven"));
+			org.assertj.core.api.Assertions.assertThat(ex.getMessage()).contains("seven");
 		}
 
 	}

--- a/src/test/java/dev/jbang/cli/TestAliasNearest.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearest.java
@@ -2,7 +2,7 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.*;
 
 import java.io.IOException;
@@ -108,7 +108,7 @@ public class TestAliasNearest extends BaseTest {
 	@Test
 	void testList() throws IOException {
 		Catalog catalog = Catalog.getMerged(true, false);
-		assertThat(catalog, notNullValue());
+		org.assertj.core.api.Assertions.assertThat(catalog).isNotNull();
 
 		HashSet<String> keys = new HashSet<>(Arrays.asList(
 				"global1",
@@ -121,21 +121,21 @@ public class TestAliasNearest extends BaseTest {
 				"dotlocal1",
 				"dotlocal2",
 				"local1"));
-		assertThat(catalog.aliases.keySet(), equalTo(keys));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).isEqualTo(keys);
 
-		assertThat(catalog.aliases.get("global1").scriptRef, is("global1ref"));
-		assertThat(catalog.aliases.get("global2").scriptRef, is("global2inparent"));
-		assertThat(catalog.aliases.get("global3").scriptRef, is("global3indotlocal"));
-		assertThat(catalog.aliases.get("global4").scriptRef, is("global4inlocal"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("global1").scriptRef).isEqualTo("global1ref");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("global2").scriptRef).isEqualTo("global2inparent");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("global3").scriptRef).isEqualTo("global3indotlocal");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("global4").scriptRef).isEqualTo("global4inlocal");
 
-		assertThat(catalog.aliases.get("parent1").scriptRef, is("parent1ref"));
-		assertThat(catalog.aliases.get("parent2").scriptRef, is("parent2indotlocal"));
-		assertThat(catalog.aliases.get("parent3").scriptRef, is("parent3inlocal"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("parent1").scriptRef).isEqualTo("parent1ref");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("parent2").scriptRef).isEqualTo("parent2indotlocal");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("parent3").scriptRef).isEqualTo("parent3inlocal");
 
-		assertThat(catalog.aliases.get("dotlocal1").scriptRef, is("dotlocal1ref"));
-		assertThat(catalog.aliases.get("dotlocal2").scriptRef, is("dotlocal2inlocal"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("dotlocal1").scriptRef).isEqualTo("dotlocal1ref");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("dotlocal2").scriptRef).isEqualTo("dotlocal2inlocal");
 
-		assertThat(catalog.aliases.get("local1").scriptRef, is("local1ref"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("local1").scriptRef).isEqualTo("local1ref");
 	}
 
 	@Test
@@ -154,8 +154,8 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.addNearestAlias("new", new Alias().withScriptRef(ref));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo(result);
 	}
 
 	@Test
@@ -165,8 +165,8 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.addAlias(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", new Alias().withScriptRef("dummy.java"));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo("dummy.java"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo("dummy.java");
 	}
 
 	@Test
@@ -188,8 +188,8 @@ public class TestAliasNearest extends BaseTest {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo(result);
 	}
 
 	@Test
@@ -214,8 +214,8 @@ public class TestAliasNearest extends BaseTest {
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo(result);
 	}
 
 	@Test
@@ -244,8 +244,8 @@ public class TestAliasNearest extends BaseTest {
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(Settings.getUserCatalogFile());
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo(result);
 	}
 
 	@Test
@@ -255,7 +255,7 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.removeNearestAlias("local1");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.aliases.keySet(), not(hasItem("local1")));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).doesNotContain("local1");
 	}
 
 	@Test
@@ -265,7 +265,7 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.removeNearestAlias("dotlocal1");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
-		assertThat(catalog.aliases.keySet(), not(hasItem("dotlocal1")));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).doesNotContain("dotlocal1");
 	}
 
 	@Test
@@ -275,7 +275,7 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.removeNearestAlias("parent1");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.aliases.keySet(), not(hasItem("parent1")));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).doesNotContain("parent1");
 	}
 
 	@Test
@@ -284,7 +284,7 @@ public class TestAliasNearest extends BaseTest {
 		CatalogUtil.removeNearestAlias("global1");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(globalCatalog);
-		assertThat(catalog.aliases.keySet(), not(hasItem("global1")));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).doesNotContain("global1");
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasNearestWithBaseRef.java
@@ -2,7 +2,7 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -68,8 +68,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		CatalogUtil.addNearestAlias("new", new Alias().withScriptRef("scripts/local.java"));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo("local.java"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo("local.java");
 	}
 
 	@Test
@@ -82,8 +82,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo("local.java"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo("local.java");
 	}
 
 	@Test
@@ -99,8 +99,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef.replace('\\', '/'), equalTo("../test/scripts/local.java"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef.replace('\\', '/')).isEqualTo("../test/scripts/local.java");
 	}
 
 	@Test
@@ -116,8 +116,8 @@ public class TestAliasNearestWithBaseRef extends BaseTest {
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.aliases.keySet(), hasItem("new"));
-		assertThat(catalog.aliases.get("new").scriptRef, equalTo("parent.java"));
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.aliases.get("new").scriptRef).isEqualTo("parent.java");
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
+++ b/src/test/java/dev/jbang/cli/TestAliasWithBaseRef.java
@@ -1,7 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -43,33 +42,33 @@ public class TestAliasWithBaseRef extends BaseTest {
 	@Test
 	void testGetAliasOne() throws IOException {
 		Alias alias = Alias.get("one");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("foo"));
-		assertThat(alias.resolve(), equalTo("http://dummy/foo"));
+		assertThat(alias).isNotNull();
+		assertThat(alias.scriptRef).isEqualTo("foo");
+		assertThat(alias.resolve()).isEqualTo("http://dummy/foo");
 	}
 
 	@Test
 	void testGetAliasTwo() throws IOException {
 		Alias alias = Alias.get("two");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("foo/bar.java"));
-		assertThat(alias.resolve(), equalTo("http://dummy/foo/bar.java"));
+		assertThat(alias).isNotNull();
+		assertThat(alias.scriptRef).isEqualTo("foo/bar.java");
+		assertThat(alias.resolve()).isEqualTo("http://dummy/foo/bar.java");
 	}
 
 	@Test
 	void testGetAliasThree() throws IOException {
 		Alias alias = Alias.get("three");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy/baz.java"));
-		assertThat(alias.resolve(), equalTo("http://dummy/baz.java"));
+		assertThat(alias).isNotNull();
+		assertThat(alias.scriptRef).isEqualTo("http://dummy/baz.java");
+		assertThat(alias.resolve()).isEqualTo("http://dummy/baz.java");
 	}
 
 	@Test
 	void testGetAliasGav() throws IOException {
 		Alias alias = Alias.get("gav");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("org.example:artifact:version"));
-		assertThat(alias.resolve(), equalTo("org.example:artifact:version"));
+		assertThat(alias).isNotNull();
+		assertThat(alias.scriptRef).isEqualTo("org.example:artifact:version");
+		assertThat(alias.resolve()).isEqualTo("org.example:artifact:version");
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -1,7 +1,7 @@
 package dev.jbang.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -59,11 +59,11 @@ public class TestApp extends BaseTest {
 	void testAppInstallFile() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
-		assertThat(result.err, containsString("Command installed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: helloworld");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		testScripts();
 	}
@@ -78,18 +78,18 @@ public class TestApp extends BaseTest {
 
 		ProjectBuilder pb = app.createProjectBuilder();
 		Project prj = pb.build(src);
-		assertThat(prj.getRepositories(), hasItem(new MavenRepo("central", "https://repo1.maven.org/maven2/")));
+		org.assertj.core.api.Assertions.assertThat(prj.getRepositories()).contains(new MavenRepo("central", "https://repo1.maven.org/maven2/"));
 	}
 
 	@Test
 	void testAppNativeInstallFile() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--native", src);
-		assertThat(result.err, containsString("Command installed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: helloworld");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		testNativeScripts();
 	}
@@ -98,11 +98,11 @@ public class TestApp extends BaseTest {
 	void testAppInstallExtensionLessFile() throws Exception {
 		String src = examplesTestFolder.resolve("kubectl-example").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
-		assertThat(result.err, containsString("Command installed: kubectl-example"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: kubectl-example");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 
 	}
@@ -112,11 +112,11 @@ public class TestApp extends BaseTest {
 	void testAppInstallURL() throws Exception {
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build",
 				"https://github.com/jbangdev/k8s-cli-java/blob/jbang/kubectl-example");
-		assertThat(result.err, containsString("Command installed: kubectl-example"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: kubectl-example");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 
 	}
@@ -125,11 +125,11 @@ public class TestApp extends BaseTest {
 	void testAppInstallGVA() throws Exception {
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name", "h2",
 				"com.h2database:h2:1.4.200");
-		assertThat(result.err, containsString("Command installed: h2"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: h2");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 
 		String cwd = examplesTestFolder.getParent().toString();
@@ -146,29 +146,28 @@ public class TestApp extends BaseTest {
 	void testAppInstallFileExists() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
-		assertThat(result.err, containsString("Command installed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: helloworld");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		result = checkedRun(null, "app", "install", "--no-build", src);
-		assertThat(result.err,
-				containsString("A script with name 'helloworld' already exists, use '--force' to install anyway."));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("A script with name 'helloworld' already exists, use '--force' to install anyway.");
 	}
 
 	@Test
 	void testAppInstallFileForce() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", src);
-		assertThat(result.err, containsString("Command installed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: helloworld");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		result = checkedRun(null, "app", "install", "--no-build", "--force", src);
-		assertThat(result.err, containsString("Command installed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: helloworld");
 		testScripts();
 	}
 
@@ -200,20 +199,20 @@ public class TestApp extends BaseTest {
 			.collect(Collectors.toList());
 		Path shFile = Settings.getConfigBinDir().resolve(name);
 		assertThat(shFile.toFile(), anExistingFile());
-		assertThat(Files.readAllLines(shFile), is(cs));
+		org.assertj.core.api.Assertions.assertThat(Files.readAllLines(shFile)).isEqualTo(cs);
 	}
 
 	@Test
 	void testAppInstallFileWithName() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
-		assertThat(result.err, containsString("Command installed: hello"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: hello");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 			assertThat(Settings.getConfigBinDir().resolve("hello.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("hello.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 			assertThat(Settings.getConfigBinDir().resolve("hello").toFile(), anExistingFile());
 		}
 	}
@@ -222,29 +221,28 @@ public class TestApp extends BaseTest {
 	void testAppInstallFileWithNameExists() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
-		assertThat(result.err, containsString("Command installed: hello"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: hello");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
-		assertThat(result.err,
-				containsString("A script with name 'hello' already exists, use '--force' to install anyway."));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("A script with name 'hello' already exists, use '--force' to install anyway.");
 	}
 
 	@Test
 	void testAppInstallFileWithNameForce() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "--name=hello", src);
-		assertThat(result.err, containsString("Command installed: hello"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: hello");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		}
 		result = checkedRun(null, "app", "install", "--no-build", "--force", "--name=hello", src);
-		assertThat(result.err, containsString("Command installed: hello"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: hello");
 	}
 
 	@Test
@@ -252,13 +250,13 @@ public class TestApp extends BaseTest {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		checkedRun(null, "alias", "add", "-g", "--name=apptest", src);
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "apptest");
-		assertThat(result.err, containsString("Command installed: apptest"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: apptest");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 			assertThat(Settings.getConfigBinDir().resolve("apptest").toFile(), anExistingFile());
 		}
 	}
@@ -270,13 +268,13 @@ public class TestApp extends BaseTest {
 		checkedRun(null, "catalog", "add", "-g", "--name=testrepo",
 				jbangTempDir.resolve("jbang-catalog.json").toString());
 		CaptureResult result = checkedRun(null, "app", "install", "--no-build", "apptest@testrepo");
-		assertThat(result.err, containsString("Command installed: apptest"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command installed: apptest");
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_EXECUTE);
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 			assertThat(Settings.getConfigBinDir().resolve("apptest").toFile(), anExistingFile());
 		}
 	}
@@ -287,7 +285,7 @@ public class TestApp extends BaseTest {
 			checkedRun(null, "app", "install", "--no-build", "--name=invalid>name", "def/not/existing/file");
 			Assert.fail();
 		} catch (IllegalArgumentException e) {
-			assertThat(e.getMessage(), containsString("Not a valid command name"));
+			org.assertj.core.api.Assertions.assertThat(e.getMessage()).contains("Not a valid command name");
 		}
 	}
 
@@ -297,8 +295,7 @@ public class TestApp extends BaseTest {
 			checkedRun(null, "app", "install", "--no-build", "def/not/existing/file");
 			Assert.fail();
 		} catch (ExitException e) {
-			assertThat(e.getMessage(),
-					containsString("Script or alias could not be found or read: 'def/not/existing/file'"));
+			org.assertj.core.api.Assertions.assertThat(e.getMessage()).contains("Script or alias could not be found or read: 'def/not/existing/file'");
 		}
 	}
 
@@ -309,8 +306,8 @@ public class TestApp extends BaseTest {
 		checkedRun(null, "app", "install", "--no-build", "--name=hello2", src);
 		checkedRun(null, "app", "install", "--no-build", "--name=hello3", src);
 		CaptureResult result = checkedRun(null, "app", "list");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
-		assertThat(result.normalizedOut(), equalTo("hello1\nhello2\nhello3\n"));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
+		org.assertj.core.api.Assertions.assertThat(result.normalizedOut()).isEqualTo("hello1\nhello2\nhello3\n");
 	}
 
 	@Test
@@ -324,8 +321,8 @@ public class TestApp extends BaseTest {
 			assertThat(Settings.getConfigBinDir().resolve("helloworld").toFile(), anExistingFile());
 		}
 		CaptureResult result = checkedRun(null, "app", "uninstall", "helloworld");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
-		assertThat(result.err, containsString("Command removed: helloworld"));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command removed: helloworld");
 		assertThat(Settings.getConfigBinDir().resolve("helloworld").toFile(), not(anExistingFile()));
 		assertThat(Settings.getConfigBinDir().resolve("helloworld.cmd").toFile(), not(anExistingFile()));
 		assertThat(Settings.getConfigBinDir().resolve("helloworld.ps1").toFile(), not(anExistingFile()));
@@ -334,8 +331,8 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppUninstallUnknown() throws Exception {
 		CaptureResult result = checkedRun(null, "app", "uninstall", "hello");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
-		assertThat(result.err, containsString("Command not found: hello"));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_INVALID_INPUT);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Command not found: hello");
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestArguments.java
+++ b/src/test/java/dev/jbang/cli/TestArguments.java
@@ -1,7 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,9 +35,9 @@ class TestArguments extends BaseTest {
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
 		assert run.helpRequested;
-		assertThat(run.runMixin.debugString, hasEntry("address", "4004"));
-		assertThat(run.scriptMixin.scriptOrFile, is("myfile.java"));
-		assertThat(run.userParams.size(), is(0));
+		assertThat(run.runMixin.debugString).containsEntry("address", "4004");
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("myfile.java");
+		assertThat(run.userParams.size()).isEqualTo(0);
 
 	}
 
@@ -47,10 +46,10 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "--debug", "test.java", "--debug", "wonka");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.runMixin.debugString, hasEntry("address", "4004"));
+		assertThat(run.runMixin.debugString).containsEntry("address", "4004");
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
-		assertThat(run.userParams, is(Arrays.asList("--debug", "wonka")));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
+		assertThat(run.userParams).isEqualTo(Arrays.asList("--debug", "wonka"));
 	}
 
 	/**
@@ -64,9 +63,9 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "-", "--help");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("-"));
-		assertThat(run.helpRequested, is(false));
-		assertThat(run.userParams, is(Collections.singletonList("--help")));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("-");
+		assertThat(run.helpRequested).isEqualTo(false);
+		assertThat(run.userParams).isEqualTo(Collections.singletonList("--help"));
 	}
 
 	@Test
@@ -74,9 +73,9 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "test.java", "-h");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
-		assertThat(run.helpRequested, is(false));
-		assertThat(run.userParams, is(Collections.singletonList("-h")));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
+		assertThat(run.helpRequested).isEqualTo(false);
+		assertThat(run.userParams).isEqualTo(Collections.singletonList("-h"));
 	}
 
 	@Test
@@ -84,8 +83,8 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "--debug", "test.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
-		assertThat(run.runMixin.debugString, notNullValue());
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
+		assertThat(run.runMixin.debugString).isNotNull();
 	}
 
 	@Test
@@ -93,10 +92,10 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "--debug=*:5000", "test.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
-		assertThat(run.runMixin.debugString, notNullValue());
-		assertThat(run.runMixin.debugString, hasEntry("address", "*:5000"));
-		assertThat(run.runMixin.debugString.size(), is(1));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
+		assertThat(run.runMixin.debugString).isNotNull();
+		assertThat(run.runMixin.debugString).containsEntry("address", "*:5000");
+		assertThat(run.runMixin.debugString.size()).isEqualTo(1);
 	}
 
 	@Test
@@ -104,9 +103,9 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "--debug", "xyz.dk:5005", "test.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
-		assertThat(run.runMixin.debugString, notNullValue());
-		assertThat(run.runMixin.debugString, hasEntry("address", "xyz.dk:5005"));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
+		assertThat(run.runMixin.debugString).isNotNull();
+		assertThat(run.runMixin.debugString).containsEntry("address", "xyz.dk:5005");
 	}
 
 	@Test
@@ -114,21 +113,21 @@ class TestArguments extends BaseTest {
 		CommandLine.ParseResult pr = cli.parseArgs("run", "test.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.scriptMixin.scriptOrFile, is("test.java"));
+		assertThat(run.scriptMixin.scriptOrFile).isEqualTo("test.java");
 	}
 
 	@Test
 	public void testClearCache() {
 		Path dir = jbangTempDir;
 		environmentVariables.set(Settings.JBANG_CACHE_DIR, dir.toString());
-		assertThat(Files.isDirectory(dir), is(true));
+		assertThat(Files.isDirectory(dir)).isEqualTo(true);
 
 		cli.execute("cache", "clear", "--all");
 
-		assertThat(Files.isDirectory(dir.resolve("urls")), is(false));
-		assertThat(Files.isDirectory(dir.resolve("jars")), is(false));
-		assertThat(Files.isDirectory(dir.resolve("jdks")), is(false));
-		assertThat(Files.notExists(Settings.getCacheDependencyFile()), is(true));
+		assertThat(Files.isDirectory(dir.resolve("urls"))).isEqualTo(false);
+		assertThat(Files.isDirectory(dir.resolve("jars"))).isEqualTo(false);
+		assertThat(Files.isDirectory(dir.resolve("jdks"))).isEqualTo(false);
+		assertThat(Files.notExists(Settings.getCacheDependencyFile())).isEqualTo(true);
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestCatalog.java
+++ b/src/test/java/dev/jbang/cli/TestCatalog.java
@@ -2,7 +2,8 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -48,14 +49,13 @@ public class TestCatalog extends BaseTest {
 
 	@Test
 	void testAddSucceeded() throws IOException {
-		assertThat(Files.isRegularFile(catsFile), is(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isRegularFile(catsFile)).isEqualTo(true);
 		String cat = new String(Files.readAllBytes(catsFile));
-		assertThat(cat, containsString("\"test\""));
-		assertThat(cat, containsString("test-catalog.json\""));
+		org.assertj.core.api.Assertions.assertThat(cat).contains("\"test\"");
+		org.assertj.core.api.Assertions.assertThat(cat).contains("test-catalog.json\"");
 
-		assertThat(Catalog.get(catsFile).catalogs, hasKey("test"));
-		assertThat(Catalog.get(catsFile).catalogs.get("test").catalogRef,
-				is(testCatalogFile.toAbsolutePath().toString()));
+		org.assertj.core.api.Assertions.assertThat(Catalog.get(catsFile).catalogs).containsKey("test");
+		org.assertj.core.api.Assertions.assertThat(Catalog.get(catsFile).catalogs.get("test").catalogRef).isEqualTo(testCatalogFile.toAbsolutePath().toString());
 	}
 
 	@Test
@@ -66,15 +66,15 @@ public class TestCatalog extends BaseTest {
 	@Test
 	void testGetAlias() throws IOException {
 		Alias alias = Alias.get("one@test");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("http://dummy"));
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("http://dummy");
 	}
 
 	@Test
 	void testGetFatJar() throws IOException {
 		Alias alias = Alias.get("fj@test");
-		assertThat(alias, notNullValue());
-		assertThat(alias.scriptRef, equalTo("i.look:like-a-gav:1.0.0.Beta5@fatjar"));
+		org.assertj.core.api.Assertions.assertThat(alias).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(alias.scriptRef).isEqualTo("i.look:like-a-gav:1.0.0.Beta5@fatjar");
 	}
 
 	@Test
@@ -84,7 +84,7 @@ public class TestCatalog extends BaseTest {
 
 	@Test
 	void testRemove() throws IOException {
-		assertThat(Catalog.get(catsFile).catalogs, hasKey("test"));
+		org.assertj.core.api.Assertions.assertThat(Catalog.get(catsFile).catalogs).containsKey("test");
 		CatalogUtil.removeCatalogRef(catsFile, "test");
 		assertThat(Catalog.get(catsFile).catalogs, not(hasKey("test")));
 	}
@@ -92,6 +92,6 @@ public class TestCatalog extends BaseTest {
 	@Test
 	void testNameFromGAV() throws IOException {
 		String name = CatalogUtil.nameFromRef("com.intuit.karate:karate-core:LATEST");
-		assertThat(name, equalTo("karate-core"));
+		org.assertj.core.api.Assertions.assertThat(name).isEqualTo("karate-core");
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestCatalogNearest.java
+++ b/src/test/java/dev/jbang/cli/TestCatalogNearest.java
@@ -2,7 +2,7 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -66,7 +66,7 @@ public class TestCatalogNearest extends BaseTest {
 	@Test
 	void testList() throws IOException {
 		Catalog catalog = Catalog.getMerged(true, false);
-		assertThat(catalog, notNullValue());
+		org.assertj.core.api.Assertions.assertThat(catalog).isNotNull();
 
 		HashSet<String> keys = new HashSet<>(Arrays.asList(
 				"global",
@@ -74,19 +74,19 @@ public class TestCatalogNearest extends BaseTest {
 				"dotlocal",
 				"local",
 				"jbanghub"));
-		assertThat(catalog.catalogs.keySet().containsAll(keys), is(true));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet().containsAll(keys)).isEqualTo(true);
 
-		assertThat(catalog.catalogs.get("global").catalogRef, is(aliasesFile.toString()));
-		assertThat(catalog.catalogs.get("dotparent").catalogRef, is(aliasesFile.toString()));
-		assertThat(catalog.catalogs.get("dotlocal").catalogRef, is(aliasesFile.toString()));
-		assertThat(catalog.catalogs.get("local").catalogRef, is(aliasesFile.toString()));
-		assertThat(catalog.catalogs.get("jbanghub").catalog, is(Catalog.getBuiltin()));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("global").catalogRef).isEqualTo(aliasesFile.toString());
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("dotparent").catalogRef).isEqualTo(aliasesFile.toString());
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("dotlocal").catalogRef).isEqualTo(aliasesFile.toString());
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("local").catalogRef).isEqualTo(aliasesFile.toString());
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("jbanghub").catalog).isEqualTo(Catalog.getBuiltin());
 
 		catalog.catalogs.keySet().removeAll(keys);
 		// After removing the known keys, the rest must come from the jbanghub import
 		final String JBANGHUB_URL = "https://raw.githubusercontent.com/jbanghub/jbang-catalog/main/jbang-catalog.json";
 		for (CatalogRef c : catalog.catalogs.values()) {
-			assertThat(c.catalog.catalogRef.getOriginalResource(), is(JBANGHUB_URL));
+			org.assertj.core.api.Assertions.assertThat(c.catalog.catalogRef.getOriginalResource()).isEqualTo(JBANGHUB_URL);
 		}
 	}
 
@@ -112,8 +112,8 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.addNearestCatalogRef("new", ref, null, false);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.catalogs.keySet(), hasItem("new"));
-		assertThat(catalog.catalogs.get("new").catalogRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("new").catalogRef).isEqualTo(result);
 	}
 
 	@Test
@@ -123,8 +123,8 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.addCatalogRef(Paths.get(Catalog.JBANG_CATALOG_JSON), "new", aliasesFile.toString(), null, null);
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.catalogs.keySet(), hasItem("new"));
-		assertThat(catalog.catalogs.get("new").catalogRef, equalTo(aliasesFile.toString()));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("new").catalogRef).isEqualTo(aliasesFile.toString());
 	}
 
 	@Test
@@ -141,8 +141,8 @@ public class TestCatalogNearest extends BaseTest {
 		assertThat(localCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
-		assertThat(catalog.catalogs.keySet(), hasItem("new"));
-		assertThat(catalog.catalogs.get("new").catalogRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("new").catalogRef).isEqualTo(result);
 	}
 
 	@Test
@@ -162,8 +162,8 @@ public class TestCatalogNearest extends BaseTest {
 		assertThat(dotLocalCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.catalogs.keySet(), hasItem("new"));
-		assertThat(catalog.catalogs.get("new").catalogRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("new").catalogRef).isEqualTo(result);
 	}
 
 	@Test
@@ -185,8 +185,8 @@ public class TestCatalogNearest extends BaseTest {
 		assertThat(parentCatalog.toFile(), not(anExistingFile()));
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(Settings.getUserCatalogFile());
-		assertThat(catalog.catalogs.keySet(), hasItem("new"));
-		assertThat(catalog.catalogs.get("new").catalogRef, equalTo(result));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).contains("new");
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.get("new").catalogRef).isEqualTo(result);
 	}
 
 	@Test
@@ -196,7 +196,7 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.removeNearestCatalogRef("local");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(localCatalog);
-		assertThat(catalog.catalogs.keySet(), not(hasItem("local")));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).doesNotContain("local");
 	}
 
 	@Test
@@ -206,7 +206,7 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.removeNearestCatalogRef("dotlocal");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(dotLocalCatalog);
-		assertThat(catalog.catalogs.keySet(), not(hasItem("dotlocal")));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).doesNotContain("dotlocal");
 	}
 
 	@Test
@@ -216,7 +216,7 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.removeNearestCatalogRef("dotparent");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(parentCatalog);
-		assertThat(catalog.catalogs.keySet(), not(hasItem("dotparent")));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).doesNotContain("dotparent");
 	}
 
 	@Test
@@ -225,6 +225,6 @@ public class TestCatalogNearest extends BaseTest {
 		CatalogUtil.removeNearestCatalogRef("global");
 		clearSettingsCaches();
 		Catalog catalog = Catalog.get(globalCatalog);
-		assertThat(catalog.catalogs.keySet(), not(hasItem("global")));
+		org.assertj.core.api.Assertions.assertThat(catalog.catalogs.keySet()).doesNotContain("global");
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestConfig.java
+++ b/src/test/java/dev/jbang/cli/TestConfig.java
@@ -1,8 +1,7 @@
 package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -47,81 +46,80 @@ public class TestConfig extends BaseTest {
 	@Test
 	void testList() throws Exception {
 		CaptureResult result = checkedRun(null, "config", "list");
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(),
-				equalTo("format = text\n" +
-						"init.template = hello\n" +
-						"one = footop\n" +
-						"run.debug = 4004\n" +
-						"run.jfr = filename={baseName}.jfr\n" +
-						"three = baz\n" +
-						"two = bar\n" +
-						"wrapper.install.dir = .\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("format = text\n" +
+			"init.template = hello\n" +
+			"one = footop\n" +
+			"run.debug = 4004\n" +
+			"run.jfr = filename={baseName}.jfr\n" +
+			"three = baz\n" +
+			"two = bar\n" +
+			"wrapper.install.dir = .\n");
 	}
 
 	@Test
 	void testGetLocal() throws Exception {
 		CaptureResult result = checkedRun(null, "config", "get", "two");
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), equalTo("bar\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("bar\n");
 	}
 
 	@Test
 	void testGetGlobal() throws Exception {
 		CaptureResult result = checkedRun(null, "config", "get", "run.debug");
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), equalTo("4004\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("4004\n");
 	}
 
 	@Test
 	void testSetLocal() throws Exception {
-		assertThat(Configuration.read(testConfigFile).keySet(), not(hasItem("mykey")));
+		assertThat(Configuration.read(testConfigFile).keySet()).doesNotContain("mykey");
 		CaptureResult result = checkedRun(null, "config", "set", "mykey", "myvalue");
-		assertThat(Configuration.read(testConfigFile).keySet(), hasItem("mykey"));
+		assertThat(Configuration.read(testConfigFile).keySet()).contains("mykey");
 	}
 
 	@Test
 	void testSetGlobal() throws Exception {
-		assertThat(Configuration.read(configFile).keySet(), not(hasItem("mykey")));
+		assertThat(Configuration.read(configFile).keySet()).doesNotContain("mykey");
 		CaptureResult result = checkedRun(null, "config", "set", "--global", "mykey", "myvalue");
-		assertThat(Configuration.read(configFile).keySet(), hasItem("mykey"));
+		assertThat(Configuration.read(configFile).keySet()).contains("mykey");
 	}
 
 	@Test
 	void testSetBuiltin() throws Exception {
 		Files.deleteIfExists(testConfigFile);
 		Files.deleteIfExists(testConfigFileSub);
-		assertThat(Configuration.read(configFile).keySet(), not(hasItem("run.debug")));
+		assertThat(Configuration.read(configFile).keySet()).doesNotContain("run.debug");
 		CaptureResult result = checkedRun(null, "config", "set", "run.debug", "42");
-		assertThat(Configuration.read(configFile).keySet(), hasItem("run.debug"));
+		assertThat(Configuration.read(configFile).keySet()).contains("run.debug");
 	}
 
 	@Test
 	void testUnsetLocal() throws Exception {
-		assertThat(Configuration.read(testConfigFile).keySet(), hasItem("two"));
+		assertThat(Configuration.read(testConfigFile).keySet()).contains("two");
 		CaptureResult result = checkedRun(null, "config", "unset", "two");
-		assertThat(Configuration.read(testConfigFile).keySet(), not(hasItem("two")));
+		assertThat(Configuration.read(testConfigFile).keySet()).doesNotContain("two");
 	}
 
 	@Test
 	void testUnsetGlobal() throws Exception {
 		checkedRun(null, "config", "set", "--global", "mykey", "myvalue");
-		assertThat(Configuration.read(configFile).keySet(), hasItem("mykey"));
+		assertThat(Configuration.read(configFile).keySet()).contains("mykey");
 		CaptureResult result = checkedRun(null, "config", "unset", "--global", "mykey");
-		assertThat(Configuration.read(configFile).keySet(), not(hasItem("mykey")));
+		assertThat(Configuration.read(configFile).keySet()).doesNotContain("mykey");
 	}
 
 	@Test
 	void testUnsetBuiltin() throws Exception {
 		CaptureResult result = checkedRun(null, "config", "unset", "run.debug");
-		assertThat(result.normalizedErr(), containsString("Cannot remove built-in option"));
+		assertThat(result.normalizedErr()).contains("Cannot remove built-in option");
 	}
 
 	@Test
 	void testCommandDefaultValueDefault() {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
 		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
-		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.text));
+		assertThat(app.formatMixin.format).isEqualTo(FormatMixin.Format.text);
 	}
 
 	@Test
@@ -129,7 +127,7 @@ public class TestConfig extends BaseTest {
 		Configuration.instance().put("app.list.format", "json");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
 		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
-		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.json));
+		assertThat(app.formatMixin.format).isEqualTo(FormatMixin.Format.json);
 	}
 
 	@Test
@@ -137,6 +135,6 @@ public class TestConfig extends BaseTest {
 		Configuration.instance().put("format", "json");
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("app", "list");
 		AppList app = (AppList) pr.subcommand().subcommand().commandSpec().userObject();
-		assertThat(app.formatMixin.format, equalTo(FormatMixin.Format.json));
+		assertThat(app.formatMixin.format).isEqualTo(FormatMixin.Format.json);
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -1,11 +1,6 @@
 package dev.jbang.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -18,7 +13,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +39,7 @@ public class TestEdit extends BaseTest {
 
 		String s = outputDir.resolve("edit.java").toString();
 		JBang.getCommandLine().execute("init", s);
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(s);
@@ -55,7 +49,7 @@ public class TestEdit extends BaseTest {
 		assertThat(project.resolve("src").toFile(), FileMatchers.anExistingDirectory());
 		Path build = project.resolve("build.gradle");
 		assert (Files.exists(build));
-		MatcherAssert.assertThat(Util.readString(build), containsString("dependencies"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(build)).contains("dependencies");
 		Path src = project.resolve("src/edit.java");
 
 		// first check for symlink. in some cases on windows (non admin privileg)
@@ -63,18 +57,16 @@ public class TestEdit extends BaseTest {
 		assert (Files.isSymbolicLink(src) || Files.exists(src));
 
 		// check eclipse is there
-		assertThat(Files.list(project).map(p -> p.getFileName().toString()).collect(Collectors.toList()),
-				containsInAnyOrder(".project", ".classpath", ".eclipse", "src", "build.gradle", ".vscode",
-						"README.md"));
+		org.assertj.core.api.Assertions.assertThat(Files.list(project).map(p -> p.getFileName().toString()).collect(Collectors.toList())).containsExactlyInAnyOrder(".project", ".classpath", ".eclipse", "src", "build.gradle", ".vscode", "README.md");
 		Path launchfile = project.resolve(".eclipse/edit.launch");
 		assert (Files.exists(launchfile));
-		assertThat(Util.readString(launchfile), containsString("launching.PROJECT_ATTR"));
-		assertThat(Util.readString(launchfile), containsString("PROGRAM_ARGUMENTS\" value=\"\""));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(launchfile)).contains("launching.PROJECT_ATTR");
+		org.assertj.core.api.Assertions.assertThat(Util.readString(launchfile)).contains("PROGRAM_ARGUMENTS\" value=\"\"");
 
 		launchfile = project.resolve(".eclipse/edit-port-4004.launch");
 		assert (Files.exists(launchfile));
-		assertThat(Util.readString(launchfile), containsString("launching.PROJECT_ATTR"));
-		assertThat(Util.readString(launchfile), containsString("4004"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(launchfile)).contains("launching.PROJECT_ATTR");
+		org.assertj.core.api.Assertions.assertThat(Util.readString(launchfile)).contains("4004");
 	}
 
 	@Test
@@ -83,7 +75,7 @@ public class TestEdit extends BaseTest {
 		Path p = outputDir.resolve("edit.java");
 		String s = p.toString();
 		JBang.getCommandLine().execute("--verbose", "init", s);
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 
 		Util.writeString(p, "//DEPS org.openjfx:javafx-graphics:11.0.2${bougus:}\n" + Util.readString(p));
 
@@ -95,11 +87,11 @@ public class TestEdit extends BaseTest {
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
 		String buildGradle = Util.readString(gradle);
-		assertThat(buildGradle, not(containsString("bogus")));
-		assertThat(buildGradle, containsString("id 'application'"));
-		assertThat(buildGradle, containsString("mainClass = 'edit'"));
-		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
-		assertThat(buildGradle, not(containsString("jitpack.io"))); // auto-added jitpack repo
+		org.assertj.core.api.Assertions.assertThat(buildGradle).doesNotContain("bogus");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("id 'application'");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("mainClass = 'edit'");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("repo1.maven.org"); // auto-added maven
+		org.assertj.core.api.Assertions.assertThat(buildGradle).doesNotContain("jitpack.io"); // auto-added jitpack repo
 
 		Path java = project.resolve("src/edit.java");
 
@@ -107,7 +99,7 @@ public class TestEdit extends BaseTest {
 		// symlink cannot be created, as fallback a hardlink will be created.
 		assert (Files.isSymbolicLink(java) || Files.exists(java));
 
-		assertThat(Files.isSameFile(java, p), equalTo(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isSameFile(java, p)).isEqualTo(true);
 	}
 
 	@Test
@@ -116,7 +108,7 @@ public class TestEdit extends BaseTest {
 		Path p = outputDir.resolve("edit.java");
 		String s = p.toString();
 		JBang.getCommandLine().execute("init", s);
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 
 		Util.writeString(p, "//DEPS io.quarkus:quarkus-bom:2.0.0.Final@pom\n" +
 				"//DEPS io.quarkus:quarkus-rest-client-reactive\n" +
@@ -130,11 +122,11 @@ public class TestEdit extends BaseTest {
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
 		String buildGradle = Util.readString(gradle);
-		assertThat(buildGradle, not(containsString("bogus")));
-		assertThat(buildGradle, containsString("id 'application'"));
-		assertThat(buildGradle, containsString("mainClass = 'edit'"));
-		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
-		assertThat(buildGradle, not(containsString("jitpack.io"))); // auto-added jitpack repo
+		org.assertj.core.api.Assertions.assertThat(buildGradle).doesNotContain("bogus");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("id 'application'");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("mainClass = 'edit'");
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("repo1.maven.org"); // auto-added maven
+		org.assertj.core.api.Assertions.assertThat(buildGradle).doesNotContain("jitpack.io"); // auto-added jitpack repo
 
 		Path java = project.resolve("src/edit.java");
 
@@ -142,7 +134,7 @@ public class TestEdit extends BaseTest {
 		// symlink cannot be created, as fallback a hardlink will be created.
 		assert (Files.isSymbolicLink(java) || Files.exists(java));
 
-		assertThat(Files.isSameFile(java, p), equalTo(true));
+		org.assertj.core.api.Assertions.assertThat(Files.isSameFile(java, p)).isEqualTo(true);
 	}
 
 	@Test
@@ -151,7 +143,7 @@ public class TestEdit extends BaseTest {
 		Path p = outputDir.resolve("edit.java");
 		String s = p.toString();
 		JBang.getCommandLine().execute("init", s);
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 
 		Util.writeString(p, "//DEPS https://github.com/oldskoolsh/libvirt-schema/tree/0.0.2\n" + Util.readString(p));
 
@@ -163,17 +155,17 @@ public class TestEdit extends BaseTest {
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
 		String buildGradle = Util.readString(gradle);
-		assertThat(buildGradle, not(containsString("github.com"))); // should be com.github
-		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
-		assertThat(buildGradle, containsString("jitpack.io")); // auto-added jitpack repo
-		assertThat(buildGradle, containsString("implementation 'com.github.oldskoolsh:libvirt-schema:0.0.2'"));
+		org.assertj.core.api.Assertions.assertThat(buildGradle).doesNotContain("github.com"); // should be com.github
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("repo1.maven.org"); // auto-added maven
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("jitpack.io"); // auto-added jitpack repo
+		org.assertj.core.api.Assertions.assertThat(buildGradle).contains("implementation 'com.github.oldskoolsh:libvirt-schema:0.0.2'");
 	}
 
 	@Test
 	void testEditMultiSource(@TempDir Path outputDir) throws IOException {
 
 		Path p = examplesTestFolder.resolve("one.java");
-		assertThat(p.toFile().exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(p.toFile().exists()).isEqualTo(true);
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(p.toString());
@@ -182,7 +174,7 @@ public class TestEdit extends BaseTest {
 
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
-		assertThat(Util.readString(gradle), not(containsString("bogus")));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(gradle)).doesNotContain("bogus");
 
 		Arrays.asList("one.java", "Two.java", "gh_fetch_release_assets.java", "gh_release_stats.java")
 			.forEach(f -> {
@@ -197,8 +189,8 @@ public class TestEdit extends BaseTest {
 		Path p = outputDir.resolve("kube-example");
 		int result = JBang.getCommandLine().execute("init", p.toString());
 		String s = p.toString();
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(s);
@@ -216,7 +208,7 @@ public class TestEdit extends BaseTest {
 	void testEditFile(@TempDir Path outputDir) throws IOException {
 
 		Path p = examplesTestFolder.resolve("res/resource.java");
-		assertThat(p.toFile().exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(p.toFile().exists()).isEqualTo(true);
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(p.toString());
@@ -225,7 +217,7 @@ public class TestEdit extends BaseTest {
 
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
-		assertThat(Util.readString(gradle), not(containsString("bogus")));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(gradle)).doesNotContain("bogus");
 
 		Arrays.asList("resource.java", "resource.properties", "renamed.properties", "META-INF/application.properties")
 			.forEach(f -> {

--- a/src/test/java/dev/jbang/cli/TestEditWithPom.java
+++ b/src/test/java/dev/jbang/cli/TestEditWithPom.java
@@ -1,7 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -56,7 +55,7 @@ public class TestEditWithPom extends BaseTest {
 		Path gradle = project.resolve("build.gradle");
 		assert (Files.exists(gradle));
 		String buildGradle = Util.readString(gradle);
-		assertThat(buildGradle, containsString("implementation platform")); // should be com.github
+		assertThat(buildGradle).contains("implementation platform"); // should be com.github
 
 	}
 

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -1,7 +1,8 @@
 package dev.jbang.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.io.FileMatchers.anExistingDirectory;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.hamcrest.io.FileMatchers.anExistingFileOrDirectory;
@@ -32,7 +33,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String outFile = cwdDir.resolve("subdir/helloworld.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "local", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*helloworld.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 	}
 
@@ -41,7 +42,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String outFile = cwdDir.resolve("helloworld").toString();
 		CaptureResult result = checkedRun(null, "export", "local", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*helloworld.jar.*");
 		assertThat(new File(outFile + ".jar"), anExistingFile());
 	}
 
@@ -50,7 +51,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String outFile = cwdDir.resolve("helloworld.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "local", src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*helloworld.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 	}
 
@@ -59,7 +60,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String outFile = cwdDir.resolve("helloworld.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "portable", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*helloworld.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile(), not(anExistingFileOrDirectory()));
 	}
@@ -69,10 +70,10 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("classpath_log.java").toString();
 		String outFile = cwdDir.resolve("classpath_log.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "portable", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*classpath_log.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*classpath_log.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile(), anExistingDirectory());
-		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile().listFiles().length, Matchers.equalTo(1));
+		org.assertj.core.api.Assertions.assertThat(cwdDir.resolve(ExportPortable.LIB).toFile().listFiles().length).isEqualTo(1);
 
 		File jar = new File(outFile);
 
@@ -80,7 +81,7 @@ public class TestExport extends BaseTest {
 			Manifest mf = jarStream.getManifest();
 
 			String cp = mf.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
-			assertThat(cp, not(containsString("m2")));
+			org.assertj.core.api.Assertions.assertThat(cp).doesNotContain("m2");
 		}
 
 		Files.delete(jar.toPath());
@@ -91,7 +92,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("classpath_log.java").toString();
 		String outFile = cwdDir.resolve("classpath_log.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "local", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*classpath_log.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*classpath_log.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 		assertThat(cwdDir.resolve(ExportPortable.LIB).toFile(), not(anExistingDirectory()));
 
@@ -101,7 +102,7 @@ public class TestExport extends BaseTest {
 			Manifest mf = jarStream.getManifest();
 
 			String cp = mf.getMainAttributes().getValue(Attributes.Name.CLASS_PATH);
-			assertThat(cp, containsString("jbang_tests_maven"));
+			org.assertj.core.api.Assertions.assertThat(cp).contains("jbang_tests_maven");
 		}
 		Files.delete(jar.toPath());
 
@@ -113,7 +114,7 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "mavenrepo", "-O", outFile.toString(),
 				"--group=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*target.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*target.*");
 		assertThat(
 				outFile.toPath().resolve("my/thing/right/helloworld/999-SNAPSHOT/helloworld-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
@@ -129,7 +130,7 @@ public class TestExport extends BaseTest {
 		// outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "mavenrepo", "-O", outFile.toString(),
 				"--group=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_INVALID_INPUT);
 
 	}
 
@@ -139,8 +140,8 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "mavenrepo", "--force", "-O",
 				outFile.toString(), examplesTestFolder.resolve("helloworld.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
-		assertThat(result.err, containsString("Add --group=<group id> and run again"));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_INVALID_INPUT);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Add --group=<group id> and run again");
 	}
 
 	@Test
@@ -148,7 +149,7 @@ public class TestExport extends BaseTest {
 		Path outFile = mavenTempDir;
 		CaptureResult result = checkedRun(null, "export", "mavenrepo", "--force",
 				"--group=g.a.v", examplesTestFolder.resolve("classpath_log.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
 		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.pom").toFile(),
@@ -167,7 +168,7 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "mavenrepo", "-O", outFile.toString(),
 				examplesTestFolder.resolve("quote.java").toString());
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*target.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*target.*");
 		assertThat(
 				outFile.toPath().resolve("dev/jbang/itests/quote/999-SNAPSHOT/quote-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
@@ -191,7 +192,7 @@ public class TestExport extends BaseTest {
 		String src = examplesTestFolder.resolve("helloworld.java").toString();
 		String outFile = cwdDir.resolve("subdir/helloworld.jar").toString();
 		CaptureResult result = checkedRun(null, "export", "fatjar", "-O", outFile, src);
-		assertThat(result.err, matchesPattern("(?s).*Exported to.*helloworld.jar.*"));
+		org.assertj.core.api.Assertions.assertThat(result.err).matches("(?s).*Exported to.*helloworld.jar.*");
 		assertThat(new File(outFile), anExistingFile());
 	}
 
@@ -201,7 +202,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -209,9 +210,9 @@ public class TestExport extends BaseTest {
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'classpath_log'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'classpath_log'");
 	}
 
 	@Test
@@ -221,7 +222,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/groovy/classpath_log.groovy");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -229,9 +230,9 @@ public class TestExport extends BaseTest {
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'classpath_log'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'classpath_log'");
 	}
 
 	@Test
@@ -241,7 +242,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/kotlin/classpath_log.kt");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -249,9 +250,9 @@ public class TestExport extends BaseTest {
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'classpath_log'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'classpath_log'");
 	}
 
 	@Test
@@ -261,7 +262,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/kotlin/classpath_main.kt");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -269,9 +270,9 @@ public class TestExport extends BaseTest {
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'Classpath_mainKt'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'Classpath_mainKt'");
 	}
 
 	@Test
@@ -281,18 +282,18 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(),
 				"-g", "dev.jbang.test", "-a", "app", "-v", "1.2.3", src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package ")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package ");
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'classpath_log'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'classpath_log'");
 	}
 
 	@Test
@@ -301,21 +302,21 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve(
 					"src/main/java/classpath_log_bom.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package ")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package ");
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("implementation platform ('org.apache.logging.log4j:log4j-bom:2.24.3')"));
-		assertThat(build, containsString("implementation 'org.apache.logging.log4j:log4j-api'"));
-		assertThat(build, containsString("implementation 'org.apache.logging.log4j:log4j-core'"));
-		assertThat(build, not(containsString("languageVersion = JavaLanguageVersion.of")));
-		assertThat(build, containsString("mainClass = 'classpath_log_bom'"));
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation platform ('org.apache.logging.log4j:log4j-bom:2.24.3')");
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'org.apache.logging.log4j:log4j-api'");
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'org.apache.logging.log4j:log4j-core'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'classpath_log_bom'");
 	}
 
 	@Test
@@ -324,13 +325,13 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/exporttags.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(startsWith("package ")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotStartWith("package ");
 
 		Path src1Path = outFile.toPath()
 			.resolve("src/main/java/Two.java");
@@ -358,15 +359,15 @@ public class TestExport extends BaseTest {
 		Path buildPath = outFile.toPath().resolve("build.gradle");
 		assertThat(buildPath.toFile(), anExistingFile());
 		String build = Util.readString(buildPath);
-		assertThat(build, containsString("description = 'some description'"));
-		assertThat(build, containsString("implementation 'log4j:log4j:1.2.17'"));
-		assertThat(build, containsString("languageVersion = JavaLanguageVersion.of"));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(8)")));
-		assertThat(build, containsString("JavaLanguageVersion.of(11)"));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(17)")));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(21+)")));
-		assertThat(build, containsString("mainClass = 'exporttags'"));
-		assertThat(build, not(containsString("JavaLanguageVersion.of(11+)")));
+		org.assertj.core.api.Assertions.assertThat(build).contains("description = 'some description'");
+		org.assertj.core.api.Assertions.assertThat(build).contains("implementation 'log4j:log4j:1.2.17'");
+		org.assertj.core.api.Assertions.assertThat(build).contains("languageVersion = JavaLanguageVersion.of");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("JavaLanguageVersion.of(8)");
+		org.assertj.core.api.Assertions.assertThat(build).contains("JavaLanguageVersion.of(11)");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("JavaLanguageVersion.of(17)");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("JavaLanguageVersion.of(21+)");
+		org.assertj.core.api.Assertions.assertThat(build).contains("mainClass = 'exporttags'");
+		org.assertj.core.api.Assertions.assertThat(build).doesNotContain("JavaLanguageVersion.of(11+)");
 	}
 
 	@Test
@@ -375,12 +376,12 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package org.example.project.classpath_log;")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package org.example.project.classpath_log;");
 		Path pomPath = outFile.toPath().resolve("pom.xml");
 		assertThat(pomPath.toFile(), anExistingFile());
 		String pom = Util.readString(pomPath);
@@ -393,10 +394,10 @@ public class TestExport extends BaseTest {
 				"<artifactId>log4j</artifactId>",
 				"<version>1.2.17</version>",
 				"<mainClass>classpath_log</mainClass>"));
-		assertThat(pom, not(containsString("<properties>")));
-		assertThat(pom, not(containsString("<dependencyManagement>")));
-		assertThat(pom, not(containsString("<repositories>")));
-		assertThat(pom, not(containsString("<release>")));
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<properties>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<dependencyManagement>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<repositories>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<release>");
 	}
 
 	@Test
@@ -405,12 +406,12 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/RootOne.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package org.example.project.classpath_log;")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package org.example.project.classpath_log;");
 		Path pomPath = outFile.toPath().resolve("pom.xml");
 		assertThat(pomPath.toFile(), anExistingFile());
 		String pom = Util.readString(pomPath);
@@ -418,10 +419,10 @@ public class TestExport extends BaseTest {
 				"<groupId>org.example.project</groupId>",
 				"<artifactId>RootOne</artifactId>",
 				"<version>999-SNAPSHOT</version>"));
-		assertThat(pom, not(containsString("<dependencies>")));
-		assertThat(pom, not(containsString("<properties>")));
-		assertThat(pom, not(containsString("<dependencyManagement>")));
-		assertThat(pom, not(containsString("<repositories>")));
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<dependencies>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<properties>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<dependencyManagement>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<repositories>");
 	}
 
 	@Test
@@ -431,12 +432,12 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "maven", "--force", "-O", outFile.toString(),
 				"-g", "dev.jbang.test", "-a", "app", "-v", "1.2.3", src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package ")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package ");
 		Path pomPath = outFile.toPath().resolve("pom.xml");
 		assertThat(pomPath.toFile(), anExistingFile());
 		String pom = Util.readString(pomPath);
@@ -449,10 +450,10 @@ public class TestExport extends BaseTest {
 				"<artifactId>log4j</artifactId>",
 				"<version>1.2.17</version>",
 				"<mainClass>classpath_log</mainClass>"));
-		assertThat(pom, not(containsString("<properties>")));
-		assertThat(pom, not(containsString("<dependencyManagement>")));
-		assertThat(pom, not(containsString("<repositories>")));
-		assertThat(pom, not(containsString("<release>")));
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<properties>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<dependencyManagement>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<repositories>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<release>");
 	}
 
 	@Test
@@ -461,13 +462,13 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 		Path targetSrcPath = outFile.toPath()
 			.resolve(
 					"src/main/java/classpath_log_bom.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package org.example.project.classpath_log_bom;")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package org.example.project.classpath_log_bom;");
 		Path pomPath = outFile.toPath().resolve("pom.xml");
 		assertThat(pomPath.toFile(), anExistingFile());
 		String pom = Util.readString(pomPath);
@@ -485,8 +486,8 @@ public class TestExport extends BaseTest {
 				"<groupId>org.apache.logging.log4j</groupId>",
 				"<artifactId>log4j-core</artifactId>",
 				"<mainClass>classpath_log_bom</mainClass>"));
-		assertThat(pom, not(containsString("<properties>")));
-		assertThat(pom, not(containsString("<repositories>")));
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<properties>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<repositories>");
 	}
 
 	@Test
@@ -495,13 +496,13 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult result = checkedRun(null, "export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		org.assertj.core.api.Assertions.assertThat(result.result).isEqualTo(BaseCommand.EXIT_OK);
 
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/exporttags.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
 		String targetSrc = Util.readString(targetSrcPath);
-		assertThat(targetSrc, not(containsString("package org.example.exporttags;")));
+		org.assertj.core.api.Assertions.assertThat(targetSrc).doesNotContain("package org.example.exporttags;");
 
 		Path src1Path = outFile.toPath()
 			.resolve("src/main/java/Two.java");
@@ -541,10 +542,10 @@ public class TestExport extends BaseTest {
 				"<repositories>",
 				"<id>jitpack</id>",
 				"<url>https://jitpack.io/</url>"));
-		assertThat(pom, containsString("<release>")); // Properties key may be in any order
-		assertThat(pom, not(containsString("<release>8</release>")));
-		assertThat(pom, containsString("<release>11</release>"));
-		assertThat(pom, not(containsString("<release>17</release>")));
-		assertThat(pom, not(containsString("<release>11+</release>")));
+		org.assertj.core.api.Assertions.assertThat(pom).contains("<release>"); // Properties key may be in any order
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<release>8</release>");
+		org.assertj.core.api.Assertions.assertThat(pom).contains("<release>11</release>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<release>17</release>");
+		org.assertj.core.api.Assertions.assertThat(pom).doesNotContain("<release>11+</release>");
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestExternalDeps.java
+++ b/src/test/java/dev/jbang/cli/TestExternalDeps.java
@@ -1,8 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.matchesPattern;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +48,7 @@ class TestExternalDeps extends BaseTest {
 		Project prj = pb.build(f.getPath());
 		String result = run.updateGeneratorForRun(prj.codeBuilder().build()).build().generate();
 
-		assertThat(result, containsString("pico"));
+		assertThat(result).contains("pico");
 	}
 
 	@Test
@@ -71,7 +69,7 @@ class TestExternalDeps extends BaseTest {
 		Project prj = pb.build(f.getPath());
 		String result = run.updateGeneratorForRun(prj.codeBuilder().build()).build().generate();
 
-		assertThat(result, matchesPattern(".*com[/\\\\]github[/\\\\]jbangdev[/\\\\]jbang.*"));
+		assertThat(result).matches(".*com[/\\\\]github[/\\\\]jbangdev[/\\\\]jbang.*");
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestInfo.java
+++ b/src/test/java/dev/jbang/cli/TestInfo.java
@@ -23,18 +23,22 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, allOf(
-				containsString("quote.java."),
-				endsWith(".jar")));
-		assertThat(info.backingResource, equalTo(src));
-		assertThat(info.javaVersion, is(nullValue()));
-		assertThat(info.mainClass, is(nullValue()));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString("picocli"))));
-		assertThat(info.description, equalTo("For testing purposes"));
-		assertThat(info.gav, equalTo("dev.jbang.itests:quote"));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar)
+			.satisfies(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).contains("quote.java."),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).endsWith(".jar")
+			);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(1))),
+				arg -> assertThat(arg, everyItem(containsString("picocli")))
+			);
+		org.assertj.core.api.Assertions.assertThat(info.description).isEqualTo("For testing purposes");
+		org.assertj.core.api.Assertions.assertThat(info.gav).isEqualTo("dev.jbang.itests:quote");
 	}
 
 	@Test
@@ -44,14 +48,18 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, allOf(
-				containsString("quote.java."),
-				endsWith(".jar")));
-		assertThat(info.mainClass, equalTo("quote"));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString("picocli"))));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar)
+			.satisfies(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).contains("quote.java."),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).endsWith(".jar")
+			);
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isEqualTo("quote");
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(1))),
+				arg -> assertThat(arg, everyItem(containsString("picocli")))
+			);
 	}
 
 	@Test
@@ -64,18 +72,22 @@ public class TestInfo extends BaseTest {
 					src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, allOf(
-				containsString("helloworld.java."),
-				endsWith(".jar")));
-		assertThat(info.backingResource, equalTo(src));
-		assertThat(info.javaVersion, is(nullValue()));
-		assertThat(info.mainClass, is(nullValue()));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(3)),
-				hasItem(containsString("picocli")),
-				hasItem(containsString("commons-io")),
-				hasItem(containsString("commons-lang3"))));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar)
+			.satisfies(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).contains("helloworld.java."),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).endsWith(".jar")
+			);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(3))),
+				arg -> assertThat(arg, hasItem(containsString("picocli"))),
+				arg -> assertThat(arg, hasItem(containsString("commons-io"))),
+				arg -> assertThat(arg, hasItem(containsString("commons-lang3")))
+			);
 	}
 
 	@Test
@@ -85,16 +97,20 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", "--cp", jar, src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, allOf(
-				containsString("helloworld.java."),
-				endsWith(".jar")));
-		assertThat(info.backingResource, equalTo(src));
-		assertThat(info.javaVersion, is(nullValue()));
-		assertThat(info.mainClass, is(nullValue()));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString(Paths.get("itests/hellojar.jar").toString()))));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar)
+			.satisfies(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).contains("helloworld.java."),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).endsWith(".jar")
+			);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(1))),
+				arg -> assertThat(arg, everyItem(containsString(Paths.get("itests/hellojar.jar").toString())))
+			);
 	}
 
 	@Test
@@ -104,21 +120,25 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, allOf(
-				containsString("sources.java."),
-				endsWith(".jar")));
-		assertThat(info.backingResource, equalTo(src));
-		assertThat(info.javaVersion, is(nullValue()));
-		assertThat(info.mainClass, is(nullValue()));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString("picocli"))));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar)
+			.satisfies(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).contains("sources.java."),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).endsWith(".jar")
+			);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(1))),
+				arg -> assertThat(arg, everyItem(containsString("picocli")))
+			);
 		assertThat(info.sources, hasSize(equalTo(2)));
-		assertThat(info.sources.get(0).originalResource, equalTo(src));
-		assertThat(info.sources.get(0).backingResource, equalTo(src));
-		assertThat(info.sources.get(1).originalResource, equalTo(quote));
-		assertThat(info.sources.get(1).backingResource, equalTo(quote));
+		org.assertj.core.api.Assertions.assertThat(info.sources.get(0).originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.sources.get(0).backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.sources.get(1).originalResource).isEqualTo(quote);
+		org.assertj.core.api.Assertions.assertThat(info.sources.get(1).backingResource).isEqualTo(quote);
 	}
 
 	@Test
@@ -127,14 +147,16 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
-		assertThat(info.applicationJar, equalTo(null));
-		assertThat(info.backingResource, equalTo(src));
-		assertThat(info.javaVersion, is(nullValue()));
-		assertThat(info.mainClass, is(nullValue()));
-		assertThat(info.resolvedDependencies, Matchers.<Collection<String>>allOf(
-				hasSize(equalTo(1)),
-				everyItem(containsString("commons-lang3"))));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar).isEqualTo(null);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isNull();
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies)
+			.satisfies(
+				arg -> assertThat(arg, hasSize(equalTo(1))),
+				arg -> assertThat(arg, everyItem(containsString("commons-lang3")))
+			);
 	}
 
 	@Test
@@ -143,12 +165,12 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", jar);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(jar));
-		assertThat(info.applicationJar, equalTo(jar));
-		assertThat(info.backingResource, equalTo(jar));
-		assertThat(info.javaVersion, not(nullValue()));
-		assertThat(info.mainClass, equalTo("helloworld"));
-		assertThat(info.resolvedDependencies, empty());
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(jar);
+		org.assertj.core.api.Assertions.assertThat(info.applicationJar).isEqualTo(jar);
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(jar);
+		org.assertj.core.api.Assertions.assertThat(info.javaVersion).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(info.mainClass).isEqualTo("helloworld");
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies).isEmpty();
 	}
 
 	@Test
@@ -157,12 +179,12 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "tools", src);
 		Tools tools = (Tools) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ScriptInfo info = tools.getInfo(false);
-		assertThat(info.originalResource, equalTo(src));
+		org.assertj.core.api.Assertions.assertThat(info.originalResource).isEqualTo(src);
 		// assertThat(info.applicationJar, equalTo(src));
-		assertThat(info.backingResource, equalTo(src));
+		org.assertj.core.api.Assertions.assertThat(info.backingResource).isEqualTo(src);
 		// assertThat(info.javaVersion, not(nullValue()));
 		// assertThat(info.mainClass, equalTo("helloworld"));
-		assertThat(info.resolvedDependencies, empty());
+		org.assertj.core.api.Assertions.assertThat(info.resolvedDependencies).isEmpty();
 	}
 
 	@Test
@@ -171,7 +193,7 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "docs", src);
 		Docs docs = (Docs) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ProjectFile pf = docs.getInfo(false).docs.get("main").get(0);
-		assertThat(pf.originalResource, endsWith(File.separator + "itests" + File.separator + "readme.md"));
+		org.assertj.core.api.Assertions.assertThat(pf.originalResource).endsWith(File.separator + "itests" + File.separator + "readme.md");
 	}
 
 	@Test
@@ -180,7 +202,7 @@ public class TestInfo extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "docs", src);
 		Docs docs = (Docs) pr.subcommand().subcommand().commandSpec().userObject();
 		BaseInfoCommand.ProjectFile pf = docs.getInfo(false).docs.get("main").get(0);
-		assertThat(pf.originalResource, equalTo("https://www.jbang.dev/documentation/guide/latest/faq.html"));
+		org.assertj.core.api.Assertions.assertThat(pf.originalResource).isEqualTo("https://www.jbang.dev/documentation/guide/latest/faq.html");
 	}
 
 	@Test
@@ -188,7 +210,7 @@ public class TestInfo extends BaseTest {
 		String src = examplesTestFolder.resolve("docstest_nodocs.java").toString();
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("info", "docs", src);
 		Docs docs = (Docs) pr.subcommand().subcommand().commandSpec().userObject();
-		assertThat(docs.getInfo(false).docs.isEmpty(), is(true));
+		org.assertj.core.api.Assertions.assertThat(docs.getInfo(false).docs.isEmpty()).isEqualTo(true);
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -1,9 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.io.FileMatchers.aReadableFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,7 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
@@ -44,7 +40,7 @@ public class TestInit extends BaseTest {
 		HashMap<String, Object> props = new HashMap<>();
 		props.put("baseName", "test");
 		new Init().renderQuteTemplate(out, ResourceRef.forResource("classpath:/init-hello.java.qute"), props);
-		assertThat(Util.readString(out), Matchers.containsString("class test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(out)).contains("class test");
 	}
 
 	@ParameterizedTest
@@ -53,7 +49,7 @@ public class TestInit extends BaseTest {
 		Exception ex = assertThrows(ExitException.class,
 				() -> new Init().renderQuteTemplate(Paths.get(filename),
 						ResourceRef.forResource("classpath:/init-hello.java.qute"), Collections.emptyMap()));
-		assertThat(ex.getMessage(), Matchers.containsString("is not a valid class name in java."));
+		org.assertj.core.api.Assertions.assertThat(ex.getMessage()).contains("is not a valid class name in java.");
 	}
 
 	@Test
@@ -61,9 +57,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", "--verbose", "--template=cli", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		MatcherAssert.assertThat(Util.readString(x), Matchers.containsString("picocli"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("picocli");
 	}
 
 	@Test
@@ -78,8 +74,8 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", "--template=bogus", s);
-		assertThat(result, not(0));
-		assertThat(new File(s).exists(), is(false));
+		org.assertj.core.api.Assertions.assertThat(result).isNotEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(false);
 	}
 
 	@Test
@@ -87,9 +83,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", "--deps", "a.b.c:mydep:1.0", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("//DEPS a.b.c:mydep:1.0"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("//DEPS a.b.c:mydep:1.0");
 	}
 
 	@Test
@@ -97,9 +93,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("java25.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", "--java", "25", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("\nvoid main(String... args)"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("\nvoid main(String... args)");
 	}
 
 	@Test
@@ -107,10 +103,10 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", "--deps", "a.b.c:mydep:1.0", "--deps", "q.z:rrr:2.0", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("//DEPS a.b.c:mydep:1.0"));
-		assertThat(Util.readString(x), Matchers.containsString("//DEPS q.z:rrr:2.0"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("//DEPS a.b.c:mydep:1.0");
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("//DEPS q.z:rrr:2.0");
 	}
 
 	@Test
@@ -123,12 +119,12 @@ public class TestInit extends BaseTest {
 					"--deps", "org.hsqldb:hsqldb:2.5.0,net.hydromatic:foodmart-data-hsqldb:0.4",
 					"--deps", "org.another.company:dep:0.1",
 					s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
 		final String fileContent = Util.readString(x);
-		assertThat(fileContent, Matchers.containsString("//DEPS org.hsqldb:hsqldb:2.5.0"));
-		assertThat(fileContent, Matchers.containsString("//DEPS net.hydromatic:foodmart-data-hsqldb:0.4"));
-		assertThat(fileContent, Matchers.containsString("//DEPS org.another.company:dep:0.1"));
+		org.assertj.core.api.Assertions.assertThat(fileContent).contains("//DEPS org.hsqldb:hsqldb:2.5.0");
+		org.assertj.core.api.Assertions.assertThat(fileContent).contains("//DEPS net.hydromatic:foodmart-data-hsqldb:0.4");
+		org.assertj.core.api.Assertions.assertThat(fileContent).contains("//DEPS org.another.company:dep:0.1");
 	}
 
 	@Test
@@ -136,9 +132,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("edit.java");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("class edit"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("class edit");
 	}
 
 	@Test
@@ -146,9 +142,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("xyz-plug");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("class XyzPlug"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("class XyzPlug");
 	}
 
 	@Test
@@ -156,9 +152,9 @@ public class TestInit extends BaseTest {
 		Path x = outputDir.resolve("xyzplug");
 		String s = x.toString();
 		int result = JBang.getCommandLine().execute("init", s);
-		assertThat(result, is(0));
-		assertThat(new File(s).exists(), is(true));
-		assertThat(Util.readString(x), Matchers.containsString("class xyzplug"));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(new File(s).exists()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(x)).contains("class xyzplug");
 	}
 
 	@Test
@@ -166,7 +162,7 @@ public class TestInit extends BaseTest {
 //		int result = JBang.getCommandLine().execute("run", "jget@quintesse");
 //		int result = JBang.getCommandLine().execute("catalog", "update");
 		int result = JBang.getCommandLine().execute("catalog", "list", "quintesse");
-		assertThat(result, is(0));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
 	}
 
 	@Test
@@ -202,12 +198,12 @@ public class TestInit extends BaseTest {
 	void testInitMultipleFiles(String targetName, String initName, String outName, boolean abs) throws IOException {
 		Path outFile = setupInitMultipleFiles(targetName, initName, abs);
 		int result = JBang.getCommandLine().execute("init", "-t=name", outFile.toString());
-		assertThat(result, is(0));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
 		assertThat(outFile.resolveSibling(outName).toFile(), aReadableFile());
 		Path f2 = outFile.resolveSibling("file2.java");
 		assertThat(f2.toFile(), aReadableFile());
 		String baseName = Util.getBaseName(Paths.get(initName).getFileName().toString());
-		assertThat(Util.readString(f2), Matchers.containsString("// " + baseName + " with " + outFile));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(f2)).contains("// " + baseName + " with " + outFile);
 		assertThat(outFile.resolveSibling("file3.md").toFile(), aReadableFile());
 
 	}
@@ -216,7 +212,7 @@ public class TestInit extends BaseTest {
 			throws IOException {
 		Path outFile = setupInitMultipleFiles(targetName, initName, abs);
 		int result = JBang.getCommandLine().execute("init", "-t=name", outFile.toString());
-		assertThat(result, is(expectedResult));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(expectedResult);
 	}
 
 	Path setupInitMultipleFiles(String targetName, String initName, boolean abs) throws IOException {
@@ -230,12 +226,12 @@ public class TestInit extends BaseTest {
 			int addResult = JBang.getCommandLine()
 				.execute("template", "add", "-f", cwd.toString(), "--name=name",
 						targetName + "=" + f1.toString(), f2.toString(), f3.toString());
-			assertThat(addResult, is(0));
+			org.assertj.core.api.Assertions.assertThat(addResult).isEqualTo(0);
 		} else {
 			int addResult = JBang.getCommandLine()
 				.execute("template", "add", "-f", cwd.toString(), "--name=name",
 						targetName + "=tpl/file1.java", "tpl/file2.java.qute", "tpl/file3.md");
-			assertThat(addResult, is(0));
+			org.assertj.core.api.Assertions.assertThat(addResult).isEqualTo(0);
 		}
 		Path appDir = Files.createDirectory(cwd.resolve("app"));
 		Util.setCwd(appDir);
@@ -257,7 +253,7 @@ public class TestInit extends BaseTest {
 
 		String outcontent = Util.readString(out);
 
-		assertThat(outcontent, containsString("propvaluerocks"));
+		org.assertj.core.api.Assertions.assertThat(outcontent).contains("propvaluerocks");
 	}
 
 	@Test
@@ -270,18 +266,18 @@ public class TestInit extends BaseTest {
 			.execute("template", "add", "-f", cwd.toString(), "--name=name",
 					"{filename}" + "=" + f1.toAbsolutePath().toString());
 
-		assertThat(out.toFile().exists(), not(true));
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isNotEqualTo(true);
 
 		int result = JBang.getCommandLine()
 			.execute("init", "--verbose", "--template=name", "-Dprop1=propvalue", "-Dprop2=rocks",
 					out.toAbsolutePath().toString());
 
-		assertThat(result, is(0));
-		assertThat(out.toFile().exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isEqualTo(true);
 
 		String outcontent = Util.readString(out);
 
-		assertThat(outcontent, containsString("propvaluerocks"));
+		org.assertj.core.api.Assertions.assertThat(outcontent).contains("propvaluerocks");
 	}
 
 	@Test
@@ -294,18 +290,18 @@ public class TestInit extends BaseTest {
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", "-P=prop1::my-test-default-value",
 					"{filename}" + "=" + f1.toAbsolutePath().toString());
 
-		assertThat(out.toFile().exists(), not(true));
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isNotEqualTo(true);
 
 		int result = JBang.getCommandLine()
 			.execute("init", "--verbose", "--template=name",
 					out.toAbsolutePath().toString());
 
-		assertThat(result, is(0));
-		assertThat(out.toFile().exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isEqualTo(true);
 
 		String outcontent = Util.readString(out);
 
-		assertThat(outcontent, containsString("my-test-default-value"));
+		org.assertj.core.api.Assertions.assertThat(outcontent).contains("my-test-default-value");
 	}
 
 	@Test
@@ -318,18 +314,18 @@ public class TestInit extends BaseTest {
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", "-P=prop1::",
 					"{filename}" + "=" + f1.toAbsolutePath().toString());
 
-		assertThat(out.toFile().exists(), not(true));
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isNotEqualTo(true);
 
 		int result = JBang.getCommandLine()
 			.execute("init", "--verbose", "--template=name",
 					out.toAbsolutePath().toString());
 
-		assertThat(result, is(0));
-		assertThat(out.toFile().exists(), is(true));
+		org.assertj.core.api.Assertions.assertThat(result).isEqualTo(0);
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isEqualTo(true);
 
 		String outcontent = Util.readString(out);
 
-		assertThat(outcontent, containsString("NOT_FOUND"));
+		org.assertj.core.api.Assertions.assertThat(outcontent).contains("NOT_FOUND");
 	}
 
 	@Test
@@ -342,7 +338,7 @@ public class TestInit extends BaseTest {
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", "-P=prop1::my-test-default-value",
 					"{filename}" + "=" + f1.toAbsolutePath().toString());
 
-		assertThat(out.toFile().exists(), not(true));
+		org.assertj.core.api.Assertions.assertThat(out.toFile().exists()).isNotEqualTo(true);
 
 	}
 

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -1,10 +1,6 @@
 package dev.jbang.cli;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.startsWith;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
@@ -41,8 +37,8 @@ class TestJdk extends BaseTest {
 	void testNoJdksInstalled() throws Exception {
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.list(false, false, FormatMixin.Format.text));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), equalTo("No JDKs installed\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("No JDKs installed\n");
 	}
 
 	@Test
@@ -52,9 +48,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.list(false, false, FormatMixin.Format.text));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(),
-				equalTo("Installed JDKs (<=default):\n   11 (11.0.7) <\n   12 (12.0.7)\n   13 (13.0.7)\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("Installed JDKs (<=default):\n   11 (11.0.7) <\n   12 (12.0.7)\n   13 (13.0.7)\n");
 	}
 
 	@Test
@@ -69,18 +64,17 @@ class TestJdk extends BaseTest {
 		CaptureResult<Integer> result = checkedRun((Jdk jdk) -> jdk.list(false, false, FormatMixin.Format.text),
 				"jdk", "--jdk-providers", "default,javahome,jbang");
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(),
-				equalTo("Installed JDKs (<=default):\n   11 (11.0.7) <\n   12 (12.0.7)\n   13 (13.0.7)\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).isEqualTo("Installed JDKs (<=default):\n   11 (11.0.7) <\n   12 (12.0.7)\n   13 (13.0.7)\n");
 	}
 
 	@Test
 	void testJdksAvailable() throws Exception {
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.list(true, false, FormatMixin.Format.text));
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
 		Pattern p = Pattern.compile("^ {3}\\d+ \\(.+?\\)$", Pattern.MULTILINE);
 		Matcher m = p.matcher(result.normalizedOut());
-		assertThat(m.find(), equalTo(true));
+		assertThat(m.find()).isEqualTo(true);
 	}
 
 	@Test
@@ -89,13 +83,13 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.defaultJdk("12"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), startsWith("[jbang] Default JDK set to 12"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).startsWith("[jbang] Default JDK set to 12");
 
 		result = checkedRun(jdk -> jdk.defaultJdk(null));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), equalTo("[jbang] Default JDK is currently set to 12\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] Default JDK is currently set to 12\n");
 	}
 
 	@Test
@@ -104,13 +98,13 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.defaultJdk("16+"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), startsWith("[jbang] Default JDK set to 17"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).startsWith("[jbang] Default JDK set to 17");
 
 		result = checkedRun(jdk -> jdk.defaultJdk(null));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), equalTo("[jbang] Default JDK is currently set to 17\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] Default JDK is currently set to 17\n");
 	}
 
 	@Test
@@ -119,8 +113,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.home(null));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), endsWith(File.separator + "currentjdk\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).endsWith(File.separator + "currentjdk\n");
 	}
 
 	@Test
@@ -129,8 +123,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.home("default"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), endsWith(File.separator + "currentjdk\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).endsWith(File.separator + "currentjdk\n");
 	}
 
 	@Test
@@ -139,8 +133,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.home("17"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), endsWith("cache" + File.separator + "jdks" + File.separator + "17\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).endsWith("cache" + File.separator + "jdks" + File.separator + "17\n");
 	}
 
 	@Test
@@ -149,8 +143,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.home("16+"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), endsWith("cache" + File.separator + "jdks" + File.separator + "17\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).endsWith("cache" + File.separator + "jdks" + File.separator + "17\n");
 	}
 
 	@Test
@@ -159,9 +153,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv(null));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(),
-				containsString(File.separator + "currentjdk" + File.separator + "bin" + File.pathSeparator));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains(File.separator + "currentjdk" + File.separator + "bin" + File.pathSeparator);
 
 		if (Util.isWindows()) {
 			// By default, on Windows we only test with CMD, so let's retest
@@ -169,9 +162,8 @@ class TestJdk extends BaseTest {
 			environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "powershell");
 			result = checkedRun(jdk -> jdk.javaEnv(null));
 
-			assertThat(result.result, equalTo(SUCCESS_EXIT));
-			assertThat(result.normalizedOut(),
-					containsString(File.separator + "currentjdk" + File.separator + "bin" + File.pathSeparator));
+			assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+			assertThat(result.normalizedOut()).contains(File.separator + "currentjdk" + File.separator + "bin" + File.pathSeparator);
 		}
 	}
 
@@ -181,8 +173,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv("default"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString(File.separator + "currentjdk"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains(File.separator + "currentjdk");
 	}
 
 	@Test
@@ -191,8 +183,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv("17"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("cache" + File.separator + "jdks" + File.separator + "17"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains("cache" + File.separator + "jdks" + File.separator + "17");
 	}
 
 	@Test
@@ -201,8 +193,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv("11"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("cache" + File.separator + "jdks" + File.separator + "11"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains("cache" + File.separator + "jdks" + File.separator + "11");
 	}
 
 	@Test
@@ -211,8 +203,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv("21"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("cache" + File.separator + "jdks" + File.separator + "21"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains("cache" + File.separator + "jdks" + File.separator + "21");
 	}
 
 	@Test
@@ -221,8 +213,8 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.javaEnv("16+"));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("cache" + File.separator + "jdks" + File.separator + "17"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedOut()).contains("cache" + File.separator + "jdks" + File.separator + "17");
 	}
 
 	@Test
@@ -237,13 +229,13 @@ class TestJdk extends BaseTest {
 		CaptureResult<Integer> result = checkedRun((Jdk jdk) -> jdk.defaultJdk("12"), "jdk", "--jdk-providers",
 				"default,javahome,jbang");
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), startsWith("[jbang] Default JDK set to 12"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).startsWith("[jbang] Default JDK set to 12");
 
 		result = checkedRun(jdk -> jdk.defaultJdk(null));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(), equalTo("[jbang] Default JDK is currently set to 12\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] Default JDK is currently set to 12\n");
 	}
 
 	@Test
@@ -276,9 +268,8 @@ class TestJdk extends BaseTest {
 			}
 		});
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(),
-				equalTo("[jbang] JDK 11 has been linked to: " + javaDir.toPath() + "\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] JDK 11 has been linked to: " + javaDir.toPath() + "\n");
 		assertTrue(Util.isLink(jdkPath.resolve("11")));
 		System.err.println("ASSERT: " + javaDir.toPath() + " - " + jdkPath.resolve("11").toRealPath());
 		assertTrue(Files.isSameFile(javaDir.toPath(), jdkPath.resolve("11").toRealPath()));
@@ -301,9 +292,8 @@ class TestJdk extends BaseTest {
 			}
 		});
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(),
-				equalTo("[jbang] JDK 11 has been linked to: " + javaDir.toPath().toString() + "\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] JDK 11 has been linked to: " + javaDir.toPath().toString() + "\n");
 		assertTrue(Util.isLink(jdkPath.resolve("11")));
 		assertTrue(Files.isSameFile(javaDir.toPath(), jdkPath.resolve("11").toRealPath()));
 	}
@@ -332,7 +322,7 @@ class TestJdk extends BaseTest {
 		checkedRunWithException(jdk -> {
 			try {
 				jdk.install(true, "13", javaDir.toPath().toString());
-				assertThat("Expected an exception to be thrown", false);
+				assertThat(false).as("Expected an exception to be thrown").isTrue();
 			} catch (Exception e) {
 				assertInstanceOf(IllegalArgumentException.class, e);
 				assertEquals("Unable to create link to JDK in path: " + javaDir.toPath(), e.getMessage());
@@ -359,7 +349,7 @@ class TestJdk extends BaseTest {
 			}
 		});
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
 
 		Util.deletePath(jdkBroken, false);
 
@@ -372,9 +362,8 @@ class TestJdk extends BaseTest {
 			}
 		});
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(),
-				equalTo("[jbang] JDK 11 has been linked to: " + jdkOk + "\n"));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).isEqualTo("[jbang] JDK 11 has been linked to: " + jdkOk + "\n");
 		assertTrue(Util.isLink(jdkPath.resolve("11")));
 		assertTrue(Files.isSameFile(jdkOk, (jdkPath.resolve("11").toRealPath())));
 	}
@@ -386,11 +375,9 @@ class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(jdk -> jdk.uninstall(Integer.toString(jdkVersion)));
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(),
-				containsString("[jbang] Default JDK unset"));
-		assertThat(result.normalizedErr(),
-				containsString("[jbang] Uninstalled JDK:\n  " + jdkVersion));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).contains("[jbang] Default JDK unset");
+		assertThat(result.normalizedErr()).contains("[jbang] Uninstalled JDK:\n  " + jdkVersion);
 	}
 
 	@Test
@@ -404,11 +391,9 @@ class TestJdk extends BaseTest {
 		CaptureResult<Integer> result = checkedRun((Jdk jdk) -> jdk.uninstall(Integer.toString(jdkVersion)), "jdk",
 				"--jdk-providers", "default,javahome,jbang");
 
-		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedErr(),
-				containsString("[jbang] Default JDK unset"));
-		assertThat(result.normalizedErr(),
-				containsString("[jbang] Uninstalled JDK:\n  " + jdkVersion));
+		assertThat(result.result).isEqualTo(SUCCESS_EXIT);
+		assertThat(result.normalizedErr()).contains("[jbang] Default JDK unset");
+		assertThat(result.normalizedErr()).contains("[jbang] Uninstalled JDK:\n  " + jdkVersion);
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -9,7 +9,6 @@ import static dev.jbang.source.Project.ATTR_PREMAIN_CLASS;
 import static dev.jbang.util.JavaUtil.defaultJdkManager;
 import static dev.jbang.util.Util.writeString;
 import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -43,8 +42,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.collection.IsCollectionWithSize;
+import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -110,27 +108,23 @@ public class TestRun extends BaseTest {
 		Project code = pb.build(arg);
 		BuildContext ctx = BuildContext.forProject(code);
 
-		assertThat(Files.exists(ctx.getJarFile()), equalTo(!first));
+		org.assertj.core.api.Assertions.assertThat(Files.exists(ctx.getJarFile())).isEqualTo(!first);
 
 		String result = Project.codeBuilder(ctx).build().build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, endsWith("helloworld"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, matchesRegex(".*helloworld\\.java\\.[a-z0-9]+.helloworld\\.jar.*"));
-		assertThat(result, containsString("picocli-4.6.3.jar"));
-		assertThat(result, containsString("hellojar.jar"));
-		assertThat(result, containsString("-Dfoo=bar"));
-		assertThat(result, containsString(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell())));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).endsWith("helloworld");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*helloworld\\.java\\.[a-z0-9]+.helloworld\\.jar.*");
+		org.assertj.core.api.Assertions.assertThat(result).contains("picocli-4.6.3.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("hellojar.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result).contains(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell()));
 		// Make sure the opts only appear once
-		assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), ""),
-				not(containsString("-Dfoo=bar")));
-		assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), ""),
-				not(containsString("-Dbar=aap noot mies")));
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), "")).doesNotContain("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), "")).doesNotContain("-Dbar=aap noot mies");
 		// Make sure the opts only appear unquoted
-		assertThat(result,
-				not(containsString(
-						CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()))));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain(CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()));
 		// assertThat(result, containsString("--source 11"));
 	}
 
@@ -145,24 +139,19 @@ public class TestRun extends BaseTest {
 		pb.catalog(cat.toFile());
 		String result = run.updateGeneratorForRun(pb.build("helloworld").codeBuilder().build()).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, endsWith("helloworld"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, containsString(".jar"));
-		assertThat(result, containsString("-Dfoo=bar"));
-		assertThat(result, containsString(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell())));
-		assertThat(result, containsString("-showversion"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).endsWith("helloworld");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).contains(".jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result).contains(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell()));
+		org.assertj.core.api.Assertions.assertThat(result).contains("-showversion");
 		// Make sure the opts only appear once
-		assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), ""),
-				not(containsString("-Dfoo=bar")));
-		assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), ""),
-				not(containsString("-Dbar=aap noot mies")));
-		assertThat(result.replaceFirst(Pattern.quote("-showversion"), ""),
-				not(containsString("-showversion")));
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), "")).doesNotContain("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), "")).doesNotContain("-Dbar=aap noot mies");
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-showversion"), "")).doesNotContain("-showversion");
 		// Make sure the opts only appear unquoted
-		assertThat(result,
-				not(containsString(
-						CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()))));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain(CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()));
 		// assertThat(result, containsString("--source 11"));
 	}
 
@@ -180,16 +169,15 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result,
-				matchesPattern("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$"));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString(arg));
-		assertThat(result.split(Pattern.quote(arg), -1).length, equalTo(2));
-		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT"));
-		assertThat(result, matchesPattern(".*--startup=[^ ]*helloworld.jsh.*"));
-		assertThat(result, not(containsString("blah")));
-		assertThat(result, containsString("jbang_exit_"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains(arg);
+		org.assertj.core.api.Assertions.assertThat(result.split(Pattern.quote(arg), -1).length).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("--source 11");
+		org.assertj.core.api.Assertions.assertThat(result).contains("--startup=DEFAULT");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*--startup=[^ ]*helloworld.jsh.*");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("blah");
+		org.assertj.core.api.Assertions.assertThat(result).contains("jbang_exit_");
 	}
 
 	@Test
@@ -207,10 +195,8 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result,
-				matchesPattern(
-						"^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM (\\^\\\")?--class-path=.*(\\^\\\")? (\\^\\\")?-J--class-path=.*(\\^\\\")? --startup=DEFAULT (\\^\\\")?--startup.*$"));
-		assertThat(result, containsString("eclipse-collections-api"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM (\\^\\\")?--class-path=.*(\\^\\\")? (\\^\\\")?-J--class-path=.*(\\^\\\")? --startup=DEFAULT (\\^\\\")?--startup.*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("eclipse-collections-api");
 	}
 
 	@Test
@@ -228,8 +214,8 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)?.*$"));
-		assertThat(result, containsString("firstarg"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)?.*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("firstarg");
 	}
 
 	@Test
@@ -243,7 +229,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$");
 	}
 
 	@Test
@@ -263,7 +249,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$");
 	}
 
 	@Test
@@ -286,7 +272,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)?.+--class-path=.*figlet.*? --startup.*$");
 	}
 
 	@Test
@@ -304,13 +290,12 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result,
-				matchesPattern("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$"));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString("empty.jsh"));
-		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT"));
-		assertThat(result, matchesPattern(".*--startup=[^ ]*empty.jsh.*"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains("empty.jsh");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("--source 11");
+		org.assertj.core.api.Assertions.assertThat(result).contains("--startup=DEFAULT");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*--startup=[^ ]*empty.jsh.*");
 	}
 
 	@Test
@@ -326,14 +311,13 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result,
-				matchesPattern("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$"));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString("hellojsh"));
-		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT"));
-		assertThat(result, matchesPattern(".*--startup=[^ ]*hellojsh.*"));
-		assertThat(result, containsString("jbang_exit_"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains("hellojsh");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("--source 11");
+		org.assertj.core.api.Assertions.assertThat(result).contains("--startup=DEFAULT");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*--startup=[^ ]*hellojsh.*");
+		org.assertj.core.api.Assertions.assertThat(result).contains("jbang_exit_");
 	}
 
 	@Test
@@ -352,15 +336,15 @@ public class TestRun extends BaseTest {
 		Project code = pb.build(jar);
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
-		assertThat(result, matchesPattern("^.*java(.exe)?.*"));
-		assertThat(code.getMainClass(), not(nullValue()));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)?.*");
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isNotNull();
 
-		assertThat(result, containsString("picocli-4.6.3.jar"));
-		assertThat(result, containsString("dummy.jar"));
-		assertThat(result, containsString("hellojar.jar"));
+		org.assertj.core.api.Assertions.assertThat(result).contains("picocli-4.6.3.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("dummy.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("hellojar.jar");
 
-		assertThat(code.getResourceRef().getFile().toString(), equalTo(jar));
-		assertThat(code.isJar(), equalTo(true));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).isEqualTo(jar);
+		org.assertj.core.api.Assertions.assertThat(code.isJar()).isEqualTo(true);
 
 		run.doCall();
 	}
@@ -382,9 +366,9 @@ public class TestRun extends BaseTest {
 
 			String cmdline = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
-			assertThat(cmdline, not(containsString("https")));
+			org.assertj.core.api.Assertions.assertThat(cmdline).doesNotContain("https");
 
-			assertThat(cmdline, not(containsString(".jar.java")));
+			org.assertj.core.api.Assertions.assertThat(cmdline).doesNotContain(".jar.java");
 
 		} finally {
 			TrustedSources.instance().remove(Collections.singletonList(jar), tdir.resolve("test.trust").toFile());
@@ -402,13 +386,12 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(jar);
 
-		assertThat(code.getResourceRef().getFile().toString(),
-				matchesPattern(".*jbang_tests_maven.*codegen-4.6.3.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*jbang_tests_maven.*codegen-4.6.3.jar");
 
 		ExitException e = Assertions.assertThrows(ExitException.class,
 				() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
 
-		assertThat(e.getMessage(), startsWith("no main class"));
+		org.assertj.core.api.Assertions.assertThat(e.getMessage()).startsWith("no main class");
 
 	}
 
@@ -425,14 +408,13 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(jar);
 
-		assertThat(code.getResourceRef().getFile().toString(),
-				matchesPattern(".*jbang_tests_maven.*codegen-4.6.3.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*jbang_tests_maven.*codegen-4.6.3.jar");
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
-		assertThat(result, matchesPattern("^.*jshell(.exe)?.*"));
-		assertThat(code.getMainClass(), nullValue());
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)?.*");
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isNull();
 
-		assertThat(code.isJar(), equalTo(true));
+		org.assertj.core.api.Assertions.assertThat(code.isJar()).isEqualTo(true);
 
 		run.doCall();
 	}
@@ -460,18 +442,18 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(jar);
 
-		assertThat(code.getResourceRef().getFile().toString(), matchesPattern(".*.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*.jar");
 
 		String cmd = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
 		if (Util.getShell() == Util.Shell.bash) {
-			assertThat(cmd, matchesPattern(".*quarkus-cli-1.9.0.Final-runner.jar.*"));
+			org.assertj.core.api.Assertions.assertThat(cmd).matches(".*quarkus-cli-1.9.0.Final-runner.jar.*");
 		} else {
 			// TODO On Windows the command is using an @file, we should parse
 			// the name, read the file and assert against it contents.
 		}
 
-		assertThat(code.getMainClass(), equalTo("io.quarkus.runner.GeneratedMain"));
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isEqualTo("io.quarkus.runner.GeneratedMain");
 
 	}
 
@@ -486,12 +468,11 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(jar);
 
-		assertThat(code.getResourceRef().getFile().toString(),
-				matchesPattern(".*jbang_tests_maven.*eclipse.jgit.pgm.*.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*jbang_tests_maven.*eclipse.jgit.pgm.*.jar");
 
 		run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
-		assertThat(code.getMainClass(), equalTo("org.eclipse.jgit.pgm.Main"));
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isEqualTo("org.eclipse.jgit.pgm.Main");
 
 	}
 
@@ -510,14 +491,13 @@ public class TestRun extends BaseTest {
 
 		String cmd = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
-		assertThat(code.getMainClass(), nullValue());
-		assertThat(cmd, endsWith("picocli.codegen.aot.graalvm.ReflectionConfigGenerator"));
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isNull();
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith("picocli.codegen.aot.graalvm.ReflectionConfigGenerator");
 
-		assertThat(code.getResourceRef().getFile().toString(),
-				matchesPattern(".*jbang_tests_maven.*codegen-4.6.3.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*jbang_tests_maven.*codegen-4.6.3.jar");
 
-		assertThat(cmd, matchesPattern(".* -classpath .*picocli-4.6.3.jar.*"));
-		assertThat(cmd, not(containsString(" -jar ")));
+		org.assertj.core.api.Assertions.assertThat(cmd).matches(".* -classpath .*picocli-4.6.3.jar.*");
+		org.assertj.core.api.Assertions.assertThat(cmd).doesNotContain(" -jar ");
 	}
 
 	@Test
@@ -535,14 +515,13 @@ public class TestRun extends BaseTest {
 
 		String cmd = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
-		assertThat(code.getMainClass(), nullValue());
-		assertThat(cmd, endsWith("info.picocli.codegen/picocli.codegen.aot.graalvm.ReflectionConfigGenerator"));
+		org.assertj.core.api.Assertions.assertThat(code.getMainClass()).isNull();
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith("info.picocli.codegen/picocli.codegen.aot.graalvm.ReflectionConfigGenerator");
 
-		assertThat(code.getResourceRef().getFile().toString(),
-				matchesPattern(".*jbang_tests_maven.*codegen-4.6.3.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*jbang_tests_maven.*codegen-4.6.3.jar");
 
-		assertThat(cmd, matchesPattern(".* -p .*picocli-4.6.3.jar.*"));
-		assertThat(cmd, not(containsString(" -jar ")));
+		org.assertj.core.api.Assertions.assertThat(cmd).matches(".* -p .*picocli-4.6.3.jar.*");
+		org.assertj.core.api.Assertions.assertThat(cmd).doesNotContain(" -jar ");
 	}
 
 	@Test
@@ -571,8 +550,7 @@ public class TestRun extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo");
 		}
 	}
 
@@ -588,12 +566,12 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(jar);
 
-		assertThat(code.getResourceRef().getFile().toString(), matchesPattern(".*\\.m2.*eclipse.jgit.pgm.*.jar"));
+		org.assertj.core.api.Assertions.assertThat(code.getResourceRef().getFile().toString()).matches(".*\\.m2.*eclipse.jgit.pgm.*.jar");
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
-		assertThat(result, containsString("picocli-4.6.3.jar"));
-		assertThat(result, containsString("hellojar.jar"));
+		org.assertj.core.api.Assertions.assertThat(result).contains("picocli-4.6.3.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("hellojar.jar");
 	}
 
 	@Test
@@ -612,14 +590,14 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? .*$"));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString("helloworld.jsh"));
-		assertThat(result, not(containsString("--source 11")));
-		assertThat(result, containsString("--startup=DEFAULT"));
-		assertThat(result, matchesPattern(".*--startup=[^ ]*helloworld.jsh.*"));
-		assertThat(result, not(containsString("blah")));
-		assertThat(result, not(containsString("jbang_exit_")));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains("helloworld.jsh");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("--source 11");
+		org.assertj.core.api.Assertions.assertThat(result).contains("--startup=DEFAULT");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*--startup=[^ ]*helloworld.jsh.*");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("blah");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("jbang_exit_");
 	}
 
 	@Test
@@ -634,12 +612,11 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result,
-				matchesPattern("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$"));
-		assertThat(result, containsString("funcs.jsh"));
-		assertThat(result, containsString("main.jsh"));
-		assertThat(result, containsString("--startup=DEFAULT"));
-		assertThat(result, containsString("jbang_exit_"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? --execution=local -J--add-modules=ALL-SYSTEM --startup.*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("funcs.jsh");
+		org.assertj.core.api.Assertions.assertThat(result).contains("main.jsh");
+		org.assertj.core.api.Assertions.assertThat(result).contains("--startup=DEFAULT");
+		org.assertj.core.api.Assertions.assertThat(result).contains("jbang_exit_");
 	}
 
 	@Test
@@ -655,12 +632,12 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, containsString("helloworld.java"));
-		assertThat(result, containsString("classpath"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("helloworld.java");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
 //		assertThat(result, containsString(" --source 11 "));
-		assertThat(result, containsString("jdwp"));
-		assertThat(result, not(containsString("  ")));
+		org.assertj.core.api.Assertions.assertThat(result).contains("jdwp");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
 	}
 
 	@Test
@@ -676,11 +653,11 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, containsString("helloworld.java"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, containsString("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=4004"));
-		assertThat(result, not(containsString("  ")));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("helloworld.java");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=4004");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
 	}
 
 	@Test
@@ -696,11 +673,11 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, containsString("helloworld.java"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, containsString("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5000"));
-		assertThat(result, not(containsString("  ")));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("helloworld.java");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5000");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
 	}
 
 	@Test
@@ -718,12 +695,12 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, containsString("classpath_example.java"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath_example.java");
 //		assertThat(result, containsString(" --source 11 "));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, containsString("log4j"));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).contains("log4j");
 	}
 
 	@Test
@@ -739,13 +716,13 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*jshell(.exe)? .*$"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*jshell(.exe)? .*$");
 		assertThat(result, (containsString("classpath_example.java")));
 //		assertThat(result, containsString(" --source 11 "));
-		assertThat(result, not(containsString("  ")));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, containsString("log4j"));
-		assertThat(result, not(endsWith(arg)));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("  ");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).contains("log4j");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotEndWith(arg);
 	}
 
 	@Test
@@ -759,9 +736,9 @@ public class TestRun extends BaseTest {
 					arg, "-Dafter=wonka");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.userParams.size(), is(1));
+		org.assertj.core.api.Assertions.assertThat(run.userParams.size()).isEqualTo(1);
 
-		assertThat(run.dependencyInfoMixin.getProperties().size(), is(2));
+		org.assertj.core.api.Assertions.assertThat(run.dependencyInfoMixin.getProperties().size()).isEqualTo(2);
 
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		pb.mainClass("fakemain");
@@ -769,17 +746,17 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, containsString("-Dwonka=panda"));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-Dwonka=panda");
 		if (Util.isWindows()) {
-			assertThat(result, containsString("^\"-Dquoted=see^ this^\""));
+			org.assertj.core.api.Assertions.assertThat(result).contains("^\"-Dquoted=see^ this^\"");
 		} else {
-			assertThat(result, containsString("'-Dquoted=see this'"));
+			org.assertj.core.api.Assertions.assertThat(result).contains("'-Dquoted=see this'");
 		}
 		String[] split = result.split("example.java");
 		assertEquals(2, split.length);
-		assertThat(split[0], not(containsString("after=wonka")));
-		assertThat(split[1], containsString("after=wonka"));
+		org.assertj.core.api.Assertions.assertThat(split[0]).doesNotContain("after=wonka");
+		org.assertj.core.api.Assertions.assertThat(split[1]).contains("after=wonka");
 	}
 
 	@Test
@@ -790,8 +767,7 @@ public class TestRun extends BaseTest {
 		ProjectBuilder ppb = Project.builder();
 		Project pre = ppb.build(url);
 
-		MatcherAssert.assertThat(Util.readString(pre.getResourceRef().getFile()),
-				containsString("Logger.getLogger(classpath_example.class);"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(pre.getResourceRef().getFile())).contains("Logger.getLogger(classpath_example.class);");
 
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", url);
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
@@ -803,7 +779,7 @@ public class TestRun extends BaseTest {
 
 		String s = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(s, not(containsString("file:")));
+		org.assertj.core.api.Assertions.assertThat(s).doesNotContain("file:");
 	}
 
 	@Test
@@ -819,9 +795,9 @@ public class TestRun extends BaseTest {
 
 		String s = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 		if (Util.isWindows()) {
-			assertThat(s, containsString("^\"^ ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\""));
+			org.assertj.core.api.Assertions.assertThat(s).contains("^\"^ ~^!@#$^%^^^&*^(^)-+\\:;'`^<^>?/,.{}[]\\^\"^\"");
 		} else {
-			assertThat(s, containsString("' ~!@#$%^&*()-+\\:;'\\''`<>?/,.{}[]\"'"));
+			org.assertj.core.api.Assertions.assertThat(s).contains("' ~!@#$%^&*()-+\\:;'\\''`<>?/,.{}[]\"'");
 		}
 	}
 
@@ -838,7 +814,7 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, containsString("reload4j-1.2.18.5.jar"));
+		org.assertj.core.api.Assertions.assertThat(result).contains("reload4j-1.2.18.5.jar");
 	}
 
 	@Test
@@ -872,9 +848,9 @@ public class TestRun extends BaseTest {
 
 		try (JarFile jf = new JarFile(out.toFile())) {
 
-			assertThat(Collections.list(jf.entries()), IsCollectionWithSize.hasSize(6));
+			org.assertj.core.api.Assertions.assertThat(Collections.list(jf.entries())).hasSize(6);
 
-			assertThat(jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS), equalTo("wonkabear"));
+			org.assertj.core.api.Assertions.assertThat(jf.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS)).isEqualTo("wonkabear");
 
 			assert (Files.exists(out));
 		}
@@ -886,21 +862,16 @@ public class TestRun extends BaseTest {
 
 		Map<String, String> properties = new HashMap<>();
 
-		assertThat(JshCmdGenerator.generateArgs(Collections.emptyList(), properties),
-				equalTo("String[] args = {  }"));
+		org.assertj.core.api.Assertions.assertThat(JshCmdGenerator.generateArgs(Collections.emptyList(), properties)).isEqualTo("String[] args = {  }");
 
-		assertThat(JshCmdGenerator.generateArgs(Collections.singletonList("one"), properties),
-				equalTo("String[] args = { \"one\" }"));
+		org.assertj.core.api.Assertions.assertThat(JshCmdGenerator.generateArgs(Collections.singletonList("one"), properties)).isEqualTo("String[] args = { \"one\" }");
 
-		assertThat(JshCmdGenerator.generateArgs(Arrays.asList("one", "two"), properties),
-				equalTo("String[] args = { \"one\", \"two\" }"));
+		org.assertj.core.api.Assertions.assertThat(JshCmdGenerator.generateArgs(Arrays.asList("one", "two"), properties)).isEqualTo("String[] args = { \"one\", \"two\" }");
 
-		assertThat(JshCmdGenerator.generateArgs(Arrays.asList("one", "two", "three \"quotes\""), properties),
-				equalTo("String[] args = { \"one\", \"two\", \"three \\\"quotes\\\"\" }"));
+		org.assertj.core.api.Assertions.assertThat(JshCmdGenerator.generateArgs(Arrays.asList("one", "two", "three \"quotes\""), properties)).isEqualTo("String[] args = { \"one\", \"two\", \"three \\\"quotes\\\"\" }");
 
 		properties.put("value", "this value");
-		assertThat(JshCmdGenerator.generateArgs(Collections.emptyList(), properties),
-				equalTo("String[] args = {  }\nSystem.setProperty(\"value\",\"this value\");"));
+		org.assertj.core.api.Assertions.assertThat(JshCmdGenerator.generateArgs(Collections.emptyList(), properties)).isEqualTo("String[] args = {  }\nSystem.setProperty(\"value\",\"this value\");");
 
 	}
 
@@ -929,7 +900,7 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainClass(), equalTo("aclass"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("aclass");
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(ctx.getJarFile(), (ClassLoader) null)) {
 			Path fileToExtract = fileSystem.getPath("META-INF/maven/dev/jbang/tests/pom.xml");
@@ -940,7 +911,7 @@ public class TestRun extends BaseTest {
 
 			String xml = s.toString("UTF-8");
 
-			assertThat(xml, not(containsString("NOT")));
+			org.assertj.core.api.Assertions.assertThat(xml).doesNotContain("NOT");
 
 			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
@@ -977,7 +948,7 @@ public class TestRun extends BaseTest {
 		Project prj = Project.builder().build(f);
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainClass(), equalTo("dualclass"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("dualclass");
 
 	}
 
@@ -1012,7 +983,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(arg);
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainClass(), equalTo("dualclass"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("dualclass");
 
 	}
 
@@ -1116,7 +1087,7 @@ public class TestRun extends BaseTest {
 
 		String s = Util.readString(x);
 
-		assertThat("should be redirect thus no html tag", s, not(containsString("html>")));
+		org.assertj.core.api.Assertions.assertThat(s).as("should be redirect thus no html tag").doesNotContain("html>");
 
 	}
 
@@ -1168,9 +1139,9 @@ public class TestRun extends BaseTest {
 			assertEquals("hello.java", x.getFileName().toString());
 		}
 		String java = Util.readString(x);
-		assertThat(java, containsString("//DEPS"));
-		assertThat(java, not(containsString("&gt;")));
-		assertThat(java, containsString("\n"));
+		org.assertj.core.api.Assertions.assertThat(java).contains("//DEPS");
+		org.assertj.core.api.Assertions.assertThat(java).doesNotContain("&gt;");
+		org.assertj.core.api.Assertions.assertThat(java).contains("\n");
 	}
 
 	@Test
@@ -1180,27 +1151,21 @@ public class TestRun extends BaseTest {
 		Path x = Util.swizzleContent(u, Util.downloadFile(u, dir));
 		assertEquals("1266904846239752192.jsh", x.getFileName().toString());
 		String java = Util.readString(x);
-		assertThat(java, startsWith("//DEPS"));
-		assertThat(java, not(containsString("&gt;")));
-		assertThat(java, containsString("\n"));
-		assertThat(java, containsString("/exit"));
+		org.assertj.core.api.Assertions.assertThat(java).startsWith("//DEPS");
+		org.assertj.core.api.Assertions.assertThat(java).doesNotContain("&gt;");
+		org.assertj.core.api.Assertions.assertThat(java).contains("\n");
+		org.assertj.core.api.Assertions.assertThat(java).contains("/exit");
 
 	}
 
 	@Test
 	void testSwizzle(@TempDir Path dir) throws IOException {
 
-		assertThat(
-				Util.swizzleURL("https://github.com/jbangdev/jbang/blob/HEAD/examples/helloworld.java"),
-				equalTo("https://raw.githubusercontent.com/jbangdev/jbang/HEAD/examples/helloworld.java"));
+		org.assertj.core.api.Assertions.assertThat(Util.swizzleURL("https://github.com/jbangdev/jbang/blob/HEAD/examples/helloworld.java")).isEqualTo("https://raw.githubusercontent.com/jbangdev/jbang/HEAD/examples/helloworld.java");
 
-		assertThat(
-				Util.swizzleURL("https://gitlab.com/jbangdev/jbang-gitlab/-/blob/HEAD/helloworld.java"),
-				equalTo("https://gitlab.com/jbangdev/jbang-gitlab/-/raw/HEAD/helloworld.java"));
+		org.assertj.core.api.Assertions.assertThat(Util.swizzleURL("https://gitlab.com/jbangdev/jbang-gitlab/-/blob/HEAD/helloworld.java")).isEqualTo("https://gitlab.com/jbangdev/jbang-gitlab/-/raw/HEAD/helloworld.java");
 
-		assertThat(
-				Util.swizzleURL("https://bitbucket.org/Shoeboom/test/src/HEAD/helloworld.java"),
-				equalTo("https://bitbucket.org/Shoeboom/test/raw/HEAD/helloworld.java"));
+		org.assertj.core.api.Assertions.assertThat(Util.swizzleURL("https://bitbucket.org/Shoeboom/test/src/HEAD/helloworld.java")).isEqualTo("https://bitbucket.org/Shoeboom/test/raw/HEAD/helloworld.java");
 
 	}
 
@@ -1233,19 +1198,19 @@ public class TestRun extends BaseTest {
 
 		if (JavaUtil.getCurrentMajorJavaVersion() >= 13) {
 			String commandLine = CmdGenerator.builder(ctx).classDataSharing(true).build().generate();
-			assertThat(commandLine, containsString("-XX:ArchiveClassesAtExit="));
+			org.assertj.core.api.Assertions.assertThat(commandLine).contains("-XX:ArchiveClassesAtExit=");
 			assertThat(jsa.toFile(), not(FileMatchers.anExistingFile()));
 
 			String out = Util.runCommand(commandLine.split(" "));
-			assertThat(out, notNullValue());
+			org.assertj.core.api.Assertions.assertThat(out).isNotNull();
 
 			commandLine = CmdGenerator.builder(ctx).classDataSharing(true).build().generate();
-			assertThat(commandLine, containsString("-XX:SharedArchiveFile="));
+			org.assertj.core.api.Assertions.assertThat(commandLine).contains("-XX:SharedArchiveFile=");
 			assertThat(jsa.toFile(), FileMatchers.anExistingFile());
 		} else {
 			CaptureResult<String> cap = captureOutput(
 					() -> CmdGenerator.builder(ctx).classDataSharing(true).build().generate());
-			assertThat(cap.err, containsString("ClassDataSharing can only be used on Java versions 13 and later"));
+			org.assertj.core.api.Assertions.assertThat(cap.err).contains("ClassDataSharing can only be used on Java versions 13 and later");
 		}
 	}
 
@@ -1264,11 +1229,11 @@ public class TestRun extends BaseTest {
 
 		if (JavaUtil.getCurrentMajorJavaVersion() >= 13) {
 			String commandLine = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
-			assertThat(commandLine, containsString("-XX:ArchiveClassesAtExit="));
+			org.assertj.core.api.Assertions.assertThat(commandLine).contains("-XX:ArchiveClassesAtExit=");
 		} else {
 			CaptureResult<String> cap = captureOutput(
 					() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
-			assertThat(cap.err, containsString("ClassDataSharing can only be used on Java versions 13 and later"));
+			org.assertj.core.api.Assertions.assertThat(cap.err).contains("ClassDataSharing can only be used on Java versions 13 and later");
 		}
 	}
 
@@ -1309,16 +1274,16 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainSource().isAgent(), is(true));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSource().isAgent()).isEqualTo(true);
 
-		assertThat(prj.getManifestAttributes().get(ATTR_AGENT_CLASS), is("Agent"));
-		assertThat(prj.getManifestAttributes().get(ATTR_PREMAIN_CLASS), is("Agent"));
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get(ATTR_AGENT_CLASS)).isEqualTo("Agent");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get(ATTR_PREMAIN_CLASS)).isEqualTo("Agent");
 
 		try (JarFile jf = new JarFile(ctx.getJarFile().toFile())) {
 			Attributes attrs = jf.getManifest().getMainAttributes();
-			assertThat(attrs.getValue("Premain-class"), equalTo("Agent"));
-			assertThat(attrs.getValue("Can-Retransform-Classes"), equalTo("true"));
-			assertThat(attrs.getValue("Can-Redefine-Classes"), equalTo("false"));
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("Premain-class")).isEqualTo("Agent");
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("Can-Retransform-Classes")).isEqualTo("true");
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("Can-Redefine-Classes")).isEqualTo("false");
 		}
 
 	}
@@ -1335,10 +1300,10 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(p.toFile().getAbsolutePath());
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainSource().isAgent(), is(true));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSource().isAgent()).isEqualTo(true);
 
-		assertThat(prj.getManifestAttributes().get(ATTR_AGENT_CLASS), is(nullValue()));
-		assertThat(prj.getManifestAttributes().get(ATTR_PREMAIN_CLASS), is("Agent"));
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get(ATTR_AGENT_CLASS)).isNull();
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get(ATTR_PREMAIN_CLASS)).isEqualTo("Agent");
 
 	}
 
@@ -1375,25 +1340,25 @@ public class TestRun extends BaseTest {
 					mainFile.toAbsolutePath().toString());
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.runMixin.javaAgentSlots.containsKey(agentFile.toAbsolutePath().toString()), is(true));
-		assertThat(run.runMixin.javaAgentSlots.get(agentFile.toAbsolutePath().toString()), equalTo("optionA"));
+		org.assertj.core.api.Assertions.assertThat(run.runMixin.javaAgentSlots.containsKey(agentFile.toAbsolutePath().toString())).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(run.runMixin.javaAgentSlots.get(agentFile.toAbsolutePath().toString())).isEqualTo("optionA");
 
 		ProjectBuilder pb = run.createProjectBuilderForRun().mainClass("fakemain");
 		Project prj = pb.build(mainFile);
 		Project ass1 = pb.build(agentFile);
 		BuildContext ctx = BuildContext.forProject(prj);
 
-		assertThat(ass1.getMainSource().isAgent(), is(true));
+		org.assertj.core.api.Assertions.assertThat(ass1.getMainSource().isAgent()).isEqualTo(true);
 
 		run.buildAgents(ctx);
 
 		CmdGeneratorBuilder bgen = CmdGenerator.builder(prj);
 		String result = run.updateGeneratorForRun(bgen).build().generate();
 
-		assertThat(result, containsString("-javaagent"));
-		assertThat(result, containsString("=optionA"));
-		assertThat(result, containsString("byteman"));
-		assertThat(result, not(containsString("null")));
+		org.assertj.core.api.Assertions.assertThat(result).contains("-javaagent");
+		org.assertj.core.api.Assertions.assertThat(result).contains("=optionA");
+		org.assertj.core.api.Assertions.assertThat(result).contains("byteman");
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain("null");
 	}
 
 	@Test
@@ -1401,7 +1366,7 @@ public class TestRun extends BaseTest {
 		CommandLine.ParseResult pr = JBang.getCommandLine().parseArgs("run", "--javaagent=xyz.jar", "wonka.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("xyz.jar"));
+		org.assertj.core.api.Assertions.assertThat(run.runMixin.javaAgentSlots).containsKey("xyz.jar");
 	}
 
 	@Test
@@ -1411,7 +1376,7 @@ public class TestRun extends BaseTest {
 					"--javaagent=org.jboss.byteman:byteman:4.0.13", "wonka.java");
 		Run run = (Run) pr.subcommand().commandSpec().userObject();
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("org.jboss.byteman:byteman:4.0.13"));
+		org.assertj.core.api.Assertions.assertThat(run.runMixin.javaAgentSlots).containsKey("org.jboss.byteman:byteman:4.0.13");
 	}
 
 	@Test
@@ -1428,7 +1393,7 @@ public class TestRun extends BaseTest {
 
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("-ea"));
+		org.assertj.core.api.Assertions.assertThat(line).contains("-ea");
 	}
 
 	@Test
@@ -1446,7 +1411,7 @@ public class TestRun extends BaseTest {
 
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("-esa"));
+		org.assertj.core.api.Assertions.assertThat(line).contains("-esa");
 	}
 
 	@Test
@@ -1463,7 +1428,7 @@ public class TestRun extends BaseTest {
 		Project code = pb.build(p);
 
 		String commandLine = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
-		assertThat(commandLine, containsString("--enable-preview"));
+		org.assertj.core.api.Assertions.assertThat(commandLine).contains("--enable-preview");
 	}
 
 	@Test
@@ -1481,7 +1446,7 @@ public class TestRun extends BaseTest {
 
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("--enable-preview"));
+		org.assertj.core.api.Assertions.assertThat(line).contains("--enable-preview");
 	}
 
 	@Test
@@ -1502,9 +1467,9 @@ public class TestRun extends BaseTest {
 
 		String cmdline = run.updateGeneratorForRun(genb).build().generate();
 
-		assertThat(cmdline, containsString("--enable-preview"));
-		assertThat(cmdline, containsString("-C--enable-preview"));
-		assertThat(cmdline, containsString("-J--enable-preview"));
+		org.assertj.core.api.Assertions.assertThat(cmdline).contains("--enable-preview");
+		org.assertj.core.api.Assertions.assertThat(cmdline).contains("-C--enable-preview");
+		org.assertj.core.api.Assertions.assertThat(cmdline).contains("-J--enable-preview");
 	}
 
 	@Test
@@ -1525,9 +1490,9 @@ public class TestRun extends BaseTest {
 
 		String cmdline = run.updateGeneratorForRun(genb).build().generate();
 
-		assertThat(cmdline, containsString("--enable-preview"));
-		assertThat(cmdline, not(containsString("-C--enable-preview")));
-		assertThat(cmdline, not(containsString("-J--enable-preview")));
+		org.assertj.core.api.Assertions.assertThat(cmdline).contains("--enable-preview");
+		org.assertj.core.api.Assertions.assertThat(cmdline).doesNotContain("-C--enable-preview");
+		org.assertj.core.api.Assertions.assertThat(cmdline).doesNotContain("-J--enable-preview");
 	}
 
 	@Test
@@ -1539,7 +1504,7 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainClass(), equalTo("resource"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("resource");
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(ctx.getJarFile(), (ClassLoader) null)) {
 
@@ -1551,7 +1516,7 @@ public class TestRun extends BaseTest {
 						ByteArrayOutputStream s = new ByteArrayOutputStream();
 						Files.copy(fileToExtract, s);
 						String xml = s.toString("UTF-8");
-						assertThat(xml, not(containsString("message=hello")));
+						org.assertj.core.api.Assertions.assertThat(xml).doesNotContain("message=hello");
 					} catch (Exception e) {
 						fail(e);
 					}
@@ -1568,8 +1533,8 @@ public class TestRun extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 
 		ExitException root = assertThrows(ExitException.class, () -> pb.build(f.getAbsolutePath()));
-		assertThat(root.toString(), containsString("'resourcethatdoesnotexist.properties"));
-		assertThat(root.toString(), containsString("brokenresource.java"));
+		org.assertj.core.api.Assertions.assertThat(root.toString()).contains("'resourcethatdoesnotexist.properties");
+		org.assertj.core.api.Assertions.assertThat(root.toString()).contains("brokenresource.java");
 
 	}
 
@@ -1583,7 +1548,7 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainClass(), equalTo("one"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("one");
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(ctx.getJarFile(), (ClassLoader) null)) {
 			Arrays.asList("one.class", "Two.class", "gh_release_stats.class", "fetchlatestgraalvm.class")
@@ -1601,7 +1566,7 @@ public class TestRun extends BaseTest {
 
 		}
 
-		assertThat("duplication of deps fixed", ctx.resolveClassPath().getArtifacts(), hasSize(7));
+		org.assertj.core.api.Assertions.assertThat(ctx.resolveClassPath().getArtifacts()).as("duplication of deps fixed").hasSize(7);
 	}
 
 	@Test
@@ -1614,7 +1579,7 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainClass(), equalTo("resources"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("resources");
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(ctx.getJarFile(), (ClassLoader) null)) {
 			Arrays.asList("resources.class", "resource.properties", "test.properties")
@@ -1641,7 +1606,7 @@ public class TestRun extends BaseTest {
 
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getMainClass(), equalTo("resourcesmnt"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("resourcesmnt");
 
 		try (FileSystem fileSystem = FileSystems.newFileSystem(ctx.getJarFile(), (ClassLoader) null)) {
 			Arrays.asList("resourcesmnt.class", "somedir/resource.properties", "somedir/test.properties")
@@ -1714,7 +1679,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(p.toFile().getAbsolutePath());
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainClass(), equalTo("Two"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("Two");
 
 	}
 
@@ -1741,7 +1706,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(p.toFile().getAbsolutePath());
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainClass(), equalTo("One"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("One");
 
 	}
 
@@ -1759,7 +1724,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(p.toFile().getAbsolutePath());
 		prj.codeBuilder().build();
 
-		assertThat(prj.getMainClass(), equalTo("Three"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("Three");
 
 	}
 
@@ -1781,8 +1746,8 @@ public class TestRun extends BaseTest {
 				return new JavaCompileBuildStep() {
 					@Override
 					protected void runCompiler(List<String> optionList) {
-						assertThat(optionList, hasItem(mainFile));
-						assertThat(optionList, hasItem(incFile));
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile);
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 						// Skip the compiler
 					}
 				};
@@ -1822,7 +1787,7 @@ public class TestRun extends BaseTest {
 					@Override
 					public Project build() {
 						Project project = ctx.getProject();
-						assertThat(project.getMainSourceSet().getResources().size(), is(1));
+						org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().size()).isEqualTo(1);
 						List<String> ps = project.getMainSourceSet()
 							.getResources()
 							.stream()
@@ -1936,7 +1901,7 @@ public class TestRun extends BaseTest {
 		ExitException e = assertThrows(ExitException.class,
 				() -> Project.builder().build(dir.toPath().toString()));
 
-		assertThat(e.getMessage(), containsString("is a directory and no default application"));
+		org.assertj.core.api.Assertions.assertThat(e.getMessage()).contains("is a directory and no default application");
 
 	}
 
@@ -1990,9 +1955,9 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(arg);
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("helloworld.jfr"));
+		org.assertj.core.api.Assertions.assertThat(line).contains("helloworld.jfr");
 		// testing it does not go to cache by accident
-		assertThat(line.split("helloworld.jfr")[0], not(containsString(Settings.getCacheDir().toString())));
+		org.assertj.core.api.Assertions.assertThat(line.split("helloworld.jfr")[0]).doesNotContain(Settings.getCacheDir().toString());
 
 	}
 
@@ -2008,7 +1973,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(arg);
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString(" --show-version "));
+		org.assertj.core.api.Assertions.assertThat(line).contains(" --show-version ");
 	}
 
 	@Test
@@ -2028,7 +1993,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(fileref.toString());
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
+		org.assertj.core.api.Assertions.assertThat(line).contains("org/openjfx".replace("/", File.separator));
 	}
 
 	@Test
@@ -2051,7 +2016,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(fileref.toString());
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
+		org.assertj.core.api.Assertions.assertThat(line).contains("org/openjfx".replace("/", File.separator));
 	}
 
 	@Test
@@ -2073,7 +2038,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(fileref.toString());
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString("org/openjfx".replace("/", File.separator)));
+		org.assertj.core.api.Assertions.assertThat(line).contains("org/openjfx".replace("/", File.separator));
 	}
 
 	@Test
@@ -2097,7 +2062,7 @@ public class TestRun extends BaseTest {
 		Project prj = pb.build(fileref.toString());
 		String line = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(line, containsString(" --module-path "));
+		org.assertj.core.api.Assertions.assertThat(line).contains(" --module-path ");
 
 	}
 
@@ -2129,8 +2094,7 @@ public class TestRun extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo");
 		}
 	}
 
@@ -2152,8 +2116,7 @@ public class TestRun extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Could not transfer artifact info.picocli:picocli-codegen:pom:4.6.3 from/to https://dummyrepo"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Could not transfer artifact info.picocli:picocli-codegen:pom:4.6.3 from/to https://dummyrepo");
 		}
 	}
 
@@ -2176,8 +2139,7 @@ public class TestRun extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Could not transfer artifact dummygroup:dummyart:pom:0.1 from/to https://dummyrepo");
 		}
 	}
 
@@ -2193,8 +2155,7 @@ public class TestRun extends BaseTest {
 		} catch (ExitException ex) {
 			StringWriter sw = new StringWriter();
 			ex.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString(
-					"Script or alias could not be found or read: 'missing.jsh'"));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("Script or alias could not be found or read: 'missing.jsh'");
 		}
 	}
 
@@ -2223,8 +2184,8 @@ public class TestRun extends BaseTest {
 		} catch (ExitException e) {
 			StringWriter sw = new StringWriter();
 			e.printStackTrace(new PrintWriter(sw));
-			assertThat(sw.toString(), containsString("in acme"));
-			assertThat(sw.toString(), not(containsString("in mavencentral=")));
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).contains("in acme");
+			org.assertj.core.api.Assertions.assertThat(sw.toString()).doesNotContain("in mavencentral=");
 		}
 	}
 
@@ -2279,7 +2240,7 @@ public class TestRun extends BaseTest {
 		Project code = pb.build(f.getPath());
 		String result = run.updateGeneratorForRun(code.codeBuilder().build()).build().generate();
 
-		assertThat(result, containsString("log4j-1.2.17.jar"));
+		org.assertj.core.api.Assertions.assertThat(result).contains("log4j-1.2.17.jar");
 	}
 
 	@Test
@@ -2291,7 +2252,7 @@ public class TestRun extends BaseTest {
 
 		ProjectBuilder pb = run.createProjectBuilderForRun();
 		Project code = pb.build(arg);
-		assertThat(code.getJavaVersion(), equalTo("" + v));
+		org.assertj.core.api.Assertions.assertThat(code.getJavaVersion()).isEqualTo("" + v);
 	}
 
 	@Test
@@ -2312,7 +2273,7 @@ public class TestRun extends BaseTest {
 					@Override
 					protected void runCompiler(List<String> optionList) throws IOException {
 						// Make sure the file "build.jbang" isn't passed to the compiler
-						assertThat(optionList.stream().filter(o -> o.contains("build.jbang")).count(), equalTo(1L));
+						org.assertj.core.api.Assertions.assertThat(optionList.stream().filter(o -> o.contains("build.jbang")).count()).isEqualTo(1L);
 						super.runCompiler(optionList);
 					}
 				};
@@ -2321,22 +2282,18 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, endsWith("quote_notags"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, matchesRegex(".*build\\.jbang\\.[a-z0-9]+.build.jbang.jar.*"));
-		assertThat(result, containsString("picocli-4.6.3.jar"));
-		assertThat(result, containsString("-Dfoo=bar"));
-		assertThat(result, containsString(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell())));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).endsWith("quote_notags");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*build\\.jbang\\.[a-z0-9]+.build.jbang.jar.*");
+		org.assertj.core.api.Assertions.assertThat(result).contains("picocli-4.6.3.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result).contains(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell()));
 		// Make sure the opts only appear once
-		assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), ""),
-				not(containsString("-Dfoo=bar")));
-		assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), ""),
-				not(containsString("-Dbar=aap noot mies")));
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), "")).doesNotContain("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), "")).doesNotContain("-Dbar=aap noot mies");
 		// Make sure the opts only appear unquoted
-		assertThat(result,
-				not(containsString(
-						CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()))));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain(CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()));
 		// assertThat(result, containsString("--source 11"));
 	}
 
@@ -2358,7 +2315,7 @@ public class TestRun extends BaseTest {
 					@Override
 					protected void runCompiler(List<String> optionList) throws IOException {
 						// Make sure the file "build.jbang" isn't passed to the compiler
-						assertThat(optionList.stream().filter(o -> o.contains("build.jbang")).count(), equalTo(1L));
+						org.assertj.core.api.Assertions.assertThat(optionList.stream().filter(o -> o.contains("build.jbang")).count()).isEqualTo(1L);
 						super.runCompiler(optionList);
 					}
 				};
@@ -2367,22 +2324,18 @@ public class TestRun extends BaseTest {
 
 		String result = run.updateGeneratorForRun(CmdGenerator.builder(prj)).build().generate();
 
-		assertThat(result, matchesPattern("^.*java(.exe)? .*$"));
-		assertThat(result, endsWith("quote_notags"));
-		assertThat(result, containsString("classpath"));
-		assertThat(result, matchesRegex(".*build\\.jbang\\.[a-z0-9]+.build.jbang.jar.*"));
-		assertThat(result, containsString("picocli-4.6.3.jar"));
-		assertThat(result, containsString("-Dfoo=bar"));
-		assertThat(result, containsString(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell())));
+		org.assertj.core.api.Assertions.assertThat(result).matches("^.*java(.exe)? .*$");
+		org.assertj.core.api.Assertions.assertThat(result).endsWith("quote_notags");
+		org.assertj.core.api.Assertions.assertThat(result).contains("classpath");
+		org.assertj.core.api.Assertions.assertThat(result).matches(".*build\\.jbang\\.[a-z0-9]+.build.jbang.jar.*");
+		org.assertj.core.api.Assertions.assertThat(result).contains("picocli-4.6.3.jar");
+		org.assertj.core.api.Assertions.assertThat(result).contains("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result).contains(CommandBuffer.escapeShellArgument("-Dbar=aap noot mies", Util.getShell()));
 		// Make sure the opts only appear once
-		assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), ""),
-				not(containsString("-Dfoo=bar")));
-		assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), ""),
-				not(containsString("-Dbar=aap noot mies")));
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dfoo=bar"), "")).doesNotContain("-Dfoo=bar");
+		org.assertj.core.api.Assertions.assertThat(result.replaceFirst(Pattern.quote("-Dbar=aap noot mies"), "")).doesNotContain("-Dbar=aap noot mies");
 		// Make sure the opts only appear unquoted
-		assertThat(result,
-				not(containsString(
-						CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()))));
+		org.assertj.core.api.Assertions.assertThat(result).doesNotContain(CommandBuffer.escapeShellArgument("-Dfoo=bar -Dbar=aap noot mies", Util.getShell()));
 		// assertThat(result, containsString("--source 11"));
 	}
 
@@ -2402,9 +2355,9 @@ public class TestRun extends BaseTest {
 		String script = examplesTestFolder.resolve("helloworld.java").toString();
 		String arg = "http://localhost:" + wms.port() + "/readme.md";
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script, "%" + arg);
-		assertThat(result.err, containsString("Requesting HTTP GET " + arg));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Requesting HTTP GET " + arg);
 		Path file = Util.downloadAndCacheFile(arg);
-		assertThat(result.err, containsString(file.toString()));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains(file.toString());
 	}
 
 	@Test
@@ -2423,9 +2376,9 @@ public class TestRun extends BaseTest {
 		String script = examplesTestFolder.resolve("helloworld.java").toString();
 		String arg = "http://localhost:" + wms.port() + "/readme.md";
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script, "%{" + arg + "}");
-		assertThat(result.err, containsString("Requesting HTTP GET " + arg));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Requesting HTTP GET " + arg);
 		Path file = Util.downloadAndCacheFile(arg);
-		assertThat(result.err, containsString(file.toString()));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains(file.toString());
 	}
 
 	@Test
@@ -2455,11 +2408,11 @@ public class TestRun extends BaseTest {
 		String arg2 = "http://localhost:" + wms.port() + "/readme2.md";
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script,
 				"foo%{" + arg1 + "}bar%{" + arg2 + "}baz");
-		assertThat(result.err, containsString("Requesting HTTP GET " + arg1));
-		assertThat(result.err, containsString("Requesting HTTP GET " + arg2));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Requesting HTTP GET " + arg1);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Requesting HTTP GET " + arg2);
 		Path file1 = Util.downloadAndCacheFile(arg1);
 		Path file2 = Util.downloadAndCacheFile(arg2);
-		assertThat(result.err, containsString("foo" + file1 + "bar" + file2 + "baz"));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("foo" + file1 + "bar" + file2 + "baz");
 	}
 
 	@Test
@@ -2482,12 +2435,12 @@ public class TestRun extends BaseTest {
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose",
 				"--javaagent=" + agent + "=test:%{" + arg + "}",
 				script);
-		assertThat(result.err, containsString("Requesting HTTP GET " + arg));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Requesting HTTP GET " + arg);
 		Path file = Util.downloadAndCacheFile(arg);
 		Project aprj = Project.builder().build(agent);
 		BuildContext actx = BuildContext.forProject(aprj);
 		Path jar = actx.getJarFile();
-		assertThat(result.err, containsString("-javaagent:" + jar + "=test:" + file));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("-javaagent:" + jar + "=test:" + file);
 	}
 
 	@Test
@@ -2496,9 +2449,9 @@ public class TestRun extends BaseTest {
 		String script = examplesTestFolder.resolve("helloworld.java").toString();
 		String arg = "http://localhost:1234/readme.md";
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script, "%%" + arg);
-		assertThat(result.err, not(containsString("Requesting HTTP GET " + arg)));
-		assertThat(result.err, containsString("%" + arg));
-		assertThat(result.err, not(containsString("%%" + arg)));
+		org.assertj.core.api.Assertions.assertThat(result.err).doesNotContain("Requesting HTTP GET " + arg);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("%" + arg);
+		org.assertj.core.api.Assertions.assertThat(result.err).doesNotContain("%%" + arg);
 	}
 
 	@Test
@@ -2510,9 +2463,9 @@ public class TestRun extends BaseTest {
 		String script = examplesTestFolder.resolve("helloworld.java").toString();
 		String arg = "http://localhost:1234/readme.md";
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script, "foo%%{" + arg + "}bar");
-		assertThat(result.err, not(containsString("Requesting HTTP GET " + arg)));
-		assertThat(result.err, containsString("foo%{" + arg + "}bar"));
-		assertThat(result.err, not(containsString("foo%%{" + arg + "}bar")));
+		org.assertj.core.api.Assertions.assertThat(result.err).doesNotContain("Requesting HTTP GET " + arg);
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("foo%{" + arg + "}bar");
+		org.assertj.core.api.Assertions.assertThat(result.err).doesNotContain("foo%%{" + arg + "}bar");
 	}
 
 	@Test
@@ -2524,10 +2477,9 @@ public class TestRun extends BaseTest {
 		String script = examplesTestFolder.resolve("helloworld.java").toString();
 		CaptureResult<Integer> result = checkedRun(null, "run", "--verbose", script,
 				"%{deps:info.picocli:picocli:4.6.3,log4j:log4j:1.2.17}");
-		assertThat(result.err, containsString("Resolving dependencies..."));
-		assertThat(result.err,
-				containsString("info/picocli/picocli/4.6.3/picocli-4.6.3.jar".replace("/", File.separator)));
-		assertThat(result.err, containsString("log4j/log4j/1.2.17/log4j-1.2.17.jar".replace("/", File.separator)));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("Resolving dependencies...");
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("info/picocli/picocli/4.6.3/picocli-4.6.3.jar".replace("/", File.separator));
+		org.assertj.core.api.Assertions.assertThat(result.err).contains("log4j/log4j/1.2.17/log4j-1.2.17.jar".replace("/", File.separator));
 	}
 
 	@Test
@@ -2558,7 +2510,7 @@ public class TestRun extends BaseTest {
 		ExitException e = Assertions.assertThrows(ExitException.class,
 				() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
 
-		assertThat(e.getMessage(), startsWith("no main class"));
+		org.assertj.core.api.Assertions.assertThat(e.getMessage()).startsWith("no main class");
 	}
 
 	@Test
@@ -2581,7 +2533,7 @@ public class TestRun extends BaseTest {
 
 		String cmdline = run.updateGeneratorForRun(genb).build().generate();
 
-		assertThat(cmdline, endsWith("echo foo bar baz"));
+		org.assertj.core.api.Assertions.assertThat(cmdline).endsWith("echo foo bar baz");
 	}
 
 	@Test
@@ -2599,7 +2551,7 @@ public class TestRun extends BaseTest {
 
 		String cmdline = run.updateGeneratorForRun(genb).build().generate();
 
-		assertThat(cmdline, endsWith("echo baz"));
+		org.assertj.core.api.Assertions.assertThat(cmdline).endsWith("echo baz");
 	}
 
 	@Test
@@ -2622,9 +2574,7 @@ public class TestRun extends BaseTest {
 
 		String cmd = CmdGenerator.builder(ctx).build().generate();
 
-		assertThat(cmd,
-				containsString(
-						"--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"));
+		org.assertj.core.api.Assertions.assertThat(cmd).contains("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED");
 	}
 
 	@Test
@@ -2642,9 +2592,7 @@ public class TestRun extends BaseTest {
 
 		String cmd = CmdGenerator.builder(ctx).build().generate();
 
-		assertThat(cmd,
-				not(containsString(
-						"--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED")));
+		org.assertj.core.api.Assertions.assertThat(cmd).doesNotContain("--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED");
 	}
 
 	@Test
@@ -2659,7 +2607,7 @@ public class TestRun extends BaseTest {
 					"run", "--source-type=java", "--enable-preview", "--verbose", "-");
 
 			// expect the JShell pipeline NOT to be used
-			assertThat(res.err, not(containsString(".jsh")));
+			org.assertj.core.api.Assertions.assertThat(res.err).doesNotContain(".jsh");
 		} finally {
 			// Always restore original System.in
 			System.setIn(originalIn);
@@ -2678,8 +2626,8 @@ public class TestRun extends BaseTest {
 
 			// current (broken) behaviour emits "test.jsh.jar".
 			// Once fixed, that message must disappear and the run should succeed.
-			assertThat(res.err, not(containsString("sourceTypeTest.jsh.jar")));
-			assertThat(res.result, equalTo(EXIT_EXECUTE));
+			org.assertj.core.api.Assertions.assertThat(res.err).doesNotContain("sourceTypeTest.jsh.jar");
+			org.assertj.core.api.Assertions.assertThat(res.result).isEqualTo(EXIT_EXECUTE);
 		} finally {
 			// Clean up the test file
 			if (Files.exists(p)) {

--- a/src/test/java/dev/jbang/cli/TestTemplate.java
+++ b/src/test/java/dev/jbang/cli/TestTemplate.java
@@ -2,8 +2,7 @@ package dev.jbang.cli;
 
 import static dev.jbang.util.TestUtil.clearSettingsCaches;
 import static dev.jbang.util.Util.entry;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -73,11 +72,11 @@ public class TestTemplate extends BaseTest {
 	void testReadFromFile() throws IOException {
 		clearSettingsCaches();
 		Template one = Template.get("one");
-		assertThat(one, notNullValue());
+		assertThat(one).isNotNull();
 		Template two = Template.get("two");
-		assertThat(two, notNullValue());
+		assertThat(two).isNotNull();
 		Template threeWithProperties = Template.get("three-with-properties");
-		assertThat(threeWithProperties, notNullValue());
+		assertThat(threeWithProperties).isNotNull();
 	}
 
 	@Test
@@ -85,14 +84,13 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine().execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("name");
-		assertThat(name.fileRefs, aMapWithSize(1));
-		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
-		assertThat(name.fileRefs.values(), hasItems("test.java"));
+		assertThat(name.fileRefs).hasSize(1);
+		assertThat(name.fileRefs.keySet()).contains("{basename}.java");
+		assertThat(name.fileRefs.values()).contains("test.java");
 	}
 
 	@Test
@@ -100,14 +98,13 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name",
 					"--description", "Description of the template", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("name");
-		assertThat(name.description, is("Description of the template"));
+		assertThat(name.description).isEqualTo("Description of the template");
 	}
 
 	@Test
@@ -119,12 +116,12 @@ public class TestTemplate extends BaseTest {
 		Files.createDirectory(hiddenJBangPath);
 		Files.createFile(Paths.get(cwd.toString(), Settings.JBANG_DOT_DIR, Catalog.JBANG_CATALOG_JSON));
 		JBang.getCommandLine().execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		Catalog catalog = Catalog.get(hiddenJBangPath);
 		Template name = catalog.templates.get("name");
-		assertThat(name.fileRefs, aMapWithSize(1));
-		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
-		assertThat(name.fileRefs.values(), hasItems(Paths.get("../test.java").toString()));
+		assertThat(name.fileRefs).hasSize(1);
+		assertThat(name.fileRefs.keySet()).contains("{basename}.java");
+		assertThat(name.fileRefs.values()).contains(Paths.get("../test.java").toString());
 	}
 
 	@Test
@@ -137,12 +134,12 @@ public class TestTemplate extends BaseTest {
 					testFile.toString());
 		Template one = Template.get("one");
 		Template name = Template.get("name");
-		assertThat(one.fileRefs, aMapWithSize(3));
-		assertThat(one.fileRefs.keySet(), hasItems("{basename}.java", "{basename}Test.java", "file2.java"));
-		assertThat(one.fileRefs.values(), hasItems("file1_1.java", "file1_1_test.java", "file1_2.java"));
-		assertThat(name.fileRefs, aMapWithSize(1));
-		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
-		assertThat(name.fileRefs.values(), hasItems("test.java"));
+		assertThat(one.fileRefs).hasSize(3);
+		assertThat(one.fileRefs.keySet()).contains("{basename}.java", "{basename}Test.java", "file2.java");
+		assertThat(one.fileRefs.values()).contains("file1_1.java", "file1_1_test.java", "file1_2.java");
+		assertThat(name.fileRefs).hasSize(1);
+		assertThat(name.fileRefs.keySet()).contains("{basename}.java");
+		assertThat(name.fileRefs.values()).contains("test.java");
 	}
 
 	@Test
@@ -152,70 +149,65 @@ public class TestTemplate extends BaseTest {
 		Files.write(testFile, "// Test file".getBytes());
 		Path testFile2 = cwd.resolve("test2.java");
 		Files.write(testFile2, "// Test file 2".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		int exitCode = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(exitCode).isEqualTo(BaseCommand.EXIT_OK);
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("name");
-		assertThat(name.fileRefs, aMapWithSize(1));
-		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
-		assertThat(name.fileRefs.values(), hasItems("test.java"));
+		assertThat(name.fileRefs).hasSize(1);
+		assertThat(name.fileRefs.keySet()).contains("{basename}.java");
+		assertThat(name.fileRefs.values()).contains("test.java");
 		exitCode = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(exitCode).isEqualTo(BaseCommand.EXIT_INVALID_INPUT);
 		exitCode = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name", "--force",
 					testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(exitCode).isEqualTo(BaseCommand.EXIT_OK);
 		name = Template.get("name");
-		assertThat(name.fileRefs, aMapWithSize(1));
-		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
-		assertThat(name.fileRefs.values(), hasItems("test2.java"));
+		assertThat(name.fileRefs).hasSize(1);
+		assertThat(name.fileRefs.keySet()).contains("{basename}.java");
+		assertThat(name.fileRefs.values()).contains("test2.java");
 	}
 
 	@Test
 	void testGetTemplateNone() throws IOException {
 		Template template = Template.get("dummy-template!");
-		assertThat(template, nullValue());
+		assertThat(template).isNull();
 	}
 
 	@Test
 	void testGetTemplateOne() throws IOException {
 		Template template = Template.get("one");
-		assertThat(template, notNullValue());
-		assertThat(template.description, is("Template 1"));
-		assertThat(template.fileRefs, aMapWithSize(3));
-		assertThat(template.fileRefs.keySet(), hasItems("{basename}.java", "{basename}Test.java", "file2.java"));
-		assertThat(template.fileRefs.values(), hasItems("file1_1.java", "file1_1_test.java", "file1_2.java"));
+		assertThat(template).isNotNull();
+		assertThat(template.description).isEqualTo("Template 1");
+		assertThat(template.fileRefs).hasSize(3);
+		assertThat(template.fileRefs.keySet()).contains("{basename}.java", "{basename}Test.java", "file2.java");
+		assertThat(template.fileRefs.values()).contains("file1_1.java", "file1_1_test.java", "file1_2.java");
 	}
 
 	@Test
 	void testGetTemplateTwo() throws IOException {
 		Template template = Template.get("two");
-		assertThat(template, notNullValue());
-		assertThat(template.description, is("Template 2"));
-		assertThat(template.fileRefs, aMapWithSize(2));
-		assertThat(template.fileRefs.keySet(), hasItems("src/{filename}", "src/file2.java"));
-		assertThat(template.fileRefs.values(), hasItems("tpl2/file2_1.java", "tpl2/file2_2.java"));
+		assertThat(template).isNotNull();
+		assertThat(template.description).isEqualTo("Template 2");
+		assertThat(template.fileRefs).hasSize(2);
+		assertThat(template.fileRefs.keySet()).contains("src/{filename}", "src/file2.java");
+		assertThat(template.fileRefs.values()).contains("tpl2/file2_1.java", "tpl2/file2_2.java");
 	}
 
 	@Test
 	void testGetTemplateThreeWithProperties() throws IOException {
 		Template template = Template.get("three-with-properties");
-		assertThat(template, notNullValue());
-		assertThat(template.description, is("Template 3"));
-		assertThat(template.fileRefs, aMapWithSize(2));
-		assertThat(template.fileRefs.keySet(), hasItems("src/{filename}", "src/file2.java"));
-		assertThat(template.fileRefs.values(), hasItems("tpl2/file2_1.java", "tpl2/file2_2.java"));
-		assertThat(template.properties.entrySet(), hasItems(
-				entry("test-key", new TemplateProperty(null, null)),
-				entry("test-key-with-description",
-						new TemplateProperty("This is a test description", null)),
-				entry("test-key-with-description-and-default-value",
-						new TemplateProperty("This is a test description with default value", "2.11")),
-				entry("test-key-with-default-value", new TemplateProperty(null, "3.12"))));
+		assertThat(template).isNotNull();
+		assertThat(template.description).isEqualTo("Template 3");
+		assertThat(template.fileRefs).hasSize(2);
+		assertThat(template.fileRefs.keySet()).contains("src/{filename}", "src/file2.java");
+		assertThat(template.fileRefs.values()).contains("tpl2/file2_1.java", "tpl2/file2_2.java");
+		assertThat(template.properties.entrySet()).contains(entry("test-key", new TemplateProperty(null, null)), entry("test-key-with-description",
+			new TemplateProperty("This is a test description", null)), entry("test-key-with-description-and-default-value",
+			new TemplateProperty("This is a test description with default value", "2.11")), entry("test-key-with-default-value", new TemplateProperty(null, "3.12")));
 	}
 
 	@Test
@@ -225,7 +217,7 @@ public class TestTemplate extends BaseTest {
 		int result = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name",
 					"/test=" + testFile.toString());
-		assertThat(result, is(2));
+		assertThat(result).isEqualTo(2);
 	}
 
 	@Test
@@ -235,7 +227,7 @@ public class TestTemplate extends BaseTest {
 		int result = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name",
 					"test/../..=" + testFile.toString());
-		assertThat(result, is(2));
+		assertThat(result).isEqualTo(2);
 	}
 
 	@Test
@@ -245,7 +237,7 @@ public class TestTemplate extends BaseTest {
 		int result = JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=name",
 					"test=" + testFile.toString());
-		assertThat(result, is(2));
+		assertThat(result).isEqualTo(2);
 	}
 
 	@Test
@@ -253,15 +245,13 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(), "--name=template-with-single-property",
 					"--description", "Description of the template", "-P", "new-test-key", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("template-with-single-property");
-		assertThat(name.properties.entrySet(), hasItems(
-				entry("new-test-key", new TemplateProperty(null, null))));
+		assertThat(name.properties.entrySet()).contains(entry("new-test-key", new TemplateProperty(null, null)));
 	}
 
 	@Test
@@ -269,18 +259,16 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(),
 					"--name=template-with-single-complex-property",
 					"--description", "Description of the template", "-P",
 					"new-test-key:This is a description for the property key:3.14", testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("template-with-single-complex-property");
-		assertThat(name.properties.entrySet(), hasItems(
-				entry("new-test-key",
-						new TemplateProperty("This is a description for the property key", "3.14"))));
+		assertThat(name.properties.entrySet()).contains(entry("new-test-key",
+			new TemplateProperty("This is a description for the property key", "3.14")));
 	}
 
 	@Test
@@ -288,7 +276,7 @@ public class TestTemplate extends BaseTest {
 		Path cwd = Util.getCwd();
 		Path testFile = cwd.resolve("test.java");
 		Files.write(testFile, "// Test file".getBytes());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(false);
 		JBang.getCommandLine()
 			.execute("template", "add", "-f", cwd.toString(),
 					"--name=template-with-complex-properties",
@@ -296,13 +284,10 @@ public class TestTemplate extends BaseTest {
 					"new-test-key:This is a description for the property key:3.14", "--property",
 					"second-test-key:This is another description for the second property key:Non-Blocker",
 					testFile.toString());
-		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
-				is(true));
+		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON))).isEqualTo(true);
 		Template name = Template.get("template-with-complex-properties");
-		assertThat(name.properties.entrySet(), hasItems(
-				entry("new-test-key",
-						new TemplateProperty("This is a description for the property key", "3.14")),
-				entry("second-test-key", new TemplateProperty(
-						"This is another description for the second property key", "Non-Blocker"))));
+		assertThat(name.properties.entrySet()).contains(entry("new-test-key",
+			new TemplateProperty("This is a description for the property key", "3.14")), entry("second-test-key", new TemplateProperty(
+			"This is another description for the second property key", "Non-Blocker")));
 	}
 }

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -2,15 +2,7 @@ package dev.jbang.dependencies;
 
 import static dev.jbang.dependencies.DependencyUtil.toMavenRepo;
 import static dev.jbang.util.JavaUtil.defaultJdkManager;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.arrayWithSize;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
@@ -125,7 +117,7 @@ class DependencyResolverTest extends BaseTest {
 			.build()
 			.resolve(deps);
 		assertEquals(2, artifacts.size());
-		assertThat(altrepo.listFiles(), arrayWithSize(4));
+		assertThat(altrepo.listFiles()).hasSize(4);
 	}
 
 	@Test
@@ -162,7 +154,7 @@ class DependencyResolverTest extends BaseTest {
 
 		HashSet<String> othercps = new HashSet<>(cps);
 
-		assertThat(cps, containsInAnyOrder(othercps.toArray()));
+		assertThat(cps).containsExactlyInAnyOrder(othercps.toArray());
 	}
 
 	@Test
@@ -196,11 +188,11 @@ class DependencyResolverTest extends BaseTest {
 
 		List<String> ma = cp.getAutoDectectedModuleArguments(defaultJdkManager().getOrInstallJdk(null));
 
-		assertThat(ma, hasItem("--module-path"));
+		assertThat(ma).contains("--module-path");
 
-		assertThat(ma, not(hasItem("docopt")));
+		assertThat(ma).doesNotContain("docopt");
 
-		assertThat(cp.getClassPath(), containsString("docopt"));
+		assertThat(cp.getClassPath()).contains("docopt");
 	}
 
 	@Test
@@ -276,12 +268,10 @@ class DependencyResolverTest extends BaseTest {
 				false,
 				true, false);
 
-		assertThat(classpath.getArtifacts(), hasSize(7));
+		assertThat(classpath.getArtifacts()).hasSize(7);
 		ArtifactInfo ai = classpath.getArtifacts().get(0);
-		assertThat(ai.getCoordinate().toCanonicalForm(),
-				equalTo("org.infinispan:infinispan-commons:tests:jar:13.0.5.Final"));
-		assertThat(ai.getFile().toString(),
-				endsWith("infinispan-commons-13.0.5.Final-tests.jar"));
+		assertThat(ai.getCoordinate().toCanonicalForm()).isEqualTo("org.infinispan:infinispan-commons:tests:jar:13.0.5.Final");
+		assertThat(ai.getFile().toString()).endsWith("infinispan-commons-13.0.5.Final-tests.jar");
 	}
 
 }

--- a/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
+++ b/src/test/java/dev/jbang/dependencies/TestArtifactInfo.java
@@ -1,7 +1,7 @@
 package dev.jbang.dependencies;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.io.FileMatchers.aFileWithSize;
 
 import java.util.Arrays;
@@ -34,9 +34,9 @@ public class TestArtifactInfo extends BaseTest {
 
 		List<ArtifactInfo> wonka = DependencyCache.findDependenciesByHash("wonka");
 
-		assertThat(wonka, notNullValue());
-		assertThat(wonka, hasSize(4));
+		org.assertj.core.api.Assertions.assertThat(wonka).isNotNull();
+		org.assertj.core.api.Assertions.assertThat(wonka).hasSize(4);
 
-		assertThat(wonka, contains(classpath.getArtifacts().toArray()));
+		org.assertj.core.api.Assertions.assertThat(wonka).containsExactly(classpath.getArtifacts().toArray());
 	}
 }

--- a/src/test/java/dev/jbang/dependencies/TestGrape.java
+++ b/src/test/java/dev/jbang/dependencies/TestGrape.java
@@ -1,8 +1,6 @@
 package dev.jbang.dependencies;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.FileNotFoundException;
 import java.util.List;
@@ -35,11 +33,11 @@ public class TestGrape extends BaseTest {
 		Project prj = Project.builder().build(src);
 		List<String> deps = prj.getMainSourceSet().getDependencies();
 
-		assertThat(deps, hasItem("org.hibernate:hibernate-core:5.4.10.Final"));
-		assertThat(deps, hasItem("net.sf.json-lib:json-lib:2.2.3:jdk15"));
-		assertThat(deps, hasItem("org.restlet:org.restlet:1.1.6"));
-		assertThat(deps, hasItem("log4j:log4j:1.2.17"));
-		assertThat(deps, not(hasItem("blah:borked:1.0@wonka")));
+		assertThat(deps).contains("org.hibernate:hibernate-core:5.4.10.Final");
+		assertThat(deps).contains("net.sf.json-lib:json-lib:2.2.3:jdk15");
+		assertThat(deps).contains("org.restlet:org.restlet:1.1.6");
+		assertThat(deps).contains("log4j:log4j:1.2.17");
+		assertThat(deps).doesNotContain("blah:borked:1.0@wonka");
 
 	}
 

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -49,7 +49,7 @@ public class TestBuilder extends BaseTest {
 		AtomicBoolean integrationStepCalled = new AtomicBoolean(false);
 		AtomicBoolean jarStepCalled = new AtomicBoolean(false);
 		AtomicBoolean nativeStepCalled = new AtomicBoolean(false);
-		runBuild(ctx, (ctxx, optionList) -> assertThat(optionList, hasItems(foo.toString(), "-g")), (ctxx) -> {
+		runBuild(ctx, (ctxx, optionList) -> org.assertj.core.api.Assertions.assertThat(optionList).contains(foo.toString(), "-g"), (ctxx) -> {
 			integrationStepCalled.set(true);
 			return new IntegrationResult(null, null, null);
 		}, (ctxx) -> {
@@ -58,9 +58,9 @@ public class TestBuilder extends BaseTest {
 		}, (ctxx, nativeStep) -> {
 			nativeStepCalled.set(true);
 		});
-		assertThat(integrationStepCalled.get(), is(true));
-		assertThat(jarStepCalled.get(), is(true));
-		assertThat(nativeStepCalled.get(), is(false));
+		org.assertj.core.api.Assertions.assertThat(integrationStepCalled.get()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(jarStepCalled.get()).isEqualTo(true);
+		org.assertj.core.api.Assertions.assertThat(nativeStepCalled.get()).isEqualTo(false);
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(foo.toString());
 		prj.setEnablePreviewRequested(true);
 		BuildContext ctx = BuildContext.forProject(prj);
-		runBuild(ctx, (ctxx, optionList) -> assertThat(optionList, hasItems(foo.toString(), "--enable-preview")), null,
+		runBuild(ctx, (ctxx, optionList) -> org.assertj.core.api.Assertions.assertThat(optionList).contains(foo.toString(), "--enable-preview"), null,
 				null, null);
 	}
 
@@ -82,23 +82,23 @@ public class TestBuilder extends BaseTest {
 		BuildContext ctx1 = BuildContext.forProject(prj, out1.toPath());
 		BuildContext ctx2 = BuildContext.forProject(prj, out2.toPath());
 		runBuild(ctx1, (ctxx, optionList) -> {
-			assertThat(optionList, hasItems(containsString(out1.toString())));
-			assertThat(optionList, not(hasItems(containsString(out2.toString()))));
-			assertThat(optionList, not(hasItems(containsString(Settings.getCacheDir().toString()))));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(containsString(out1.toString()));
+			org.assertj.core.api.Assertions.assertThat(optionList).doesNotContain(containsString(out2.toString()));
+			org.assertj.core.api.Assertions.assertThat(optionList).doesNotContain(containsString(Settings.getCacheDir().toString()));
 		}, null, ctxx -> {
-			assertThat(ctxx.getJarFile().toString(), containsString(out1.toString()));
-			assertThat(ctxx.getJarFile().toString(), not(containsString(out2.toString())));
-			assertThat(ctxx.getJarFile().toString(), not(containsString(Settings.getCacheDir().toString())));
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).contains(out1.toString());
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).doesNotContain(out2.toString());
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).doesNotContain(Settings.getCacheDir().toString());
 			return ctxx.getProject();
 		}, null);
 		runBuild(ctx2, (ctxx, optionList) -> {
-			assertThat(optionList, hasItems(containsString(out2.toString())));
-			assertThat(optionList, not(hasItems(containsString(out1.toString()))));
-			assertThat(optionList, not(hasItems(containsString(Settings.getCacheDir().toString()))));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(containsString(out2.toString()));
+			org.assertj.core.api.Assertions.assertThat(optionList).doesNotContain(containsString(out1.toString()));
+			org.assertj.core.api.Assertions.assertThat(optionList).doesNotContain(containsString(Settings.getCacheDir().toString()));
 		}, null, ctxx -> {
-			assertThat(ctxx.getJarFile().toString(), containsString(out2.toString()));
-			assertThat(ctxx.getJarFile().toString(), not(containsString(out1.toString())));
-			assertThat(ctxx.getJarFile().toString(), not(containsString(Settings.getCacheDir().toString())));
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).contains(out2.toString());
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).doesNotContain(out1.toString());
+			org.assertj.core.api.Assertions.assertThat(ctxx.getJarFile().toString()).doesNotContain(Settings.getCacheDir().toString());
 			return ctxx.getProject();
 		}, null);
 	}
@@ -109,7 +109,7 @@ public class TestBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder().compileOptions(Arrays.asList("--foo", "--bar"));
 		Project prj = pb.build(foo.toString());
 		BuildContext ctx = BuildContext.forProject(prj);
-		runBuild(ctx, (ctxx, optionList) -> assertThat(optionList, hasItems(foo.toString(), "-g", "--foo", "--bar")),
+		runBuild(ctx, (ctxx, optionList) -> org.assertj.core.api.Assertions.assertThat(optionList).contains(foo.toString(), "-g", "--foo", "--bar"),
 				null, null, null);
 	}
 
@@ -119,7 +119,7 @@ public class TestBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder().compileOptions(Arrays.asList("--foo", "--bar"));
 		Project prj = pb.build(foo.toString());
 		BuildContext ctx = BuildContext.forProject(prj);
-		runBuild(ctx, (ctxx, optionList) -> assertThat(optionList, hasItems(foo.toString(), "--foo", "--bar")), null,
+		runBuild(ctx, (ctxx, optionList) -> org.assertj.core.api.Assertions.assertThat(optionList).contains(foo.toString(), "--foo", "--bar"), null,
 				null, null);
 	}
 
@@ -132,8 +132,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(foo.toString());
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(foo.toString()));
-			assertThat(optionList, hasItem(bar.toString()));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(foo.toString());
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(bar.toString());
 		}, null, null, null);
 	}
 
@@ -149,8 +149,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(mainFile);
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(mainFile));
-			assertThat(optionList, hasItem(incFile));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile);
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 		}, null, null, null);
 	}
 
@@ -169,8 +169,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(mainFile.toString());
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(mainFile.toString()));
-			assertThat(optionList, hasItem(incFile));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile.toString());
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 		}, null, null, null);
 	}
 
@@ -185,8 +185,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(mainFile);
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(mainFile));
-			assertThat(optionList, hasItem(incFile));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile);
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 		}, null, null, null);
 	}
 
@@ -201,8 +201,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(mainFile);
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(mainFile));
-			assertThat(optionList, hasItem(incFile));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile);
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 		}, null, null, null);
 	}
 
@@ -217,8 +217,8 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(mainFile);
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-			assertThat(optionList, hasItem(mainFile));
-			assertThat(optionList, hasItem(incFile));
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(mainFile);
+			org.assertj.core.api.Assertions.assertThat(optionList).contains(incFile);
 		}, null, null, null);
 	}
 
@@ -237,13 +237,9 @@ public class TestBuilder extends BaseTest {
 		runBuild(ctx, (ctxx, optionList) -> {
 		}, null, ctxx -> {
 			Project project = ctxx.getProject();
-			assertThat(project.getMainSourceSet().getResources().size(), is(2));
-			assertThat(
-					project.getMainSourceSet().getResources().get(0).getSource().getFile().endsWith(res1),
-					is(true));
-			assertThat(
-					project.getMainSourceSet().getResources().get(1).getSource().getFile().endsWith(res2),
-					is(true));
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().size()).isEqualTo(2);
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(0).getSource().getFile().endsWith(res1)).isEqualTo(true);
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(1).getSource().getFile().endsWith(res2)).isEqualTo(true);
 			return project;
 		}, null);
 	}
@@ -263,17 +259,11 @@ public class TestBuilder extends BaseTest {
 		runBuild(ctx, (ctxx, optionList) -> {
 		}, null, ctxx -> {
 			Project project = ctxx.getProject();
-			assertThat(project.getMainSourceSet().getResources().size(), is(2));
-			assertThat(project.getMainSourceSet().getResources().get(0).getTarget().toString(),
-					is("somedir" + File.separator + "resource.properties"));
-			assertThat(
-					project.getMainSourceSet().getResources().get(0).getSource().getFile().endsWith(res1),
-					is(true));
-			assertThat(project.getMainSourceSet().getResources().get(1).getTarget().toString(),
-					is("somedir" + File.separator + "sub.properties"));
-			assertThat(
-					project.getMainSourceSet().getResources().get(1).getSource().getFile().endsWith(res2),
-					is(true));
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().size()).isEqualTo(2);
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(0).getTarget().toString()).isEqualTo("somedir" + File.separator + "resource.properties");
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(0).getSource().getFile().endsWith(res1)).isEqualTo(true);
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(1).getTarget().toString()).isEqualTo("somedir" + File.separator + "sub.properties");
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().get(1).getSource().getFile().endsWith(res2)).isEqualTo(true);
 			return project;
 		}, null);
 	}
@@ -292,7 +282,7 @@ public class TestBuilder extends BaseTest {
 			assertThat(optionList, hasItem(endsWith(File.separator + "foo.java")));
 		}, null, ctxx -> {
 			Project project = ctxx.getProject();
-			assertThat(project.getMainSourceSet().getResources().size(), is(3));
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().size()).isEqualTo(3);
 			List<String> ps = project.getMainSourceSet()
 				.getResources()
 				.stream()
@@ -317,7 +307,7 @@ public class TestBuilder extends BaseTest {
 			assertThat(optionList, hasItem(endsWith(File.separator + "foo.java")));
 		}, null, ctxx -> {
 			Project project = ctxx.getProject();
-			assertThat(project.getMainSourceSet().getResources().size(), is(4));
+			org.assertj.core.api.Assertions.assertThat(project.getMainSourceSet().getResources().size()).isEqualTo(4);
 			List<String> ps = project.getMainSourceSet()
 				.getResources()
 				.stream()
@@ -344,9 +334,9 @@ public class TestBuilder extends BaseTest {
 			assertThat(optionList, hasItem(endsWith(File.separator + "foo.java")));
 		}, null, null, (ctxx, optionList) -> {
 			if (Util.isWindows()) {
-				assertThat(optionList.get(optionList.size() - 1), not(endsWith(".exe")));
+				org.assertj.core.api.Assertions.assertThat(optionList.get(optionList.size() - 1)).doesNotEndWith(".exe");
 			} else {
-				assertThat(optionList.get(optionList.size() - 1), endsWith(".bin"));
+				org.assertj.core.api.Assertions.assertThat(optionList.get(optionList.size() - 1)).endsWith(".bin");
 			}
 		});
 	}
@@ -364,15 +354,15 @@ public class TestBuilder extends BaseTest {
 		BuildContext ctx = BuildContext.forProject(prj);
 		Project.codeBuilder(ctx).build();
 
-		assertThat(prj.getManifestAttributes().get("foo"), is("true"));
-		assertThat(prj.getManifestAttributes().get("bar"), is("baz"));
-		assertThat(prj.getManifestAttributes().get("baz"), is("algo"));
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get("foo")).isEqualTo("true");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get("bar")).isEqualTo("baz");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes().get("baz")).isEqualTo("algo");
 
 		try (JarFile jf = new JarFile(ctx.getJarFile().toFile())) {
 			Attributes attrs = jf.getManifest().getMainAttributes();
-			assertThat(attrs.getValue("foo"), equalTo("true"));
-			assertThat(attrs.getValue("bar"), equalTo("baz"));
-			assertThat(attrs.getValue("baz"), equalTo("algo"));
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("foo")).isEqualTo("true");
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("bar")).isEqualTo("baz");
+			org.assertj.core.api.Assertions.assertThat(attrs.getValue("baz")).isEqualTo("algo");
 		}
 	}
 
@@ -383,7 +373,7 @@ public class TestBuilder extends BaseTest {
 		Project prj = pb.build(foo.toString());
 		BuildContext ctx = BuildContext.forProject(prj);
 		runBuild(ctx, (ctxx, optionList) -> {
-		}, null, null, (ctxx, optionList) -> assertThat(optionList, hasItem("-O1")));
+		}, null, null, (ctxx, optionList) -> org.assertj.core.api.Assertions.assertThat(optionList).contains("-O1"));
 	}
 
 	@Test
@@ -404,7 +394,7 @@ public class TestBuilder extends BaseTest {
 		});
 		runBuild(ctx, (ctxx, optionList) -> {
 		}, null, null, (ctxx, optionList) -> callCount.incrementAndGet());
-		assertThat(callCount.get(), equalTo(2));
+		org.assertj.core.api.Assertions.assertThat(callCount.get()).isEqualTo(2);
 	}
 
 	@Test
@@ -418,18 +408,18 @@ public class TestBuilder extends BaseTest {
 			int cc = callCount.incrementAndGet();
 			if (cc == 1) {
 				assertThat(ctxx, not(is(ctx)));
-				assertThat(ctxx.getProject().getSubProjects(), is(empty()));
-				assertThat(ctxx.resolveClassPath().getArtifacts(), hasSize(7));
+				org.assertj.core.api.Assertions.assertThat(ctxx.getProject().getSubProjects()).isEmpty();
+				org.assertj.core.api.Assertions.assertThat(ctxx.resolveClassPath().getArtifacts()).hasSize(7);
 			} else if (cc == 2) {
-				assertThat(ctxx, is(ctx));
-				assertThat(ctxx.getProject().getSubProjects(), hasSize(1));
-				assertThat(ctxx.resolveClassPath().getArtifacts(), hasSize(8));
-				assertThat(ctxx.resolveClassPath().getClassPath(), containsString("Two.jar"));
+				org.assertj.core.api.Assertions.assertThat(ctxx).isEqualTo(ctx);
+				org.assertj.core.api.Assertions.assertThat(ctxx.getProject().getSubProjects()).hasSize(1);
+				org.assertj.core.api.Assertions.assertThat(ctxx.resolveClassPath().getArtifacts()).hasSize(8);
+				org.assertj.core.api.Assertions.assertThat(ctxx.resolveClassPath().getClassPath()).contains("Two.jar");
 			} else {
 				throw new IllegalStateException("Should not be called more than twice!");
 			}
 		}, null, null, null);
-		assertThat(callCount.get(), equalTo(2));
+		org.assertj.core.api.Assertions.assertThat(callCount.get()).isEqualTo(2);
 	}
 
 	@Test
@@ -439,7 +429,7 @@ public class TestBuilder extends BaseTest {
 			ProjectBuilder pb = Project.builder();
 			Project prj = pb.build(selfdep.toString());
 		} catch (ExitException ex) {
-			assertThat(ex.getMessage(), startsWith("Self-referencing project dependency found for:"));
+			org.assertj.core.api.Assertions.assertThat(ex.getMessage()).startsWith("Self-referencing project dependency found for:");
 		}
 	}
 
@@ -455,7 +445,7 @@ public class TestBuilder extends BaseTest {
 			integrationStepCalled.set(true);
 			return new IntegrationResult(null, null, null);
 		}, null, null);
-		assertThat(integrationStepCalled.get(), is(false));
+		org.assertj.core.api.Assertions.assertThat(integrationStepCalled.get()).isEqualTo(false);
 	}
 
 	@Test
@@ -463,14 +453,14 @@ public class TestBuilder extends BaseTest {
 		Path foo = examplesTestFolder.resolve("noints.java").toAbsolutePath();
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(foo.toString());
-		assertThat(prj.disableIntegrations(), is(true));
+		org.assertj.core.api.Assertions.assertThat(prj.disableIntegrations()).isEqualTo(true);
 		BuildContext ctx = BuildContext.forProject(prj);
 		AtomicBoolean integrationStepCalled = new AtomicBoolean(false);
 		runBuild(ctx, null, (ctxx) -> {
 			integrationStepCalled.set(true);
 			return new IntegrationResult(null, null, null);
 		}, null, null);
-		assertThat(integrationStepCalled.get(), is(false));
+		org.assertj.core.api.Assertions.assertThat(integrationStepCalled.get()).isEqualTo(false);
 	}
 
 	private void runBuild(BuildContext ctx, BiConsumer<BuildContext, List<String>> compileStep,

--- a/src/test/java/dev/jbang/source/TestMain.java
+++ b/src/test/java/dev/jbang/source/TestMain.java
@@ -1,7 +1,6 @@
 package dev.jbang.source;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +48,7 @@ public class TestMain extends BaseTest {
 		try (JarInputStream jarStream = new JarInputStream(Files.newInputStream(ctx.getJarFile()))) {
 			Manifest mf = jarStream.getManifest();
 			String main = mf.getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
-			assertThat(main, equalTo("test.maintest"));
+			assertThat(main).isEqualTo("test.maintest");
 		}
 	}
 
@@ -66,7 +65,7 @@ public class TestMain extends BaseTest {
 		try (JarInputStream jarStream = new JarInputStream(Files.newInputStream(ctx.getJarFile()))) {
 			Manifest mf = jarStream.getManifest();
 			String main = mf.getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
-			assertThat(main, equalTo("test.two"));
+			assertThat(main).isEqualTo("test.two");
 		}
 	}
 
@@ -83,10 +82,10 @@ public class TestMain extends BaseTest {
 		try (JarInputStream jarStream = new JarInputStream(Files.newInputStream(ctx.getJarFile()))) {
 			Manifest mf = jarStream.getManifest();
 			String main = mf.getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
-			assertThat(main, equalTo("test.two"));
+			assertThat(main).isEqualTo("test.two");
 		}
 
 		String cmd = gen.mainClass("test.three").build().generate();
-		assertThat(cmd, containsString("test.three"));
+		assertThat(cmd).contains("test.three");
 	}
 }

--- a/src/test/java/dev/jbang/source/TestModule.java
+++ b/src/test/java/dev/jbang/source/TestModule.java
@@ -1,7 +1,8 @@
 package dev.jbang.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -86,11 +87,11 @@ public class TestModule extends BaseTest {
 				return new JavaCompileBuildStep() {
 					@Override
 					protected void runCompiler(List<String> optionList) throws IOException {
-						assertThat(optionList, hasItems(endsWith("module-info.java")));
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(endsWith("module-info.java"));
 
 						Path modInfo = ctx.getGeneratedSourcesDir().resolve("module-info.java");
 						assertThat(modInfo.toFile(), anExistingFile());
-						assertThat(Util.readFileContent(modInfo), containsString("requires info.picocli;"));
+						org.assertj.core.api.Assertions.assertThat(Util.readFileContent(modInfo)).contains("requires info.picocli;");
 
 						super.runCompiler(optionList);
 					}
@@ -111,7 +112,7 @@ public class TestModule extends BaseTest {
 		}.setFresh(true).build();
 
 		String cmd = gen.build().generate();
-		assertThat(cmd, endsWith(" -m testmodule/test.moduletest"));
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith(" -m testmodule/test.moduletest");
 	}
 
 	@Test
@@ -138,11 +139,11 @@ public class TestModule extends BaseTest {
 				return new JavaCompileBuildStep() {
 					@Override
 					protected void runCompiler(List<String> optionList) throws IOException {
-						assertThat(optionList, hasItems(endsWith("module-info.java")));
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(endsWith("module-info.java"));
 
 						Path modInfo = ctx.getGeneratedSourcesDir().resolve("module-info.java");
 						assertThat(modInfo.toFile(), anExistingFile());
-						assertThat(Util.readFileContent(modInfo), containsString("requires info.picocli;"));
+						org.assertj.core.api.Assertions.assertThat(Util.readFileContent(modInfo)).contains("requires info.picocli;");
 
 						super.runCompiler(optionList);
 					}
@@ -163,7 +164,7 @@ public class TestModule extends BaseTest {
 		}.setFresh(true).build();
 
 		String cmd = gen.build().generate();
-		assertThat(cmd, endsWith(" -m moduletest/test.moduletest"));
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith(" -m moduletest/test.moduletest");
 	}
 
 	@Test
@@ -185,7 +186,7 @@ public class TestModule extends BaseTest {
 				return new JavaCompileBuildStep() {
 					@Override
 					protected void runCompiler(List<String> optionList) {
-						assertThat(optionList, hasItems(endsWith("module-info.java")));
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(endsWith("module-info.java"));
 
 						Path modInfo = ctx.getGeneratedSourcesDir().resolve("module-info.java");
 						assertThat(modInfo.toFile(), not(anExistingFile()));
@@ -196,7 +197,7 @@ public class TestModule extends BaseTest {
 		}.setFresh(true).build();
 
 		String cmd = gen.build().generate();
-		assertThat(cmd, endsWith(" -m testmodule/test.moduletest"));
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith(" -m testmodule/test.moduletest");
 	}
 
 	@Test
@@ -214,11 +215,11 @@ public class TestModule extends BaseTest {
 				return new JavaCompileBuildStep() {
 					@Override
 					protected void runCompiler(List<String> optionList) throws IOException {
-						assertThat(optionList, hasItems(endsWith("module-info.java")));
+						org.assertj.core.api.Assertions.assertThat(optionList).contains(endsWith("module-info.java"));
 
 						Path modInfo = ctx.getGeneratedSourcesDir().resolve("module-info.java");
 						assertThat(modInfo.toFile(), anExistingFile());
-						assertThat(Util.readFileContent(modInfo), containsString("requires info.picocli;"));
+						org.assertj.core.api.Assertions.assertThat(Util.readFileContent(modInfo)).contains("requires info.picocli;");
 
 						super.runCompiler(optionList);
 					}
@@ -227,10 +228,10 @@ public class TestModule extends BaseTest {
 		}.setFresh(true).build();
 
 		String cmd = gen.build().generate();
-		assertThat(cmd, endsWith(" -m testmodule/test.moduletest"));
+		org.assertj.core.api.Assertions.assertThat(cmd).endsWith(" -m testmodule/test.moduletest");
 
 		if (JavaUtil.getCurrentMajorJavaVersion() >= 9) {
-			assertThat(ModuleUtil.getModuleName(ctx.getJarFile()), equalTo("testmodule"));
+			org.assertj.core.api.Assertions.assertThat(ModuleUtil.getModuleName(ctx.getJarFile())).isEqualTo("testmodule");
 		}
 	}
 }

--- a/src/test/java/dev/jbang/source/TestProjectBuilder.java
+++ b/src/test/java/dev/jbang/source/TestProjectBuilder.java
@@ -1,15 +1,7 @@
 package dev.jbang.source;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.aMapWithSize;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -97,50 +89,35 @@ public class TestProjectBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 		Path src = examplesTestFolder.resolve("alltags.java");
 		Project prj = pb.build(src);
-		assertThat(prj.getDescription().get(), equalTo("some description"));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().get()).isEqualTo("some description");
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(2));
-		assertThat(prj.getRuntimeOptions(), contains("--add-opens", "java.base/java.net=ALL-UNNAMED"));
+		org.assertj.core.api.Assertions.assertThat(prj.getRuntimeOptions()).containsExactly("--add-opens", "java.base/java.net=ALL-UNNAMED");
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(6));
-		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				ResourceRef.forFile(src),
-				ResourceRef.forFile(examplesTestFolder.resolve("Two.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("gh_fetch_release_assets.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("gh_release_stats.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedTwo.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedOne.java"))));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getSources()).containsExactlyInAnyOrder(ResourceRef.forFile(src), ResourceRef.forFile(examplesTestFolder.resolve("Two.java")), ResourceRef.forFile(examplesTestFolder.resolve("gh_fetch_release_assets.java")), ResourceRef.forFile(examplesTestFolder.resolve("gh_release_stats.java")), ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedTwo.java")), ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedOne.java")));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(3));
-		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")), null),
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
-						Paths.get("renamed.properties")),
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
-						Paths.get("META-INF/application.properties"))));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getResources()).containsExactlyInAnyOrder(RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")), null), RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
+			Paths.get("renamed.properties")), RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
+			Paths.get("META-INF/application.properties")));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(5));
-		assertThat(prj.getMainSourceSet().getDependencies(), contains(
-				"dummy.org:dummy:1.2.3",
-				"info.picocli:picocli:4.6.3",
-				"org.kohsuke:github-api:1.116",
-				"info.picocli:picocli:4.6.3",
-				"org.kohsuke:github-api:1.116"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getDependencies()).containsExactly("dummy.org:dummy:1.2.3", "info.picocli:picocli:4.6.3", "org.kohsuke:github-api:1.116", "info.picocli:picocli:4.6.3", "org.kohsuke:github-api:1.116");
 		assertThat(prj.getRepositories(), iterableWithSize(1));
-		assertThat(prj.getRepositories(), contains(new MavenRepo("dummy", "http://dummy")));
+		org.assertj.core.api.Assertions.assertThat(prj.getRepositories()).containsExactly(new MavenRepo("dummy", "http://dummy"));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(0));
-		assertThat(prj.getProperties(), anEmptyMap());
-		assertThat(prj.getJavaVersion(), equalTo("11+"));
-		assertThat(prj.getMainClass(), equalTo("mainclass"));
-		assertThat(prj.getModuleName().get(), equalTo("mymodule"));
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).isEmpty();
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isEqualTo("11+");
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("mainclass");
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().get()).isEqualTo("mymodule");
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(4));
-		assertThat(prj.getMainSourceSet().getCompileOptions(),
-				contains("-g", "-parameters", "--enable-preview", "--verbose"));
-		assertThat(prj.isNativeImage(), is(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getCompileOptions()).containsExactly("-g", "-parameters", "--enable-preview", "--verbose");
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(2));
-		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "-d"));
-		assertThat(prj.enableCDS(), is(Boolean.TRUE));
-		assertThat(prj.enablePreview(), is(Boolean.TRUE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(3));
-		assertThat(prj.getManifestAttributes(), hasEntry("one", "1"));
-		assertThat(prj.getManifestAttributes(), hasEntry("two", "2"));
-		assertThat(prj.getManifestAttributes(), hasEntry("three", "3"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getNativeOptions()).containsExactly("-O1", "-d");
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(3);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("one", "1");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("three", "3");
 	}
 
 	@Test
@@ -148,23 +125,23 @@ public class TestProjectBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 		Path src = examplesTestFolder.resolve("hellojar.jar");
 		Project prj = pb.build(src);
-		assertThat(prj.getDescription().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(0));
 		assertThat(prj.getRepositories(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(0));
-		assertThat(prj.getProperties(), anEmptyMap());
-		assertThat(prj.getJavaVersion(), equalTo("8+"));
-		assertThat(prj.getMainClass(), equalTo("helloworld"));
-		assertThat(prj.getModuleName().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).isEmpty();
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isEqualTo("8+");
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("helloworld");
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(0));
-		assertThat(prj.isNativeImage(), is(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(0));
-		assertThat(prj.enableCDS(), is(Boolean.FALSE));
-		assertThat(prj.enablePreview(), is(Boolean.FALSE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(0));
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(0);
 	}
 
 	@Test
@@ -172,24 +149,24 @@ public class TestProjectBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 		String gav = "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r";
 		Project prj = pb.build(gav);
-		assertThat(prj.getDescription().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getDependencies(), contains(gav));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getDependencies()).containsExactly(gav);
 		assertThat(prj.getRepositories(), iterableWithSize(0));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(0));
-		assertThat(prj.getProperties(), anEmptyMap());
-		assertThat(prj.getJavaVersion(), nullValue());
-		assertThat(prj.getMainClass(), equalTo("org.eclipse.jgit.pgm.Main"));
-		assertThat(prj.getModuleName().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).isEmpty();
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isNull();
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("org.eclipse.jgit.pgm.Main");
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(0));
-		assertThat(prj.isNativeImage(), is(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(0));
-		assertThat(prj.enableCDS(), is(Boolean.FALSE));
-		assertThat(prj.enablePreview(), is(Boolean.FALSE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(0));
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.FALSE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(0);
 	}
 
 	@Test
@@ -198,62 +175,42 @@ public class TestProjectBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 		Path src = examplesTestFolder.resolve("alltags.java");
 		Project prj = pb.build("alltags");
-		assertThat(prj.getDescription().get(), equalTo("some description"));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().get()).isEqualTo("some description");
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(4));
-		assertThat(prj.getRuntimeOptions(),
-				contains("--add-opens", "java.base/java.net=ALL-UNNAMED", "-Dfoo=bar", "-Dbar=aap noot mies"));
+		org.assertj.core.api.Assertions.assertThat(prj.getRuntimeOptions()).containsExactly("--add-opens", "java.base/java.net=ALL-UNNAMED", "-Dfoo=bar", "-Dbar=aap noot mies");
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(7));
-		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				new AliasResourceResolver.AliasedResourceRef(prj.getResourceRef(), null),
-				ResourceRef.forFile(examplesTestFolder.resolve("Two.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("gh_fetch_release_assets.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("gh_release_stats.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedTwo.java")),
-				ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedOne.java")),
-				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getSources()).containsExactlyInAnyOrder(new AliasResourceResolver.AliasedResourceRef(prj.getResourceRef(), null), ResourceRef.forFile(examplesTestFolder.resolve("Two.java")), ResourceRef.forFile(examplesTestFolder.resolve("gh_fetch_release_assets.java")), ResourceRef.forFile(examplesTestFolder.resolve("gh_release_stats.java")), ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedTwo.java")), ResourceRef.forFile(examplesTestFolder.resolve("nested/NestedOne.java")), ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java")));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(4));
-		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")), null),
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
-						Paths.get("renamed.properties")),
-				RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
-						Paths.get("META-INF/application.properties")),
-				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
-						examplesTestFolder.resolve("res/test.properties")), null)));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getResources()).containsExactlyInAnyOrder(RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")), null), RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
+			Paths.get("renamed.properties")), RefTarget.create(ResourceRef.forFile(examplesTestFolder.resolve("res/resource.properties")),
+			Paths.get("META-INF/application.properties")), RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
+			examplesTestFolder.resolve("res/test.properties")), null));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(6));
-		assertThat(prj.getMainSourceSet().getDependencies(), contains(
-				"dummy.org:dummy:1.2.3",
-				"info.picocli:picocli:4.6.3",
-				"org.kohsuke:github-api:1.116",
-				"info.picocli:picocli:4.6.3",
-				"org.kohsuke:github-api:1.116",
-				"twodep"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getDependencies()).containsExactly("dummy.org:dummy:1.2.3", "info.picocli:picocli:4.6.3", "org.kohsuke:github-api:1.116", "info.picocli:picocli:4.6.3", "org.kohsuke:github-api:1.116", "twodep");
 		assertThat(prj.getRepositories(), iterableWithSize(2));
-		assertThat(prj.getRepositories(),
-				contains(new MavenRepo("dummy", "http://dummy"), new MavenRepo("tworepo", "tworepo")));
+		org.assertj.core.api.Assertions.assertThat(prj.getRepositories()).containsExactly(new MavenRepo("dummy", "http://dummy"), new MavenRepo("tworepo", "tworepo"));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getClassPaths(), contains("twocp"));
-		assertThat(prj.getProperties(), aMapWithSize(1));
-		assertThat(prj.getProperties(), hasEntry("two", "2"));
-		assertThat(prj.getJavaVersion(), equalTo("twojava"));
-		assertThat(prj.getMainClass(), equalTo("mainclass")); // This is not updated from Alias here!
-		assertThat(prj.getModuleName().get(), equalTo("mymodule")); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getClassPaths()).containsExactly("twocp");
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isEqualTo("twojava");
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("mainclass"); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().get()).isEqualTo("mymodule"); // This is not updated from Alias here!
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(5));
-		assertThat(prj.getMainSourceSet().getCompileOptions(),
-				contains("-g", "-parameters", "--enable-preview", "--verbose", "--ctwo"));
-		assertThat(prj.isNativeImage(), is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getCompileOptions()).containsExactly("-g", "-parameters", "--enable-preview", "--verbose", "--ctwo");
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.TRUE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(4));
-		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "-d", "-O1", "--ntwo"));
-		assertThat(prj.enableCDS(), is(Boolean.TRUE));
-		assertThat(prj.enablePreview(), is(Boolean.TRUE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(7));
-		assertThat(prj.getManifestAttributes(), hasEntry("one", "1"));
-		assertThat(prj.getManifestAttributes(), hasEntry("two", "2"));
-		assertThat(prj.getManifestAttributes(), hasEntry("three", "3"));
-		assertThat(prj.getManifestAttributes(), hasEntry("foo", "true"));
-		assertThat(prj.getManifestAttributes(), hasEntry("bar", "baz"));
-		assertThat(prj.getManifestAttributes(), hasEntry("baz", "nada"));
-		assertThat(prj.getManifestAttributes(), hasEntry("twom", "2"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getNativeOptions()).containsExactly("-O1", "-d", "-O1", "--ntwo");
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(7);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("one", "1");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("three", "3");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("foo", "true");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("bar", "baz");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("baz", "nada");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("twom", "2");
 	}
 
 	@Test
@@ -261,39 +218,37 @@ public class TestProjectBuilder extends BaseTest {
 		Util.setCwd(examplesTestFolder);
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build("hellojar");
-		assertThat(prj.getDescription().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(2));
-		assertThat(prj.getRuntimeOptions(), contains("-Dfoo=bar", "-Dbar=aap noot mies"));
+		org.assertj.core.api.Assertions.assertThat(prj.getRuntimeOptions()).containsExactly("-Dfoo=bar", "-Dbar=aap noot mies");
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getSources()).containsExactlyInAnyOrder(ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java")));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
-						examplesTestFolder.resolve("res/test.properties")), null)));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getResources()).containsExactlyInAnyOrder(RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
+			examplesTestFolder.resolve("res/test.properties")), null));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getDependencies(), contains("twodep"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getDependencies()).containsExactly("twodep");
 		assertThat(prj.getRepositories(), iterableWithSize(1));
-		assertThat(prj.getRepositories(), contains(new MavenRepo("tworepo", "tworepo")));
+		org.assertj.core.api.Assertions.assertThat(prj.getRepositories()).containsExactly(new MavenRepo("tworepo", "tworepo"));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getClassPaths(), contains("twocp"));
-		assertThat(prj.getProperties(), aMapWithSize(1));
-		assertThat(prj.getProperties(), hasEntry("two", "2"));
-		assertThat(prj.getJavaVersion(), equalTo("twojava"));
-		assertThat(prj.getMainClass(), equalTo("helloworld")); // This is not updated from Alias here!
-		assertThat(prj.getModuleName().isPresent(), equalTo(Boolean.FALSE)); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getClassPaths()).containsExactly("twocp");
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isEqualTo("twojava");
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("helloworld"); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().isPresent()).isEqualTo(Boolean.FALSE); // This is not updated from Alias here!
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getCompileOptions(), contains("--ctwo"));
-		assertThat(prj.isNativeImage(), is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getCompileOptions()).containsExactly("--ctwo");
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.TRUE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(2));
-		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "--ntwo"));
-		assertThat(prj.enableCDS(), is(Boolean.FALSE)); // This is not updated from Alias here!
-		assertThat(prj.enablePreview(), is(Boolean.TRUE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(4));
-		assertThat(prj.getManifestAttributes(), hasEntry("foo", "true"));
-		assertThat(prj.getManifestAttributes(), hasEntry("bar", "baz"));
-		assertThat(prj.getManifestAttributes(), hasEntry("baz", "nada"));
-		assertThat(prj.getManifestAttributes(), hasEntry("twom", "2"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getNativeOptions()).containsExactly("-O1", "--ntwo");
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.FALSE); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(4);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("foo", "true");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("bar", "baz");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("baz", "nada");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("twom", "2");
 	}
 
 	@Test
@@ -302,40 +257,36 @@ public class TestProjectBuilder extends BaseTest {
 		ProjectBuilder pb = Project.builder();
 		String gav = "org.eclipse.jgit:org.eclipse.jgit.pgm:5.9.0.202009080501-r";
 		Project prj = pb.build("pgmgav");
-		assertThat(prj.getDescription().isPresent(), equalTo(Boolean.FALSE));
+		org.assertj.core.api.Assertions.assertThat(prj.getDescription().isPresent()).isEqualTo(Boolean.FALSE);
 		assertThat(prj.getRuntimeOptions(), iterableWithSize(2));
-		assertThat(prj.getRuntimeOptions(), contains("-Dfoo=bar", "-Dbar=aap noot mies"));
+		org.assertj.core.api.Assertions.assertThat(prj.getRuntimeOptions()).containsExactly("-Dfoo=bar", "-Dbar=aap noot mies");
 		assertThat(prj.getMainSourceSet().getSources(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getSources(), containsInAnyOrder(
-				ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java"))));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getSources()).containsExactlyInAnyOrder(ResourceRef.forResolvedResource("helloworld.java", examplesTestFolder.resolve("helloworld.java")));
 		assertThat(prj.getMainSourceSet().getResources(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getResources(), containsInAnyOrder(
-				RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
-						examplesTestFolder.resolve("res/test.properties")), null)));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getResources()).containsExactlyInAnyOrder(RefTarget.create(ResourceRef.forResolvedResource("res/test.properties",
+			examplesTestFolder.resolve("res/test.properties")), null));
 		assertThat(prj.getMainSourceSet().getDependencies(), iterableWithSize(2));
-		assertThat(prj.getMainSourceSet().getDependencies(), contains(
-				gav, "info.picocli:picocli:4.6.3"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getDependencies()).containsExactly(gav, "info.picocli:picocli:4.6.3");
 		assertThat(prj.getRepositories(), iterableWithSize(2));
-		assertThat(prj.getRepositories(), contains(new MavenRepo("mavencentral", "https://repo1.maven.org/maven2/"),
-				new MavenRepo("tworepo", "tworepo")));
+		org.assertj.core.api.Assertions.assertThat(prj.getRepositories()).containsExactly(new MavenRepo("mavencentral", "https://repo1.maven.org/maven2/"), new MavenRepo("tworepo", "tworepo"));
 		assertThat(prj.getMainSourceSet().getClassPaths(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getClassPaths(), contains("twocp"));
-		assertThat(prj.getProperties(), aMapWithSize(1));
-		assertThat(prj.getProperties(), hasEntry("two", "2"));
-		assertThat(prj.getJavaVersion(), equalTo("twojava"));
-		assertThat(prj.getMainClass(), equalTo("org.eclipse.jgit.pgm.Main")); // This is not updated from Alias here!
-		assertThat(prj.getModuleName().isPresent(), equalTo(Boolean.FALSE)); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getClassPaths()).containsExactly("twocp");
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).hasSize(1);
+		org.assertj.core.api.Assertions.assertThat(prj.getProperties()).containsEntry("two", "2");
+		org.assertj.core.api.Assertions.assertThat(prj.getJavaVersion()).isEqualTo("twojava");
+		org.assertj.core.api.Assertions.assertThat(prj.getMainClass()).isEqualTo("org.eclipse.jgit.pgm.Main"); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.getModuleName().isPresent()).isEqualTo(Boolean.FALSE); // This is not updated from Alias here!
 		assertThat(prj.getMainSourceSet().getCompileOptions(), iterableWithSize(1));
-		assertThat(prj.getMainSourceSet().getCompileOptions(), contains("--ctwo"));
-		assertThat(prj.isNativeImage(), is(Boolean.TRUE));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getCompileOptions()).containsExactly("--ctwo");
+		org.assertj.core.api.Assertions.assertThat(prj.isNativeImage()).isEqualTo(Boolean.TRUE);
 		assertThat(prj.getMainSourceSet().getNativeOptions(), iterableWithSize(2));
-		assertThat(prj.getMainSourceSet().getNativeOptions(), contains("-O1", "--ntwo"));
-		assertThat(prj.enableCDS(), is(Boolean.FALSE)); // This is not updated from Alias here!
-		assertThat(prj.enablePreview(), is(Boolean.TRUE));
-		assertThat(prj.getManifestAttributes(), aMapWithSize(4));
-		assertThat(prj.getManifestAttributes(), hasEntry("foo", "true"));
-		assertThat(prj.getManifestAttributes(), hasEntry("bar", "baz"));
-		assertThat(prj.getManifestAttributes(), hasEntry("baz", "nada"));
-		assertThat(prj.getManifestAttributes(), hasEntry("twom", "2"));
+		org.assertj.core.api.Assertions.assertThat(prj.getMainSourceSet().getNativeOptions()).containsExactly("-O1", "--ntwo");
+		org.assertj.core.api.Assertions.assertThat(prj.enableCDS()).isEqualTo(Boolean.FALSE); // This is not updated from Alias here!
+		org.assertj.core.api.Assertions.assertThat(prj.enablePreview()).isEqualTo(Boolean.TRUE);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).hasSize(4);
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("foo", "true");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("bar", "baz");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("baz", "nada");
+		org.assertj.core.api.Assertions.assertThat(prj.getManifestAttributes()).containsEntry("twom", "2");
 	}
 }

--- a/src/test/java/dev/jbang/source/TestSource.java
+++ b/src/test/java/dev/jbang/source/TestSource.java
@@ -1,8 +1,7 @@
 package dev.jbang.source;
 
 import static dev.jbang.util.Util.writeString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -184,7 +183,7 @@ public class TestSource extends BaseTest {
 
 		List<String> deps = prj.getMainSourceSet().getDependencies();
 
-		assertThat(deps, containsInAnyOrder("info.picocli:picocli:4.6.3"));
+		assertThat(deps).containsExactlyInAnyOrder("info.picocli:picocli:4.6.3");
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/source/TestTagReader.java
+++ b/src/test/java/dev/jbang/source/TestTagReader.java
@@ -1,8 +1,6 @@
 package dev.jbang.source;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasItem;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
@@ -18,10 +16,10 @@ public class TestTagReader {
 				"//DEPS foo:bar, abc:DEF:123, https://github.com/jbangdev/jbang, something", null);
 
 		List<String> deps = tr.collectBinaryDependencies();
-		assertThat(deps, containsInAnyOrder("foo:bar", "abc:DEF:123", "https://github.com/jbangdev/jbang"));
+		assertThat(deps).containsExactlyInAnyOrder("foo:bar", "abc:DEF:123", "https://github.com/jbangdev/jbang");
 
 		List<String> subs = tr.collectSourceDependencies();
-		assertThat(subs, containsInAnyOrder("something"));
+		assertThat(subs).containsExactlyInAnyOrder("something");
 	}
 
 	@Test
@@ -30,25 +28,25 @@ public class TestTagReader {
 				"//DEPS foo:bar, abc:DEF:123, \thttps://github.com/jbangdev/jbang \tsomething\t ", null);
 
 		List<String> deps = tr.collectBinaryDependencies();
-		assertThat(deps, containsInAnyOrder("foo:bar", "abc:DEF:123", "https://github.com/jbangdev/jbang"));
+		assertThat(deps).containsExactlyInAnyOrder("foo:bar", "abc:DEF:123", "https://github.com/jbangdev/jbang");
 
 		List<String> subs = tr.collectSourceDependencies();
-		assertThat(subs, containsInAnyOrder("something"));
+		assertThat(subs).containsExactlyInAnyOrder("something");
 	}
 
 	@Test
 	void textExtractRepositories() {
 		List<MavenRepo> repos = new TagReader.Extended("//REPOS jcenter=https://xyz.org", null).collectRepositories();
 
-		assertThat(repos, hasItem(new MavenRepo("jcenter", "https://xyz.org")));
+		assertThat(repos).contains(new MavenRepo("jcenter", "https://xyz.org"));
 
 		repos = new TagReader.Extended("//REPOS jcenter=https://xyz.org localMaven xyz=file://~test",
 				null)
 			.collectRepositories();
 
-		assertThat(repos, hasItem(new MavenRepo("jcenter", "https://xyz.org")));
-		assertThat(repos, hasItem(new MavenRepo("localmaven", "localMaven")));
-		assertThat(repos, hasItem(new MavenRepo("xyz", "file://~test")));
+		assertThat(repos).contains(new MavenRepo("jcenter", "https://xyz.org"));
+		assertThat(repos).contains(new MavenRepo("localmaven", "localMaven"));
+		assertThat(repos).contains(new MavenRepo("xyz", "file://~test"));
 	}
 
 	@Test
@@ -57,12 +55,12 @@ public class TestTagReader {
 				"@GrabResolver(name=\"restlet.org\", root=\"http://maven.restlet.org\")", null)
 			.collectRepositories();
 
-		assertThat(deps, hasItem(new MavenRepo("restlet.org", "http://maven.restlet.org")));
+		assertThat(deps).contains(new MavenRepo("restlet.org", "http://maven.restlet.org"));
 
 		deps = new TagReader.Extended("@GrabResolver(\"http://maven.restlet.org\")", null)
 			.collectRepositories();
 
-		assertThat(deps, hasItem(new MavenRepo("http://maven.restlet.org", "http://maven.restlet.org")));
+		assertThat(deps).contains(new MavenRepo("http://maven.restlet.org", "http://maven.restlet.org"));
 
 	}
 }

--- a/src/test/java/dev/jbang/util/TestCommandBuffer.java
+++ b/src/test/java/dev/jbang/util/TestCommandBuffer.java
@@ -20,10 +20,10 @@ public class TestCommandBuffer extends BaseTest {
 	void testRunWinBat() {
 		String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
 				"abc=def", "abc,def");
-		assertThat(out, containsString("ARG = abc def"));
-		assertThat(out, containsString("ARG = abc;def"));
-		assertThat(out, containsString("ARG = abc=def"));
-		assertThat(out, containsString("ARG = abc,def"));
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc;def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc=def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc,def");
 	}
 
 	@Test
@@ -32,17 +32,17 @@ public class TestCommandBuffer extends BaseTest {
 		environmentVariables.set(JBANG_RUNTIME_SHELL, "bash");
 		String out = Util.runCommand(examplesTestFolder.resolve("echo.bat").toString(), "abc def", "abc;def",
 				"abc=def", "abc,def");
-		assertThat(out, containsString("ARG = abc def"));
-		assertThat(out, containsString("ARG = abc;def"));
-		assertThat(out, containsString("ARG = abc=def"));
-		assertThat(out, containsString("ARG = abc,def"));
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc;def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc=def");
+		org.assertj.core.api.Assertions.assertThat(out).contains("ARG = abc,def");
 	}
 
 	@Test
 	@EnabledOnOs(OS.WINDOWS)
 	void testRunWinPS1() {
 		String out = CommandBuffer.of("abc def", "abc;def").shell(Util.Shell.powershell).asCommandLine();
-		assertThat(out, equalTo("'abc def' 'abc;def'"));
+		org.assertj.core.api.Assertions.assertThat(out).isEqualTo("'abc def' 'abc;def'");
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.cmd)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), greaterThan(2));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isGreaterThan(2);
 		assertThat(pb.command().get(1), not(anyOf(startsWith("@"), startsWith("\"@"))));
 	}
 
@@ -63,8 +63,12 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.cmd)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
@@ -74,7 +78,7 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.bash)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), greaterThan(2));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isGreaterThan(2);
 		assertThat(pb.command().get(1), not(anyOf(startsWith("@"), startsWith("\"@"))));
 	}
 
@@ -85,8 +89,12 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.cmd)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
@@ -96,8 +104,12 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.bash)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
@@ -107,8 +119,12 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.cmd)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
@@ -118,28 +134,36 @@ public class TestCommandBuffer extends BaseTest {
 			.shell(Util.Shell.bash)
 			.applyWindowsMaxProcessLimit()
 			.asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
 	void testUsingArgsFileWith1Arg() throws IOException {
 		ProcessBuilder pb = CommandBuffer.of("abc").usingArgsFile().asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(1));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(1);
 	}
 
 	@Test
 	void testUsingArgsFileWith3Args() throws IOException {
 		ProcessBuilder pb = CommandBuffer.of("abc", "def", "ghi").usingArgsFile().asProcessBuilder();
-		assertThat(pb.command().size(), equalTo(2));
-		assertThat(pb.command().get(1), anyOf(startsWith("@"), startsWith("\"@")));
+		org.assertj.core.api.Assertions.assertThat(pb.command().size()).isEqualTo(2);
+		org.assertj.core.api.Assertions.assertThat(pb.command().get(1))
+			.satisfiesAnyOf(
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("@"),
+				arg -> org.assertj.core.api.Assertions.assertThat(arg).startsWith("\"@")
+			);
 	}
 
 	@Test
 	void testUsingArgsFileNoDup() throws IOException {
 		CommandBuffer cmd = CommandBuffer.of("abc", "def", "ghi").usingArgsFile();
 		CommandBuffer cmd2 = cmd.usingArgsFile();
-		assertThat(cmd, is(cmd2));
+		org.assertj.core.api.Assertions.assertThat(cmd).isEqualTo(cmd2);
 	}
 
 	private String[] argsTooLong(String cmd, int cnt) {

--- a/src/test/java/dev/jbang/util/TestUtil.java
+++ b/src/test/java/dev/jbang/util/TestUtil.java
@@ -1,11 +1,7 @@
 package dev.jbang.util;
 
 import static dev.jbang.util.Util.ConnectionConfigurator.authentication;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.not;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
@@ -98,22 +94,22 @@ public class TestUtil extends BaseTest {
 
 		final List<String> p = Util.explode(source, baseDir, "**.java");
 
-		assertThat(p, hasItem("res/resource.java"));
-		assertThat(p, not(hasItem("hello.jsh")));
-		assertThat(p, hasItem("quote.java"));
+		assertThat(p).contains("res/resource.java");
+		assertThat(p).doesNotContain("hello.jsh");
+		assertThat(p).contains("quote.java");
 
 		p.clear();
 		p.addAll(Util.explode(source, baseDir, "**/*.java"));
 
-		assertThat(p, hasItem("res/resource.java"));
-		assertThat(p, not(hasItem("quote.java")));
-		assertThat(p, not(hasItem("main.jsh")));
+		assertThat(p).contains("res/resource.java");
+		assertThat(p).doesNotContain("quote.java");
+		assertThat(p).doesNotContain("main.jsh");
 
 		p.clear();
 		p.addAll(Util.explode(source, baseDir, "res/resource.java"));
 
-		assertThat(p, containsInAnyOrder("res/resource.java"));
-		assertThat(p, not(hasItem("test.java")));
+		assertThat(p).containsExactlyInAnyOrder("res/resource.java");
+		assertThat(p).doesNotContain("test.java");
 
 	}
 
@@ -126,38 +122,35 @@ public class TestUtil extends BaseTest {
 
 		final List<String> p = Util.explode(source, cwdDir, dir + "/**.java");
 
-		assertThat(p, hasItem(dir + "/res/resource.java"));
-		assertThat(p, not(hasItem(dir + "/hello.jsh")));
-		assertThat(p, hasItem(dir + "/quote.java"));
+		assertThat(p).contains(dir + "/res/resource.java");
+		assertThat(p).doesNotContain(dir + "/hello.jsh");
+		assertThat(p).contains(dir + "/quote.java");
 
 		p.clear();
 		p.addAll(Util.explode(source, cwdDir, dir + "/**/*.java"));
 
-		assertThat(p, hasItem(dir + "/res/resource.java"));
-		assertThat(p, not(hasItem(dir + "/quote.java")));
-		assertThat(p, not(hasItem(dir + "/main.jsh")));
+		assertThat(p).contains(dir + "/res/resource.java");
+		assertThat(p).doesNotContain(dir + "/quote.java");
+		assertThat(p).doesNotContain(dir + "/main.jsh");
 
 		p.clear();
 		p.addAll(Util.explode(source, cwdDir, dir + "/res/resource.java"));
 
-		assertThat(p, containsInAnyOrder(dir + "/res/resource.java"));
-		assertThat(p, not(hasItem(dir + "/test.java")));
+		assertThat(p).containsExactlyInAnyOrder(dir + "/res/resource.java");
+		assertThat(p).doesNotContain(dir + "/test.java");
 
 	}
 
 	@Test
 	void testDispostionFilename() {
-		assertThat(Util.getDispositionFilename("inline; filename=token"), equalTo("token"));
-		assertThat(Util.getDispositionFilename("inline; filename=\"quoted string\""), equalTo("quoted string"));
-		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates"), equalTo("£ rates"));
-		assertThat(Util.getDispositionFilename("inline; filename*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates"),
-				equalTo("£ and € rates"));
-		assertThat(Util.getDispositionFilename("inline; filename=token; filename*=iso-8859-1'en'%A3%20rates"),
-				equalTo("£ rates"));
+		assertThat(Util.getDispositionFilename("inline; filename=token")).isEqualTo("token");
+		assertThat(Util.getDispositionFilename("inline; filename=\"quoted string\"")).isEqualTo("quoted string");
+		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates")).isEqualTo("£ rates");
+		assertThat(Util.getDispositionFilename("inline; filename*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates")).isEqualTo("£ and € rates");
+		assertThat(Util.getDispositionFilename("inline; filename=token; filename*=iso-8859-1'en'%A3%20rates")).isEqualTo("£ rates");
 		// The spec actually tells us to always use filename* but our implementation is
 		// too dumb for that
-		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates; filename=token"),
-				equalTo("token"));
+		assertThat(Util.getDispositionFilename("inline; filename*=iso-8859-1'en'%A3%20rates; filename=token")).isEqualTo("token");
 		// assertThat(Util.getDispositionFilename("inline;
 		// filename*=iso-fake-1''dummy"), equalTo(""));
 	}
@@ -171,26 +164,25 @@ public class TestUtil extends BaseTest {
 
 		authentication().configure(connection);
 
-		assertThat(connection.getRequestProperty("Authorization"),
-				equalTo("Basic Sm9obkRvZTpWZXJ5U3Ryb25nUGFzc3dvcmQx"));
+		assertThat(connection.getRequestProperty("Authorization")).isEqualTo("Basic Sm9obkRvZTpWZXJ5U3Ryb25nUGFzc3dvcmQx");
 	}
 
 	@Test
 	void testToJavaIdentifier() {
 		// dont get a leading underscore if a valid name
-		assertThat(Util.toJavaIdentifier("HelloWorld"), equalTo("HelloWorld"));
-		assertThat(Util.toJavaIdentifier("_underscore"), equalTo("_underscore"));
-		assertThat(Util.toJavaIdentifier("Ångström"), equalTo("Ångström"));
-		assertThat(Util.toJavaIdentifier("café"), equalTo("café"));
+		assertThat(Util.toJavaIdentifier("HelloWorld")).isEqualTo("HelloWorld");
+		assertThat(Util.toJavaIdentifier("_underscore")).isEqualTo("_underscore");
+		assertThat(Util.toJavaIdentifier("Ångström")).isEqualTo("Ångström");
+		assertThat(Util.toJavaIdentifier("café")).isEqualTo("café");
 
 		// Leading digits are handled by the extra underscore
-		assertThat(Util.toJavaIdentifier("123abc"), equalTo("_123abc"));
-		assertThat(Util.toJavaIdentifier("0test"), equalTo("_0test"));
+		assertThat(Util.toJavaIdentifier("123abc")).isEqualTo("_123abc");
+		assertThat(Util.toJavaIdentifier("0test")).isEqualTo("_0test");
 
 		// Invalid characters are replaced with underscores
-		assertThat(Util.toJavaIdentifier("foo-bar"), equalTo("_foo_bar"));
-		assertThat(Util.toJavaIdentifier("hello world"), equalTo("_hello_world"));
-		assertThat(Util.toJavaIdentifier("my.package.Class"), equalTo("_my_package_Class"));
-		assertThat(Util.toJavaIdentifier("test+plus"), equalTo("_test_plus"));
+		assertThat(Util.toJavaIdentifier("foo-bar")).isEqualTo("_foo_bar");
+		assertThat(Util.toJavaIdentifier("hello world")).isEqualTo("_hello_world");
+		assertThat(Util.toJavaIdentifier("my.package.Class")).isEqualTo("_my_package_Class");
+		assertThat(Util.toJavaIdentifier("test+plus")).isEqualTo("_test_plus");
 	}
 }

--- a/src/test/java/dev/jbang/util/TestUtilDownloads.java
+++ b/src/test/java/dev/jbang/util/TestUtilDownloads.java
@@ -2,7 +2,6 @@ package dev.jbang.util;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
 import static org.hamcrest.io.FileMatchers.anExistingFile;
 
 import java.io.IOException;
@@ -47,7 +46,7 @@ public class TestUtilDownloads extends BaseTest {
 		String url = wmri.getHttpBaseUrl() + "/test.txt";
 		Path file = Util.downloadAndCacheFile(url);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 	}
 
 	@Test
@@ -67,7 +66,7 @@ public class TestUtilDownloads extends BaseTest {
 		ZonedDateTime zlmt = ZonedDateTime.ofInstant(lmt.toInstant(), ZoneId.of("GMT"));
 		String cachedLastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(zlmt);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		Thread.sleep(1100);
 
@@ -83,9 +82,9 @@ public class TestUtilDownloads extends BaseTest {
 		Util.withCacheEvict("0", () -> {
 			Path file2 = Util.downloadAndCacheFile(url);
 			assertThat(file2.toFile(), anExistingFile());
-			assertThat(file2, equalTo(file));
-			assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-			assertThat(Util.readString(file2), is("test2"));
+			org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+			org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+			org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 			return 0;
 		});
 	}
@@ -105,7 +104,7 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		Thread.sleep(1100);
 
@@ -120,9 +119,9 @@ public class TestUtilDownloads extends BaseTest {
 		Util.freshly(() -> {
 			Path file2 = Util.downloadAndCacheFile(url);
 			assertThat(file2.toFile(), anExistingFile());
-			assertThat(file2, equalTo(file));
-			assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-			assertThat(Util.readString(file2), is("test2"));
+			org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+			org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+			org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 			return null;
 		});
 	}
@@ -146,7 +145,7 @@ public class TestUtilDownloads extends BaseTest {
 		ZonedDateTime zlmt = ZonedDateTime.ofInstant(lmt.toInstant(), ZoneId.of("GMT"));
 		String cachedLastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(zlmt);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -162,9 +161,9 @@ public class TestUtilDownloads extends BaseTest {
 
 		Path file2 = Util.downloadAndCacheFile(url);
 		assertThat(file2.toFile(), anExistingFile());
-		assertThat(file2, equalTo(file));
-		assertThat(Files.getLastModifiedTime(file2), greaterThanOrEqualTo(lmt));
-		assertThat(Util.readString(file2), is("test"));
+		org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+		org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isGreaterThanOrEqualTo(lmt);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test");
 	}
 
 	@Test
@@ -184,7 +183,7 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		Thread.sleep(1100);
 
@@ -199,9 +198,9 @@ public class TestUtilDownloads extends BaseTest {
 		Util.withCacheEvict("0", () -> {
 			Path file2 = Util.downloadAndCacheFile(url);
 			assertThat(file2.toFile(), anExistingFile());
-			assertThat(file2, equalTo(file));
-			assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-			assertThat(Util.readString(file2), is("test2"));
+			org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+			org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+			org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 			return 0;
 		});
 	}
@@ -225,7 +224,7 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -237,9 +236,9 @@ public class TestUtilDownloads extends BaseTest {
 
 		Path file2 = Util.downloadAndCacheFile(url);
 		assertThat(file2.toFile(), anExistingFile());
-		assertThat(file2, equalTo(file));
-		assertThat(Files.getLastModifiedTime(file2), equalTo(lmt));
-		assertThat(Util.readString(file2), is("test"));
+		org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+		org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isEqualTo(lmt);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test");
 	}
 
 	@Test
@@ -261,7 +260,7 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		Thread.sleep(1100);
 
@@ -275,9 +274,9 @@ public class TestUtilDownloads extends BaseTest {
 
 		Path file2 = Util.downloadAndCacheFile(url);
 		assertThat(file2.toFile(), anExistingFile());
-		assertThat(file2, equalTo(file));
-		assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-		assertThat(Util.readString(file2), is("test2"));
+		org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+		org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 	}
 
 	@Test
@@ -299,7 +298,7 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 
 		Thread.sleep(1100);
 
@@ -313,9 +312,9 @@ public class TestUtilDownloads extends BaseTest {
 
 		Path file2 = Util.downloadAndCacheFile(url);
 		assertThat(file2.toFile(), anExistingFile());
-		assertThat(file2, equalTo(file));
-		assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-		assertThat(Util.readString(file2), is("test2"));
+		org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+		org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 	}
 
 	@Test
@@ -336,10 +335,10 @@ public class TestUtilDownloads extends BaseTest {
 		ZonedDateTime zlmt = ZonedDateTime.ofInstant(lmt.toInstant(), ZoneId.of("GMT"));
 		String cachedLastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(zlmt);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 		Path etag = Util.etagFile(file, Util.getCacheMetaDir(file.getParent()));
 		assertThat(etag.toFile(), anExistingFile());
-		assertThat(Util.readString(etag), is("tag1"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(etag)).isEqualTo("tag1");
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -353,12 +352,12 @@ public class TestUtilDownloads extends BaseTest {
 
 		Path file2 = Util.downloadAndCacheFile(url);
 		assertThat(file2.toFile(), anExistingFile());
-		assertThat(file2, equalTo(file));
-		assertThat(Files.getLastModifiedTime(file2), greaterThanOrEqualTo(lmt));
-		assertThat(Util.readString(file2), is("test"));
+		org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+		org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isGreaterThanOrEqualTo(lmt);
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test");
 		Path etag2 = Util.etagFile(file, Util.getCacheMetaDir(file2.getParent()));
 		assertThat(etag2.toFile(), anExistingFile());
-		assertThat(Util.readString(etag2), is("tag1"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(etag2)).isEqualTo("tag1");
 	}
 
 	@Test
@@ -377,10 +376,10 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = Util.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 		Path etag = Util.etagFile(file, Util.getCacheMetaDir(file.getParent()));
 		assertThat(etag.toFile(), anExistingFile());
-		assertThat(Util.readString(etag), is("tag1"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(etag)).isEqualTo("tag1");
 
 		Thread.sleep(1100);
 
@@ -394,12 +393,12 @@ public class TestUtilDownloads extends BaseTest {
 		Util.withCacheEvict("0", () -> {
 			Path file2 = Util.downloadAndCacheFile(url);
 			assertThat(file2.toFile(), anExistingFile());
-			assertThat(file2, equalTo(file));
-			assertThat(Files.getLastModifiedTime(file2), not(equalTo(lmt)));
-			assertThat(Util.readString(file2), is("test2"));
+			org.assertj.core.api.Assertions.assertThat(file2).isEqualTo(file);
+			org.assertj.core.api.Assertions.assertThat(Files.getLastModifiedTime(file2)).isNotEqualTo(lmt);
+			org.assertj.core.api.Assertions.assertThat(Util.readString(file2)).isEqualTo("test2");
 			Path etag2 = Util.etagFile(file, Util.getCacheMetaDir(file2.getParent()));
 			assertThat(etag2.toFile(), anExistingFile());
-			assertThat(Util.readString(etag2), is("tag2"));
+			org.assertj.core.api.Assertions.assertThat(Util.readString(etag2)).isEqualTo("tag2");
 			return 0;
 		});
 	}
@@ -417,7 +416,7 @@ public class TestUtilDownloads extends BaseTest {
 		String url = wmri.getHttpBaseUrl() + "/test.txt?path=foo/bar";
 		Path file = Util.downloadAndCacheFile(url);
 		assertThat(file.toFile(), anExistingFile());
-		assertThat(Util.readString(file), is("test"));
+		org.assertj.core.api.Assertions.assertThat(Util.readString(file)).isEqualTo("test");
 	}
 
 	private static ValueMatcher<Request> withoutHeader(String hdr) {


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.java.testing.hamcrest.MigrateHamcrestToAssertJ?organizationId=QUxML09wZW4gU291cmNlL0pCYW5n