### PR TITLE
fix: Install adds ~/.jbang/bin to PATH via .config/fish/conf.d/jbang.fish

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -8,7 +8,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -76,7 +80,7 @@ class AppInstall extends BaseBuildCommand {
 		// dependencyInfoMixin.validate();
 		boolean installed = false;
 		try {
-			if (scriptMixin.scriptOrFile.equals("jbang")) {
+			if ("jbang".equals(scriptMixin.scriptOrFile)) {
 				if (name != null && !"jbang".equals(name)) {
 					throw new IllegalArgumentException(
 							"It's not possible to install jbang with a different name");

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -444,14 +444,14 @@ class AppSetup extends BaseCommand {
 				// Update shell startup scripts
 				if (Util.isMac()) {
 					Path bashFile = getHome().resolve(".bash_profile");
-					changed = changeScript(binDir, jdkHome, bashFile) || changed;
+					changed = changeBashOrZshRcScript(binDir, jdkHome, bashFile) || changed;
 				}
 				if (!changed) {
 					Path bashFile = getHome().resolve(".bashrc");
-					changed = changeScript(binDir, jdkHome, bashFile) || changed;
+					changed = changeBashOrZshRcScript(binDir, jdkHome, bashFile) || changed;
 				}
 				Path zshRcFile = getHome().resolve(".zshrc");
-				changed = changeScript(binDir, jdkHome, zshRcFile) || changed;
+				changed = changeBashOrZshRcScript(binDir, jdkHome, zshRcFile) || changed;
 			}
 		}
 
@@ -482,11 +482,11 @@ class AppSetup extends BaseCommand {
 		}
 	}
 
-	private static boolean changeScript(Path binDir, Path javaHome, Path bashFile) {
+	private static boolean changeBashOrZshRcScript(Path binDir, Path javaHome, Path rcFile) {
 		try {
 			// Detect if JBang has already been set up before
-			boolean jbangFound = Files.exists(bashFile)
-					&& Files.lines(bashFile)
+			boolean jbangFound = Files.exists(rcFile)
+					&& Files.lines(rcFile)
 						.anyMatch(ln -> ln.trim().startsWith("#") && ln.toLowerCase().contains("jbang"));
 			if (!jbangFound) {
 				// Add lines to add JBang to PATH
@@ -499,12 +499,12 @@ class AppSetup extends BaseCommand {
 				} else {
 					lines += "export PATH=\"" + toHomePath(binDir) + ":$PATH\"\n";
 				}
-				Files.write(bashFile, lines.getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
-				Util.verboseMsg("Added JBang setup lines " + bashFile);
+				Files.write(rcFile, lines.getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+				Util.verboseMsg("Added JBang setup lines " + rcFile);
 				return true;
 			}
 		} catch (IOException e) {
-			Util.verboseMsg("Couldn't change script: " + bashFile, e);
+			Util.verboseMsg("Couldn't change script: " + rcFile, e);
 		}
 		return false;
 	}

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -452,6 +452,9 @@ class AppSetup extends BaseCommand {
 				}
 				Path zshRcFile = getHome().resolve(".zshrc");
 				changed = changeBashOrZshRcScript(binDir, jdkHome, zshRcFile) || changed;
+
+				Path fishRcFile = getHome().resolve(".config/fish/conf.d/jbang.fish");
+				changed = changeFishRc(binDir, jdkHome, fishRcFile) || changed;
 			}
 		}
 
@@ -480,6 +483,22 @@ class AppSetup extends BaseCommand {
 		} else {
 			return EXIT_OK;
 		}
+	}
+
+	private static boolean changeFishRc(Path binDir, Path jdkHome, Path fishRcFile) {
+		boolean jbangFound = Files.exists(fishRcFile);
+		if (jbangFound)
+			return false;
+
+		try {
+			List<String> lines = new ArrayList<String>();
+			lines.add("fish_add_path " + binDir + "\n");
+			Files.write(fishRcFile, lines, StandardOpenOption.CREATE_NEW);
+		} catch (IOException e) {
+			Util.verboseMsg("Couldn't change script: " + fishRcFile, e);
+			return false;
+		}
+		return true;
 	}
 
 	private static boolean changeBashOrZshRcScript(Path binDir, Path javaHome, Path rcFile) {

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -459,9 +459,9 @@ class AppSetup extends BaseCommand {
 		}
 
 		if (changed) {
-			Util.infoMsg("Setting up JBang environment...");
+			Util.infoMsg("JBang environment setup completed...");
 		} else if (chatty) {
-			Util.infoMsg("JBang environment is already set up.");
+			Util.infoMsg("JBang is already available in PATH.");
 			Util.infoMsg("(You can use --force to perform the setup anyway)");
 		}
 		if (Util.getShell() == Util.Shell.bash) {
@@ -487,13 +487,18 @@ class AppSetup extends BaseCommand {
 
 	private static boolean changeFishRc(Path binDir, Path jdkHome, Path fishRcFile) {
 		boolean jbangFound = Files.exists(fishRcFile);
-		if (jbangFound)
+		if (jbangFound) {
+			Util.verboseMsg("JBang setup lines already present in " + fishRcFile);
 			return false;
+		}
 
 		try {
 			List<String> lines = new ArrayList<String>();
+			lines.add("# Add JBang to environment\n");
+			lines.add("abbr --add j! jbang\n");
 			lines.add("fish_add_path " + binDir + "\n");
 			Files.write(fishRcFile, lines, StandardOpenOption.CREATE_NEW);
+			Util.verboseMsg("Added JBang setup lines " + fishRcFile);
 		} catch (IOException e) {
 			Util.verboseMsg("Couldn't change script: " + fishRcFile, e);
 			return false;
@@ -521,6 +526,8 @@ class AppSetup extends BaseCommand {
 				Files.write(rcFile, lines.getBytes(), StandardOpenOption.APPEND, StandardOpenOption.CREATE);
 				Util.verboseMsg("Added JBang setup lines " + rcFile);
 				return true;
+			} else {
+				Util.verboseMsg("JBang setup lines already present in " + rcFile);
 			}
 		} catch (IOException e) {
 			Util.verboseMsg("Couldn't change script: " + rcFile, e);


### PR DESCRIPTION
Should fix #2189.

But I've written this "blindly", and not actual run it.

@maxandersen during development, how do I make it "do the same thing that `curl -Ls https://sh.jbang.dev | bash -s - app setup` would do", to test? What `./gradlew ...` do I need to run to get a `jbang` somewhere? And then launch it as ... what, `???/jbang app setup`, presumably?

Let's get #2190 merged first, so that I can rebase this and it only has the actual fix.

Draft, for now; until I've actually been able to test it.
