### PR TITLE
fix: this fixes part of the slowness on startup

### DIFF
--- a/src/it/java/dev/jbang/it/BaseIT.java
+++ b/src/it/java/dev/jbang/it/BaseIT.java
@@ -68,7 +68,7 @@ public class BaseIT {
 
 		// Add built jbang to PATH (not a gurantee that this will work if other jbang
 		// instances are installed)
-		env.put("PATH", Paths.get("build/install/jbang/bin").toAbsolutePath().toString() + File.pathSeparator
+		env.put("PATH", Paths.get("build/install/jbang/bin").toAbsolutePath() + File.pathSeparator
 				+ System.getenv("PATH"));
 		System.out.println("PATH: " + env.get("PATH"));
 		return env;

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -62,8 +62,7 @@ public class Main {
 					// We do this test because we want aliases to have a higher
 					// priority than the next case, which is to look up commands
 					// in the user's PATH which might be slow-ish
-				} else if (!Util.findCommandsWith(p -> Util.base(p.getFileName().toString()).equals("jbang-" + cmd))
-					.isEmpty()) {
+				} else if (Catalog.isValidName(cmd) && Util.searchPath("jbang-" + cmd) != null) {
 					// We found a matching "jbang-xxx" command on the user's PATH
 					List<String> result = new ArrayList<>();
 					result.add("jbang-" + cmd);

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -10,7 +10,10 @@ import static picocli.CommandLine.Model.UsageMessageSpec.SECTION_KEY_COMMAND_LIS
 import static picocli.CommandLine.Option;
 import static picocli.CommandLine.ScopeType;
 
+import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,7 +27,9 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Future;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import dev.jbang.Configuration;
 import dev.jbang.util.Util;
@@ -265,52 +270,37 @@ public class JBang extends BaseCommand {
 	}
 
 	public static CommandGroupRenderer getCommandRenderer() {
-		Map<String, List<String>> sections = new LinkedHashMap<>();
-		sections.put("Essentials", asList("run", "build"));
-		sections.put("Editing", asList("init", "edit"));
-		sections.put("Caching", asList("cache", "export", "jdk"));
-		sections.put("Configuration", asList("config", "trust", "alias", "template", "catalog", "app"));
-		sections.put("Other", asList("completion", "info", "version", "wrapper"));
-		Map<String, String> cmds = findExternalCommands();
-		if (!cmds.isEmpty()) {
-			sections.put("External", new ArrayList<>(cmds.keySet()));
-		}
-		CommandGroupRenderer renderer = new CommandGroupRenderer(sections, cmds);
-		return renderer;
-	}
-
-	private static Map<String, String> findExternalCommands() {
-		Map<String, String> result = new TreeMap<>();
-		// Add any aliases whose names start with "jbang-" to the result
-		try {
-			dev.jbang.catalog.Catalog cat = dev.jbang.catalog.Catalog.getMerged(true, false);
-			for (String name : cat.aliases.keySet()) {
-				if (name.startsWith("jbang-")) {
-					result.put(name.substring(6), cat.aliases.get(name).description);
-				}
-			}
-		} catch (Exception ex) {
-			Util.verboseMsg("Error trying to list aliases", ex);
-		}
-		// Now add any commands found on the PATH whose names start with "jbang-"
-		try {
-			List<Path> cmds = Util.findCommandsWith(p -> p.getFileName().toString().startsWith("jbang-"));
-			for (Path p : cmds) {
-				result.put(Util.base(p.getFileName().toString()).substring(6), null);
-			}
-		} catch (Exception ex) {
-			Util.verboseMsg("Error trying to list jbang-commands", ex);
-		}
-		return result;
+		return new CommandGroupRenderer();
 	}
 
 	public static class CommandGroupRenderer implements CommandLine.IHelpSectionRenderer {
-		private final Map<String, List<String>> sections;
-		private final Map<String, String> externals;
+		private Map<String, List<String>> sections;
+		private Map<String, String> externals;
 
-		public CommandGroupRenderer(Map<String, List<String>> sections, Map<String, String> externals) {
-			this.sections = sections;
-			this.externals = externals;
+		public CommandGroupRenderer() {
+		}
+
+		private Map<String, List<String>> sections() {
+			if (sections == null) {
+				sections = new LinkedHashMap<>();
+				sections.put("Essentials", asList("run", "build"));
+				sections.put("Editing", asList("init", "edit"));
+				sections.put("Caching", asList("cache", "export", "jdk"));
+				sections.put("Configuration", asList("config", "trust", "alias", "template", "catalog", "app"));
+				sections.put("Other", asList("completion", "info", "version", "wrapper"));
+				Map<String, String> cmds = externals();
+				if (!cmds.isEmpty()) {
+					sections.put("External", new ArrayList<>(cmds.keySet()));
+				}
+			}
+			return sections;
+		}
+
+		private Map<String, String> externals() {
+			if (externals == null) {
+				externals = findExternalCommands();
+			}
+			return externals;
 		}
 
 		/**
@@ -321,7 +311,7 @@ public class JBang extends BaseCommand {
 		 */
 		public void validate(CommandLine.Help help) {
 			Set<String> cmds = new HashSet<>();
-			sections.forEach((key, value) -> cmds.addAll(value));
+			sections().forEach((key, value) -> cmds.addAll(value));
 
 			Set<String> actualcmds = new HashSet<>(help.subcommands().keySet());
 
@@ -337,11 +327,11 @@ public class JBang extends BaseCommand {
 				throw new IllegalStateException(("Commands found with no assigned section" + actualcmds));
 			}
 
-			sections.forEach((key, value) -> cmds.addAll(value));
+			sections().forEach((key, value) -> cmds.addAll(value));
 
 		}
 
-		// @Override
+		@Override
 		public String render(CommandLine.Help help) {
 			if (help.commandSpec().subcommands().isEmpty()) {
 				return "";
@@ -349,7 +339,7 @@ public class JBang extends BaseCommand {
 
 			StringBuilder result = new StringBuilder();
 
-			sections.forEach((key, value) -> result.append(renderSection(key, value, help)));
+			sections().forEach((key, value) -> result.append(renderSection(key, value, help)));
 			return result.toString();
 		}
 
@@ -369,8 +359,8 @@ public class JBang extends BaseCommand {
 					addCommand(textTable, names, description, help);
 				}
 			} else {
-				for (String name : externals.keySet()) {
-					String description = externals.get(name);
+				for (String name : externals().keySet()) {
+					String description = externals().get(name);
 					addCommand(textTable, name, description, help);
 				}
 			}
@@ -417,6 +407,51 @@ public class JBang extends BaseCommand {
 			for (int i = 0; i < lines.length; i++) {
 				CommandLine.Help.Ansi.Text cmdNamesText = help.colorScheme().commandText(i == 0 ? name : "");
 				textTable.addRowValues(cmdNamesText, lines[i]);
+			}
+		}
+
+		private static Map<String, String> findExternalCommands() {
+			Map<String, String> result = new TreeMap<>();
+			// Add any aliases whose names start with "jbang-" to the result
+			try {
+				dev.jbang.catalog.Catalog cat = dev.jbang.catalog.Catalog.getMerged(true, false);
+				for (String name : cat.aliases.keySet()) {
+					if (name.startsWith("jbang-")) {
+						result.put(name.substring(6), cat.aliases.get(name).description);
+					}
+				}
+			} catch (Exception ex) {
+				Util.verboseMsg("Error trying to list aliases", ex);
+			}
+			// Now add any commands found on the PATH whose names start with "jbang-"
+			try {
+				List<Path> cmds = findCommandsWith(p -> p.getFileName().toString().startsWith("jbang-"));
+				for (Path p : cmds) {
+					result.put(Util.base(p.getFileName().toString()).substring(6), null);
+				}
+			} catch (Exception ex) {
+				Util.verboseMsg("Error trying to list jbang-commands", ex);
+			}
+			return result;
+		}
+
+		private static List<Path> findCommandsWith(Predicate<Path> accept) {
+			String[] elems = System.getenv().getOrDefault("PATH", "").split(File.pathSeparator);
+			return Stream.of(elems)
+				.map(elem -> Util.getCwd().resolve(elem))
+				.flatMap(dir -> listFiles(dir).filter(Util::isExecutable).filter(accept))
+				.collect(Collectors.toList());
+		}
+
+		private static Stream<Path> listFiles(Path dir) {
+			if (Files.isDirectory(dir)) {
+				try {
+					return Files.list(dir);
+				} catch (IOException e) {
+					throw new RuntimeException(e.getMessage(), e);
+				}
+			} else {
+				return Stream.empty();
 			}
 		}
 	}


### PR DESCRIPTION
The setup of help information for PicoCli is now done lazily which improves JBang startup time in general but specifically on systems that for some reason are slow when scanning the PATH for plugins. We also improved direct plugin lookup by not using full file scanning.

See #2147 and #2137
