### PR TITLE
fix: code should not rely on MavenCoordinate equals/hashcode

### DIFF
--- a/src/main/java/dev/jbang/dependencies/MavenCoordinate.java
+++ b/src/main/java/dev/jbang/dependencies/MavenCoordinate.java
@@ -1,6 +1,5 @@
 package dev.jbang.dependencies;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -8,6 +7,18 @@ import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+/**
+ * 
+ * MavenCoordinate should not implement euqals as it is not meaningfull to use
+ * as a key in a set as it can have version ranges / different behaviors.
+ * 
+ * At least at time of writing ModuleUtil had code making the assumption you
+ * could look up in set/list of deps. Thus removing it until proven otherwise it
+ * is needed/useful.
+ * 
+ * Use getManagmentKey() if you want to see if dependency exist in list of
+ * dpeendencies. Or resolve it fully into an artifact. a
+ */
 public class MavenCoordinate {
 	private final String groupId;
 	private final String artifactId;
@@ -23,6 +34,7 @@ public class MavenCoordinate {
 
 	private static final Pattern canonicalPattern = Pattern.compile(
 			"^(?<groupid>[^:]*):(?<artifactid>[^:]*)((:(?<type>.*)(:(?<classifier>[^@]*))?)?:(?<version>[^:@]*))?$");
+	private String managementKey;
 
 	public String getGroupId() {
 		return groupId;
@@ -46,6 +58,19 @@ public class MavenCoordinate {
 
 	public static MavenCoordinate fromString(String depId) {
 		return parse(depId, gavPattern);
+	}
+
+	/**
+	 * @return the management key as <code>groupId:artifactId:type</code>
+	 *
+	 *         This is when want to know what dependency this is about ignoring
+	 *         versionrange or any additional properties.
+	 */
+	public String getManagementKey() {
+		if (managementKey == null) {
+			managementKey = groupId + ":" + artifactId + ":" + type + (classifier != null ? ":" + classifier : "");
+		}
+		return managementKey;
 	}
 
 	public static MavenCoordinate fromCanonicalString(String depId) {
@@ -131,19 +156,13 @@ public class MavenCoordinate {
 	}
 
 	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		MavenCoordinate that = (MavenCoordinate) o;
-		return groupId.equals(that.groupId) && artifactId.equals(that.artifactId)
-				&& Objects.equals(version, that.version) && Objects.equals(classifier, that.classifier)
-				&& Objects.equals(type, that.type);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(groupId, artifactId, version, classifier, type);
+	public String toString() {
+		return "MavenCoordinate{" +
+				"groupId='" + groupId + '\'' +
+				", artifactId='" + artifactId + '\'' +
+				", version='" + version + '\'' +
+				", classifier='" + classifier + '\'' +
+				", type='" + type + '\'' +
+				'}';
 	}
 }

--- a/src/main/java/dev/jbang/util/ModuleUtil.java
+++ b/src/main/java/dev/jbang/util/ModuleUtil.java
@@ -6,8 +6,9 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -81,17 +82,17 @@ public class ModuleUtil {
 			Util.warnMsg("Could not locate module-info.java template");
 		} else {
 			// First get the list of root dependencies as proper maven coordinates
-			Set<MavenCoordinate> deps = project.getMainSourceSet()
+			Map<String, MavenCoordinate> deps = project.getMainSourceSet()
 				.getDependencies()
 				.stream()
 				.map(MavenCoordinate::fromString)
-				.collect(Collectors.toSet());
+				.collect(Collectors.toMap(MavenCoordinate::getManagementKey, Function.identity()));
 			// Now filter out the resolved artifacts that are root dependencies
 			// and get their names
 			Stream<String> depModNames = ctx.resolveClassPath()
 				.getArtifacts()
 				.stream()
-				.filter(a -> deps.contains(a.getCoordinate()))
+				.filter(a -> deps.containsKey(a.getCoordinate().getManagementKey()))
 				.map(ArtifactInfo::getModuleName)
 				.filter(Objects::nonNull);
 			// And join this list of names with the JDK module names

--- a/src/test/java/dev/jbang/source/TestModule.java
+++ b/src/test/java/dev/jbang/source/TestModule.java
@@ -43,6 +43,15 @@ public class TestModule extends BaseTest {
 			"    }\n" +
 			"}\n";
 
+	String srcWithEmptyVersionRangeDep = "//MODULE\n" +
+			"//DEPS info.picocli:picocli:4.6+\n" +
+			"package test;" +
+			"public class moduletest {\n" +
+			"    public static void main(String... args) {\n" +
+			"        System.out.println(\"Hello World\");\n" +
+			"    }\n" +
+			"}\n";
+
 	String srcWithEmptyModDep = "//MODULE\n" +
 			"//DEPS info.picocli:picocli:4.6.3\n" +
 			"package test;" +
@@ -122,6 +131,11 @@ public class TestModule extends BaseTest {
 	@Test
 	void testEmptyModuleTrailingWhiteSpaces(@TempDir File output) throws IOException {
 		testEmptyModule(srcWithEmptyModDep.replace("//MODULE", "//MODULE  \t  "), output);
+	}
+
+	@Test
+	void testEmptyVersionRangedModule(@TempDir File output) throws IOException {
+		testEmptyModule(srcWithEmptyVersionRangeDep, output);
 	}
 
 	void testEmptyModule(String script, File output) throws IOException {


### PR DESCRIPTION
While doing #2133 i spotted that ModuleUtil relied on MavenCoordinate to be used as key in list - that wont do what you most likely want given a mavencoordinate is more like a "request for a dependency" so it can have version ranges in it and soon scope info. 

So I'm isolating this fix as I believe its a bug on its own right and to not make scope deps fix having too many things in it.

