### PR TITLE
fix: replace os detector with nisse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,6 @@ dependencies {
 	implementation 'org.apache.commons:commons-compress:1.27.1'
 	implementation 'info.picocli:picocli:4.7.7'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
-	implementation 'kr.motd.maven:os-maven-plugin:1.7.1'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
 	implementation 'com.google.code.gson:gson:2.10.1'
 	implementation 'org.jsoup:jsoup:1.17.1'
@@ -147,6 +146,9 @@ dependencies {
 
 	implementation "eu.maveniverse.maven.mima:context:2.4.33"
 	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.33"
+	implementation "org.apache.maven:maven-model:3.9.11"
+
+	implementation "eu.maveniverse.maven.nisse.sources:os-source:0.4.4"
 
 	testImplementation platform('org.junit:junit-bom:5.12.2')
 	testImplementation "org.junit.jupiter:junit-jupiter"

--- a/src/main/java/dev/jbang/dependencies/Detector.java
+++ b/src/main/java/dev/jbang/dependencies/Detector.java
@@ -1,38 +1,52 @@
 package dev.jbang.dependencies;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
-public class Detector extends kr.motd.maven.os.Detector {
+import dev.jbang.util.Util;
+
+import eu.maveniverse.maven.nisse.core.NisseConfiguration;
+import eu.maveniverse.maven.nisse.core.internal.SimpleNisseConfiguration;
+import eu.maveniverse.maven.nisse.source.osdetector.OsDetectorPropertySource;
+
+public class Detector {
 
 	public Detector() {
 		super();
 	}
 
-	@Override
-	protected void log(String message) {
+	public void detect(final Properties properties, List<String> classiferWithLikes) {
 
-	}
+		// TODO: this is a minimal use of nisse to replace the os-maven-plugin defaults.
+		// in future maybe add more from nisse but for now keep it simple.
+		Properties uPropertiers = new Properties(properties);
+		uPropertiers.put("nisse.compat.osDetector", "true");
+		try {
+			NisseConfiguration config = SimpleNisseConfiguration.builder()
+				.withSystemProperties(System.getProperties())
+				.withUserProperties(uPropertiers)
+				.build();
 
-	@Override
-	protected void logProperty(String name, String value) {
+			Map<String, String> props = new OsDetectorPropertySource().getProperties(config);
 
-	}
+			properties.putAll(props);
 
-	public void detect(Properties properties, List<String> classiferWithLikes) {
-		super.detect(properties, classiferWithLikes);
-
-		// "hack" to expose a property that works with javafx mac classifers
-		String os = properties.getProperty("os.detected.name");
-		if (os.equals("osx")) {
-			os = "mac";
-			if ("aarch64".equals(System.getProperty("os.arch"))) {
-				os = "mac-aarch64";
+			// "hack" to expose a property that works with javafx mac classifers
+			String os = properties.getProperty("os.detected.name");
+			if (os.equals("osx")) {
+				os = "mac";
+				if ("aarch64".equals(System.getProperty("os.arch"))) {
+					os = "mac-aarch64";
+				}
+			} else if (os.equals("windows")) {
+				os = "win";
 			}
-		} else if (os.equals("windows")) {
-			os = "win";
-		}
-		properties.setProperty("os.detected.jfxname", os);
-	}
+			properties.setProperty("os.detected.jfxname", os);
 
+		} catch (IOException e) {
+			Util.warnMsg("Failed to detect OS properties, continuing without them.", e);
+		}
+	}
 }


### PR DESCRIPTION
kmotd is incompatible with newer maven including maveniverse so need to decoupe from it.

first attempt here is using Nisse from @cstamas but might go for what @aalmiray done in jreleaeser and simply copied in the needed classes - but this stuff really should be a independent library...so nisse it is for now :)