### PR TITLE
build: move to jspecify for nullability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,7 +130,7 @@ sourceSets.main.compileClasspath += sourceSets.java9.output.classesDirs;
 
 dependencies {
 	implementation 'dev.jbang:devkitman:0.2.0'
-
+	implementation 'org.jspecify:jspecify:1.0.0'
 	implementation 'org.apache.commons:commons-text:1.11.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'
 	implementation 'info.picocli:picocli:4.7.7'

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -62,12 +62,12 @@ public class Alias extends CatalogItem {
 
 	public static class JavaAgent {
 		@SerializedName(value = "agent-ref")
-		@Nonnull
+		@NonNull
 		public final String agentRef;
-		@Nonnull
+		@NonNull
 		public final String options;
 
-		public JavaAgent(@Nonnull String agentRef, @Nonnull String options) {
+		public JavaAgent(@NonNull String agentRef, @NonNull String options) {
 			this.agentRef = agentRef;
 			this.options = options;
 		}

--- a/src/main/java/dev/jbang/dependencies/MavenCoordinate.java
+++ b/src/main/java/dev/jbang/dependencies/MavenCoordinate.java
@@ -4,8 +4,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * 
@@ -96,11 +96,11 @@ public class MavenCoordinate {
 		return new MavenCoordinate(groupId, artifactId, version, classifier, type);
 	}
 
-	public MavenCoordinate(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version) {
+	public MavenCoordinate(@NonNull String groupId, @NonNull String artifactId, @NonNull String version) {
 		this(groupId, artifactId, version, null, null);
 	}
 
-	public MavenCoordinate(@Nonnull String groupId, @Nonnull String artifactId, @Nonnull String version,
+	public MavenCoordinate(@NonNull String groupId, @NonNull String artifactId, @NonNull String version,
 			@Nullable String classifier, @Nullable String type) {
 		this.groupId = groupId;
 		this.artifactId = artifactId;

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -14,12 +14,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-
 import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
 import org.codehaus.plexus.languages.java.jpms.LocationManager;
 import org.codehaus.plexus.languages.java.jpms.ResolvePathsRequest;
 import org.codehaus.plexus.languages.java.jpms.ResolvePathsResult;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.devkitman.Jdk;
 import dev.jbang.util.Util;
@@ -67,7 +66,7 @@ public class ModularClassPath {
 		return javafx.get();
 	}
 
-	public List<String> getAutoDectectedModuleArguments(@Nonnull Jdk jdk) {
+	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
 		if (hasJavaFX() && supportsModules(jdk)) {
 			List<String> commandArguments = new ArrayList<>();
 

--- a/src/main/java/dev/jbang/source/BuildContext.java
+++ b/src/main/java/dev/jbang/source/BuildContext.java
@@ -3,7 +3,7 @@ package dev.jbang.source;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
@@ -31,7 +31,7 @@ public class BuildContext {
 		}
 	}
 
-	@Nonnull
+	@NonNull
 	private static Path getBuildDir(Path baseDir, Project project) {
 		if (baseDir == null) {
 			baseDir = Settings.getCacheDir(Cache.CacheClass.jars);
@@ -82,17 +82,17 @@ public class BuildContext {
 		}
 	}
 
-	@Nonnull
+	@NonNull
 	public Path getCompileDir() {
 		return buildDir.resolve("classes");
 	}
 
-	@Nonnull
+	@NonNull
 	public Path getGeneratedSourcesDir() {
 		return buildDir.resolve("generated");
 	}
 
-	@Nonnull
+	@NonNull
 	private Path getBasePath(String extension) {
 		return buildDir.resolve(
 				Util.sourceBase(project.getResourceRef().getFile().getFileName().toString()) + extension);
@@ -106,7 +106,7 @@ public class BuildContext {
 		return getJarFile() != null && Files.exists(getJarFile()) && resolveClassPath().isValid();
 	}
 
-	@Nonnull
+	@NonNull
 	public ModularClassPath resolveClassPath() {
 		if (mcp == null) {
 			DependencyResolver resolver = new DependencyResolver();

--- a/src/main/java/dev/jbang/source/CodeBuilderProvider.java
+++ b/src/main/java/dev/jbang/source/CodeBuilderProvider.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.source.sources.JavaSource;
 
@@ -44,13 +44,13 @@ public class CodeBuilderProvider implements Supplier<Builder<CmdGeneratorBuilder
 	 *
 	 * @return A <code>Builder</code>
 	 */
-	@Nonnull
+	@NonNull
 	@Override
 	public Builder<CmdGeneratorBuilder> get() {
 		return get(buildContext);
 	}
 
-	@Nonnull
+	@NonNull
 	protected Builder<CmdGeneratorBuilder> get(BuildContext ctx) {
 		Builder<CmdGeneratorBuilder> builder = getBuilder(ctx);
 		Project prj = ctx.getProject();
@@ -70,7 +70,7 @@ public class CodeBuilderProvider implements Supplier<Builder<CmdGeneratorBuilder
 		}
 	}
 
-	@Nonnull
+	@NonNull
 	protected Builder<CmdGeneratorBuilder> getBuilder(BuildContext ctx) {
 		Project prj = ctx.getProject();
 		if (prj.getMainSource() != null) {

--- a/src/main/java/dev/jbang/source/DocRef.java
+++ b/src/main/java/dev/jbang/source/DocRef.java
@@ -2,14 +2,14 @@ package dev.jbang.source;
 
 import java.util.Objects;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public class DocRef {
 	private final @Nullable String id;
-	private final @Nonnull ResourceRef ref;
+	private final @NonNull ResourceRef ref;
 
-	private DocRef(@Nullable String id, @Nonnull ResourceRef ref) {
+	private DocRef(@Nullable String id, @NonNull ResourceRef ref) {
 		this.id = id;
 		this.ref = ref;
 	}
@@ -18,7 +18,7 @@ public class DocRef {
 		return id;
 	}
 
-	public @Nonnull ResourceRef getRef() {
+	public @NonNull ResourceRef getRef() {
 		return ref;
 	}
 

--- a/src/main/java/dev/jbang/source/InputStreamResourceRef.java
+++ b/src/main/java/dev/jbang/source/InputStreamResourceRef.java
@@ -5,23 +5,23 @@ import java.io.InputStream;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.util.Util;
 
 public class InputStreamResourceRef implements ResourceRef {
-	@Nonnull
+	@NonNull
 	protected final String originalResource;
-	@Nonnull
+	@NonNull
 	protected final Function<String, InputStream> streamFactory;
 
-	public InputStreamResourceRef(@Nonnull String resource,
-			@Nonnull Function<String, InputStream> streamFactory) {
+	public InputStreamResourceRef(@NonNull String resource,
+			@NonNull Function<String, InputStream> streamFactory) {
 		this.originalResource = resource;
 		this.streamFactory = streamFactory;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String getOriginalResource() {
 		return originalResource;
@@ -36,7 +36,7 @@ public class InputStreamResourceRef implements ResourceRef {
 		}
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public InputStream getInputStream() {
 		InputStream is = streamFactory.apply(getOriginalResource());
@@ -46,7 +46,7 @@ public class InputStreamResourceRef implements ResourceRef {
 		return is;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String getExtension() {
 		return Util.extension(getOriginalResource());

--- a/src/main/java/dev/jbang/source/Project.java
+++ b/src/main/java/dev/jbang/source/Project.java
@@ -7,8 +7,8 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.dependencies.DependencyResolver;
 import dev.jbang.dependencies.MavenRepo;
@@ -24,7 +24,7 @@ import dev.jbang.util.Util;
  * the <code>AppBuilder</code> to create a JAR file, for example.
  */
 public class Project {
-	@Nonnull
+	@NonNull
 	private final ResourceRef resourceRef;
 	private Source mainSource;
 
@@ -74,66 +74,66 @@ public class Project {
 		return new ProjectBuilder();
 	}
 
-	public Project(@Nonnull ResourceRef resourceRef) {
+	public Project(@NonNull ResourceRef resourceRef) {
 		this.resourceRef = resourceRef;
 	}
 
 	// TODO This should be refactored and removed
-	public Project(@Nonnull Source mainSource) {
+	public Project(@NonNull Source mainSource) {
 		this.resourceRef = mainSource.getResourceRef();
 		this.mainSource = mainSource;
 	}
 
-	@Nonnull
+	@NonNull
 	public ResourceRef getResourceRef() {
 		return resourceRef;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet getMainSourceSet() {
 		return mainSourceSet;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<MavenRepo> getRepositories() {
 		return Collections.unmodifiableList(repositories);
 	}
 
-	@Nonnull
-	public Project addRepository(@Nonnull MavenRepo repository) {
+	@NonNull
+	public Project addRepository(@NonNull MavenRepo repository) {
 		repositories.add(repository);
 		return this;
 	}
 
-	@Nonnull
-	public Project addRepositories(@Nonnull Collection<MavenRepo> repositories) {
+	@NonNull
+	public Project addRepositories(@NonNull Collection<MavenRepo> repositories) {
 		this.repositories.addAll(repositories);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> getRuntimeOptions() {
 		return Collections.unmodifiableList(runtimeOptions);
 	}
 
-	@Nonnull
-	public Project addRuntimeOption(@Nonnull String option) {
+	@NonNull
+	public Project addRuntimeOption(@NonNull String option) {
 		runtimeOptions.add(option);
 		return this;
 	}
 
-	@Nonnull
-	public Project addRuntimeOptions(@Nonnull Collection<String> options) {
+	@NonNull
+	public Project addRuntimeOptions(@NonNull Collection<String> options) {
 		runtimeOptions.addAll(options);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<Project> getSubProjects() {
 		return Collections.unmodifiableList(subProjects);
 	}
 
-	public void addSubProject(@Nonnull Project subProject) {
+	public void addSubProject(@NonNull Project subProject) {
 		subProjects.add(subProject);
 	}
 
@@ -141,11 +141,11 @@ public class Project {
 		return Collections.unmodifiableMap(properties);
 	}
 
-	public void putProperties(@Nonnull Map<String, String> properties) {
+	public void putProperties(@NonNull Map<String, String> properties) {
 		this.properties = properties;
 	}
 
-	@Nonnull
+	@NonNull
 	public Map<String, String> getManifestAttributes() {
 		return manifestAttributes;
 	}
@@ -163,46 +163,46 @@ public class Project {
 		return javaVersion;
 	}
 
-	@Nonnull
+	@NonNull
 	public Project setJavaVersion(String javaVersion) {
 		this.javaVersion = javaVersion;
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public Optional<String> getDescription() {
 		return Optional.ofNullable(description);
 	}
 
-	@Nonnull
+	@NonNull
 	public Project setDescription(String description) {
 		this.description = description;
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<DocRef> getDocs() {
 		return Collections.unmodifiableList(docs);
 	}
 
-	@Nonnull
+	@NonNull
 	public Project addDoc(DocRef docs) {
 		this.docs.add(docs);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public Project addDocs(List<DocRef> docs) {
 		this.docs.addAll(docs);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public Optional<String> getGav() {
 		return Optional.ofNullable(gav);
 	}
 
-	@Nonnull
+	@NonNull
 	public Project setGav(String gav) {
 		this.gav = gav;
 		return this;
@@ -224,12 +224,12 @@ public class Project {
 		this.enablePreviewRequested = enablePreview;
 	}
 
-	@Nonnull
+	@NonNull
 	public Optional<String> getModuleName() {
 		return Optional.ofNullable(moduleName);
 	}
 
-	@Nonnull
+	@NonNull
 	public Project setModuleName(String moduleName) {
 		this.moduleName = moduleName;
 		return this;
@@ -305,7 +305,7 @@ public class Project {
 	 *
 	 * @return A <code>Builder</code>
 	 */
-	@Nonnull
+	@NonNull
 	public Builder<CmdGeneratorBuilder> codeBuilder() {
 		return CodeBuilderProvider.create(this).get();
 	}
@@ -318,7 +318,7 @@ public class Project {
 	 *            and intermediate results
 	 * @return A <code>Builder</code>
 	 */
-	@Nonnull
+	@NonNull
 	public static Builder<CmdGeneratorBuilder> codeBuilder(BuildContext ctx) {
 		return CodeBuilderProvider.create(ctx).get();
 	}

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -19,11 +19,10 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.Settings;
 import dev.jbang.catalog.Alias;
@@ -566,7 +565,7 @@ public class ProjectBuilder {
 	 * @param resolver The resolver to use for dependent (re)sources
 	 * @return The given <code>Project</code>
 	 */
-	@Nonnull
+	@NonNull
 	private Project updateProject(Source src, Project prj, ResourceResolver resolver) {
 		ResourceRef srcRef = src.getResourceRef();
 		if (!prj.getMainSourceSet().getSources().contains(srcRef)) {

--- a/src/main/java/dev/jbang/source/RefTarget.java
+++ b/src/main/java/dev/jbang/source/RefTarget.java
@@ -8,8 +8,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.cli.ExitException;
 import dev.jbang.util.Util;
@@ -20,18 +20,18 @@ import dev.jbang.util.Util;
  * //FILES target=source directives in scripts and templates.
  */
 public class RefTarget {
-	@Nonnull
+	@NonNull
 	protected final ResourceRef source;
 	@Nullable
 	protected final Path target;
 
-	protected RefTarget(@Nonnull ResourceRef source, @Nullable Path target) {
+	protected RefTarget(@NonNull ResourceRef source, @Nullable Path target) {
 		assert (source != null);
 		this.source = source;
 		this.target = target;
 	}
 
-	@Nonnull
+	@NonNull
 	public ResourceRef getSource() {
 		return source;
 	}

--- a/src/main/java/dev/jbang/source/ResourceRef.java
+++ b/src/main/java/dev/jbang/source/ResourceRef.java
@@ -6,8 +6,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.source.resolvers.FileResourceResolver;
 import dev.jbang.util.Util;
@@ -61,7 +61,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 		return getOriginalResource() != null && isStdin(getOriginalResource());
 	}
 
-	static boolean isStdin(@Nonnull String scriptResource) {
+	static boolean isStdin(@NonNull String scriptResource) {
 		return scriptResource.equals("-") || scriptResource.equals("/dev/stdin");
 	}
 
@@ -75,7 +75,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * 
 	 * @return A file reference
 	 */
-	@Nonnull
+	@NonNull
 	default Path getFile() {
 		throw new ResourceNotFoundException(getOriginalResource(), "Getting contents from resource not supported");
 	}
@@ -109,7 +109,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @return the file extension of the resource, or an empty string if no
 	 *         extension is found
 	 */
-	@Nonnull
+	@NonNull
 	default String getExtension() {
 		if (getOriginalResource() != null) {
 			return Util.extension(getOriginalResource());
@@ -124,7 +124,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @param file the file path used to create the resource reference
 	 * @return a {@code ResourceRef} instance representing the specified file
 	 */
-	static ResourceRef forFile(@Nonnull Path file) {
+	static ResourceRef forFile(@NonNull Path file) {
 		return new FileResourceResolver.FileResourceRef(file.toString(), file);
 	}
 
@@ -138,7 +138,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @return a {@code ResourceRef} instance representing the specified resolved
 	 *         resource
 	 */
-	static ResourceRef forResolvedResource(@Nonnull String resource, @Nonnull Path resolvedResource) {
+	static ResourceRef forResolvedResource(@NonNull String resource, @NonNull Path resolvedResource) {
 		return new FileResourceResolver.FileResourceRef(resource, resolvedResource);
 	}
 
@@ -152,7 +152,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @return a {@code ResourceRef} instance representing the specified resolved
 	 *         resource
 	 */
-	static ResourceRef forLazyFileResource(@Nonnull String resource, @Nonnull Function<String, Path> obtainer) {
+	static ResourceRef forLazyFileResource(@NonNull String resource, @NonNull Function<String, Path> obtainer) {
 		return new FileResourceResolver.FileResourceRef(resource, obtainer);
 	}
 
@@ -164,7 +164,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @param resource the resource string
 	 * @return a {@code ResourceRef} instance
 	 */
-	static ResourceRef forUnresolvable(@Nonnull String resource) {
+	static ResourceRef forUnresolvable(@NonNull String resource) {
 		return new UnresolvableResourceRef(resource);
 	}
 
@@ -177,7 +177,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	 * @return a {@code ResourceRef} instance representing the specified resource
 	 *         string
 	 */
-	static ResourceRef forResource(@Nonnull String resource) {
+	static ResourceRef forResource(@NonNull String resource) {
 		return ResourceResolver.forResources().resolve(resource);
 	}
 
@@ -206,10 +206,10 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 	}
 
 	class WrappedResourceRef implements ResourceRef {
-		@Nonnull
+		@NonNull
 		private final ResourceRef wrappedRef;
 
-		public WrappedResourceRef(@Nonnull ResourceRef wrappedRef) {
+		public WrappedResourceRef(@NonNull ResourceRef wrappedRef) {
 			this.wrappedRef = wrappedRef;
 		}
 
@@ -224,7 +224,7 @@ public interface ResourceRef extends Comparable<ResourceRef> {
 			return wrappedRef.exists();
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public Path getFile() {
 			return wrappedRef.getFile();

--- a/src/main/java/dev/jbang/source/ResourceResolver.java
+++ b/src/main/java/dev/jbang/source/ResourceResolver.java
@@ -1,7 +1,7 @@
 package dev.jbang.source;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.source.resolvers.*;
 
@@ -57,7 +57,7 @@ public interface ResourceResolver {
 		return resolve(resource, false);
 	}
 
-	@Nonnull
+	@NonNull
 	String description();
 
 	/**
@@ -66,7 +66,7 @@ public interface ResourceResolver {
 	 *
 	 * @return A <code>ResourceRef</code> or <code>null</code>
 	 */
-	@Nonnull
+	@NonNull
 	static ResourceResolver forResources() {
 		return new CombinedResourceResolver(
 				new RemoteResourceResolver(true),

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -7,7 +7,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
@@ -68,12 +68,12 @@ public abstract class Source {
 		return new TagReader.Extended(contents, replaceProperties);
 	}
 
-	@Nonnull
+	@NonNull
 	public Stream<String> getTags() {
 		return tagReader.getTags();
 	}
 
-	public abstract @Nonnull Type getType();
+	public abstract @NonNull Type getType();
 
 	protected List<String> collectBinaryDependencies() {
 		return tagReader.collectBinaryDependencies();
@@ -95,7 +95,7 @@ public abstract class Source {
 		return resourceRef;
 	}
 
-	@Nonnull
+	@NonNull
 	public Optional<String> getJavaPackage() {
 		if (contents != null) {
 			return Util.getSourcePackage(contents);

--- a/src/main/java/dev/jbang/source/SourceSet.java
+++ b/src/main/java/dev/jbang/source/SourceSet.java
@@ -7,7 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.dependencies.DependencyResolver;
 import dev.jbang.util.Util;
@@ -26,109 +26,109 @@ public class SourceSet {
 	private final List<String> compileOptions = new ArrayList<>();
 	private final List<String> nativeOptions = new ArrayList<>();
 
-	@Nonnull
+	@NonNull
 	public List<ResourceRef> getSources() {
 		return Collections.unmodifiableList(sources);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addSource(ResourceRef source) {
 		sources.add(source);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addSources(Collection<ResourceRef> sources) {
 		this.sources.addAll(sources);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<RefTarget> getResources() {
 		return Collections.unmodifiableList(resources);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addResource(RefTarget resource) {
 		resources.add(resource);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addResources(Collection<RefTarget> resources) {
 		this.resources.addAll(resources);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> getDependencies() {
 		return Collections.unmodifiableList(dependencies);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addDependency(String dependency) {
 		dependencies.add(dependency);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addDependencies(Collection<String> dependencies) {
 		this.dependencies.addAll(dependencies);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> getClassPaths() {
 		return Collections.unmodifiableList(classPaths);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addClassPath(String classPath) {
 		classPaths.add(classPath);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addClassPaths(Collection<String> classPaths) {
 		this.classPaths.addAll(classPaths);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> getCompileOptions() {
 		return Collections.unmodifiableList(compileOptions);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addCompileOption(String option) {
 		compileOptions.add(option);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addCompileOptions(Collection<String> options) {
 		compileOptions.addAll(options);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> getNativeOptions() {
 		return Collections.unmodifiableList(nativeOptions);
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addNativeOption(String option) {
 		nativeOptions.add(option);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public SourceSet addNativeOptions(Collection<String> options) {
 		nativeOptions.addAll(options);
 		return this;
 	}
 
-	@Nonnull
+	@NonNull
 	public DependencyResolver updateDependencyResolver(DependencyResolver resolver) {
 		return resolver.addDependencies(dependencies).addClassPaths(classPaths);
 	}

--- a/src/main/java/dev/jbang/source/TagReader.java
+++ b/src/main/java/dev/jbang/source/TagReader.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.DependencyUtil;
@@ -249,7 +249,7 @@ public abstract class TagReader {
 		return line.startsWith(GAV_COMMENT_PREFIX);
 	}
 
-	@Nonnull
+	@NonNull
 	public List<String> collectOptions(String... prefixes) {
 		List<String> options;
 		if (prefixes.length > 1) {
@@ -266,7 +266,7 @@ public abstract class TagReader {
 		return Project.quotedStringToList(String.join(" ", options));
 	}
 
-	@Nonnull
+	@NonNull
 	List<String> collectRawOptions(String prefix) {
 		List<String> javaOptions = getTags()
 			.map(it -> it.split(" // ")[0]) // strip away nested comments.

--- a/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/AliasResourceResolver.java
@@ -3,8 +3,8 @@ package dev.jbang.source.resolvers;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.Catalog;
@@ -14,16 +14,16 @@ import dev.jbang.source.ResourceResolver;
 public class AliasResourceResolver implements ResourceResolver {
 	@Nullable
 	private final Catalog catalog;
-	@Nonnull
+	@NonNull
 	private final Function<Alias, ResourceResolver> resolverFactory;
 
 	public AliasResourceResolver(@Nullable Catalog catalog,
-			@Nonnull Function<Alias, ResourceResolver> resolverFactory) {
+			@NonNull Function<Alias, ResourceResolver> resolverFactory) {
 		this.catalog = catalog;
 		this.resolverFactory = resolverFactory;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return String.format("Alias resolver from catalog %s using %s",
@@ -52,15 +52,15 @@ public class AliasResourceResolver implements ResourceResolver {
 	}
 
 	public static class AliasedResourceRef extends ResourceRef.WrappedResourceRef {
-		@Nonnull
+		@NonNull
 		private final Alias alias;
 
-		public AliasedResourceRef(ResourceRef aliasRef, @Nonnull Alias alias) {
+		public AliasedResourceRef(ResourceRef aliasRef, @NonNull Alias alias) {
 			super(aliasRef);
 			this.alias = alias;
 		}
 
-		@Nonnull
+		@NonNull
 		public Alias getAlias() {
 			return alias;
 		}

--- a/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/ClasspathResourceResolver.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.source.*;
 
@@ -16,7 +16,7 @@ import dev.jbang.source.*;
  * reference to that.
  */
 public class ClasspathResourceResolver implements ResourceResolver {
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return "Classpath resolver";
@@ -35,7 +35,7 @@ public class ClasspathResourceResolver implements ResourceResolver {
 	}
 
 	public static class ClasspathResourceRef extends InputStreamResourceRef {
-		protected ClasspathResourceRef(@Nonnull String ref) {
+		protected ClasspathResourceRef(@NonNull String ref) {
 			super(ref, ClasspathResourceRef::createStream);
 		}
 

--- a/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/CombinedResourceResolver.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.source.ResourceRef;
 import dev.jbang.source.ResourceResolver;
@@ -32,7 +32,7 @@ public class CombinedResourceResolver implements ResourceResolver {
 			.orElse(null);
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return String.format("Chain of [%s]",

--- a/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/FileResourceResolver.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.source.ResourceNotFoundException;
 import dev.jbang.source.ResourceRef;
@@ -22,7 +22,7 @@ import dev.jbang.util.Util;
  */
 public class FileResourceResolver implements ResourceResolver {
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return "File Resource resolver";
@@ -47,25 +47,25 @@ public class FileResourceResolver implements ResourceResolver {
 	}
 
 	public static class FileResourceRef implements ResourceRef {
-		@Nonnull
+		@NonNull
 		private final String originalResource;
-		@Nonnull
+		@NonNull
 		private final Function<String, Path> obtainer;
 		@Nullable
 		private Optional<Path> file;
 
-		public FileResourceRef(@Nonnull String resource, @Nonnull Function<String, Path> obtainer) {
+		public FileResourceRef(@NonNull String resource, @NonNull Function<String, Path> obtainer) {
 			this.originalResource = resource;
 			this.obtainer = obtainer;
 		}
 
-		public FileResourceRef(@Nonnull String resource, @Nonnull Path file) {
+		public FileResourceRef(@NonNull String resource, @NonNull Path file) {
 			this.originalResource = resource;
 			this.obtainer = ref -> file;
 			this.file = Optional.of(file);
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getOriginalResource() {
 			return originalResource;
@@ -80,7 +80,7 @@ public class FileResourceResolver implements ResourceResolver {
 			}
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public Path getFile() {
 			if (file == null) {
@@ -92,7 +92,7 @@ public class FileResourceResolver implements ResourceResolver {
 			return file.get();
 		}
 
-		@Nonnull
+		@NonNull
 		@Override
 		public String getExtension() {
 			if (file == null || file.isPresent()) {

--- a/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/GavResourceResolver.java
@@ -2,7 +2,7 @@ package dev.jbang.source.resolvers;
 
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.dependencies.ModularClassPath;
@@ -21,7 +21,7 @@ public class GavResourceResolver implements ResourceResolver {
 		this.depResolver = depResolver;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return "Maven GAV";

--- a/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/LiteralScriptResourceResolver.java
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
@@ -55,7 +55,7 @@ public class LiteralScriptResourceResolver implements ResourceResolver {
 		return result;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return "Literal stdin";

--- a/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RemoteResourceResolver.java
@@ -9,7 +9,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.cli.ExitException;
 import dev.jbang.net.TrustedSources;
@@ -30,7 +30,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 		this.alwaysTrust = alwaysTrust;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return String.format("%s remote resource", alwaysTrust ? "Trusted" : "Non-trusted");

--- a/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/RenamingScriptResourceResolver.java
@@ -7,7 +7,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
@@ -32,7 +32,7 @@ public class RenamingScriptResourceResolver implements ResourceResolver {
 		this.forceType = forceType;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return "Renaming resolver";

--- a/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
+++ b/src/main/java/dev/jbang/source/resolvers/SiblingResourceResolver.java
@@ -5,7 +5,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.catalog.Catalog;
 import dev.jbang.source.ResourceNotFoundException;
@@ -27,7 +27,7 @@ public class SiblingResourceResolver implements ResourceResolver {
 		this.resolver = resolver;
 	}
 
-	@Nonnull
+	@NonNull
 	@Override
 	public String description() {
 		return String.format("%s via %s", sibling.getOriginalResource(), resolver.description());

--- a/src/main/java/dev/jbang/source/sources/GroovySource.java
+++ b/src/main/java/dev/jbang/source/sources/GroovySource.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.net.GroovyManager;
 import dev.jbang.source.*;
@@ -28,7 +28,7 @@ public class GroovySource extends Source {
 	}
 
 	@Override
-	public @Nonnull Type getType() {
+	public @NonNull Type getType() {
 		return Type.groovy;
 	}
 

--- a/src/main/java/dev/jbang/source/sources/JavaSource.java
+++ b/src/main/java/dev/jbang/source/sources/JavaSource.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.devkitman.Jdk;
 import dev.jbang.source.*;
@@ -31,7 +31,7 @@ public class JavaSource extends Source {
 	}
 
 	@Override
-	public @Nonnull Type getType() {
+	public @NonNull Type getType() {
 		return Type.java;
 	}
 

--- a/src/main/java/dev/jbang/source/sources/JshSource.java
+++ b/src/main/java/dev/jbang/source/sources/JshSource.java
@@ -2,7 +2,7 @@ package dev.jbang.source.sources;
 
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.source.*;
 
@@ -16,7 +16,7 @@ public class JshSource extends JavaSource {
 	}
 
 	@Override
-	public @Nonnull Type getType() {
+	public @NonNull Type getType() {
 		return Type.jshell;
 	}
 

--- a/src/main/java/dev/jbang/source/sources/KotlinSource.java
+++ b/src/main/java/dev/jbang/source/sources/KotlinSource.java
@@ -8,7 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.net.KotlinManager;
 import dev.jbang.source.*;
@@ -27,7 +27,7 @@ public class KotlinSource extends Source {
 	}
 
 	@Override
-	public @Nonnull Type getType() {
+	public @NonNull Type getType() {
 		return Type.kotlin;
 	}
 

--- a/src/main/java/dev/jbang/source/sources/MarkdownSource.java
+++ b/src/main/java/dev/jbang/source/sources/MarkdownSource.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
@@ -22,7 +22,7 @@ public class MarkdownSource extends JshSource {
 	}
 
 	@Override
-	public @Nonnull Type getType() {
+	public @NonNull Type getType() {
 		return Type.markdown;
 	}
 

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -117,7 +117,7 @@ public class IntegrationManager {
 		return result;
 	}
 
-	@Nonnull
+	@NonNull
 	private static URLClassLoader getClassLoader(Collection<Path> deps) {
 		URL[] urls = deps.stream().map(path -> {
 			try {

--- a/src/main/java/dev/jbang/util/JavaUtil.java
+++ b/src/main/java/dev/jbang/util/JavaUtil.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
@@ -22,12 +22,12 @@ import dev.jbang.devkitman.util.RemoteAccessProvider;
 
 public class JavaUtil {
 
-	@Nonnull
+	@NonNull
 	public static JdkManager defaultJdkManager(String... names) {
 		return (new JdkManBuilder()).provider(names).build();
 	}
 
-	@Nonnull
+	@NonNull
 	public static JdkManager defaultJdkManager(List<String> names) {
 		return (new JdkManBuilder()).provider(names).build();
 	}
@@ -179,7 +179,7 @@ public class JavaUtil {
 		return parseJavaVersion(System.getProperty("java.version"));
 	}
 
-	public static String resolveInJavaHome(@Nonnull String cmd, @Nonnull Jdk jdk) {
+	public static String resolveInJavaHome(@NonNull String cmd, @NonNull Jdk jdk) {
 		if (jdk.isInstalled()) {
 			Path jdkHome = ((Jdk.InstalledJdk) jdk).home();
 			if (Util.isWindows()) {

--- a/src/main/java/dev/jbang/util/ModuleUtil.java
+++ b/src/main/java/dev/jbang/util/ModuleUtil.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.catalog.CatalogUtil;
 import dev.jbang.dependencies.ArtifactInfo;

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -48,11 +48,11 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.annotation.Nonnull;
 import javax.swing.*;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+import org.jspecify.annotations.NonNull;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -1980,8 +1980,8 @@ public class Util {
 		return res;
 	}
 
-	public static String replaceAll(@Nonnull Pattern pattern, @Nonnull String input,
-			@Nonnull Function<MatchResult, String> replacer) {
+	public static String replaceAll(@NonNull Pattern pattern, @NonNull String input,
+			@NonNull Function<MatchResult, String> replacer) {
 		Matcher matcher = pattern.matcher(input);
 		matcher.reset();
 		boolean result = matcher.find();
@@ -2042,7 +2042,7 @@ public class Util {
 	 * @param baseName The input string to convert
 	 * @return A valid Java identifier, never null or empty
 	 */
-	public static String toJavaIdentifier(@Nonnull String baseName) {
+	public static String toJavaIdentifier(@NonNull String baseName) {
 		if (isValidJavaIdentifier(baseName)) {
 			return baseName;
 		}

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -21,8 +21,7 @@ import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -478,7 +477,7 @@ public class TestBuilder extends BaseTest {
 			BiConsumer<BuildContext, List<String>> nativeStep)
 			throws IOException {
 		new CodeBuilderProvider(ctx) {
-			@Nonnull
+			@NonNull
 			@Override
 			protected Builder<CmdGeneratorBuilder> getBuilder(BuildContext ctx) {
 				return new JavaSource.JavaAppBuilder(ctx) {


### PR DESCRIPTION
in trying to fix #2133 I hit that maveninverse and motd are incompatible on maven deps -  so trying to remove motd but then I remove javax.annotations (weirdly enough) and thus thought - lets just move to jspecify rather than more intermediate steps.

these are just annotations and we don't use them rigorously so i don't expect it will be of any issue as not affecting runtime and the null checks are dubious anyway :)

in other words - if the build passes i'll merge it even withot review as i prefer not to have PR with this many changes hanging:)