### PR TITLE
feat: add the Gradle "Dependency Updates" Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
-	id "com.github.ben-manes.versions" version "0.51.0"   // 0.52.0 requires Java 17
+	// id "com.github.ben-manes.versions" version "0.51.0"
 }
 
 def allureVersion = '2.29.0'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
-
+    id "com.github.ben-manes.versions" version "0.51.0"
 }
 
 def allureVersion = '2.29.0'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
-	id "com.github.ben-manes.versions" version "0.51.0"
+	id "com.github.ben-manes.versions" version "0.51.0"   // 0.52.0 requires Java 17
 }
 
 def allureVersion = '2.29.0'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
-    id "com.github.ben-manes.versions" version "0.51.0"
+	id "com.github.ben-manes.versions" version "0.51.0"
 }
 
 def allureVersion = '2.29.0'


### PR DESCRIPTION
The only reason to add this plugin to build.gradle, is to be able to check if newer dependencies are available. If we're doing a good job merging the pull requests generated by renovate[bot] then running this plugin would just confirm that the dependencies are up to date.

$ ./gradlew dependencyUpdates

The plugin is added for reporting purposes only. 
