### PR TITLE
include version.txt in distributions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -505,6 +505,8 @@ task clidoc(type: Exec) {
 //didn't find better way yet.
 distZip.dependsOn(versionTxt)
 distTar.dependsOn(versionTxt)
+latestDistZip.dependsOn(versionTxt)
+latestDistTar.dependsOn(versionTxt)
 
 build.dependsOn(latestDistZip)
 build.dependsOn(latestDistTar)


### PR DESCRIPTION
this fixes #1047 but I'm actually not even sure we want it in there at all.

@quintesse this would put a /version.txt in all the distributions - do we want that? any overlap in some install mechanisms?
should it have a different name?

if we don't need it I'll make a PR that removes the unnecessary attempt on including the file - our GitHub Action builds does rely on the file but only on filesystem not in the built archives.