### PR TITLE
feat: requestedJavaVersion honored by init templates

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -89,6 +89,7 @@ public class Init extends BaseCommand {
 		int reqVersion = buildMixin.javaVersion != null ? JavaUtil.minRequestedVersion(buildMixin.javaVersion)
 				: JavaUtil.getCurrentMajorJavaVersion();
 
+		properties.put("requestedJavaVersion", buildMixin.javaVersion);
 		properties.put("javaVersion", reqVersion);
 		properties.put("compactSourceFiles", reqVersion >= 25);
 		// properties.put("magiccontent", "//no gpt response. make sure you ran with

--- a/src/main/resources/init-agent.java.qute
+++ b/src/main/resources/init-agent.java.qute
@@ -1,4 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+{#if requestedJavaVersion}
+//JAVA {requestedJavaVersion}
+{/if}
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}

--- a/src/main/resources/init-cli.java.qute
+++ b/src/main/resources/init-cli.java.qute
@@ -1,4 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+{#if requestedJavaVersionr}
+//JAVA {requestedJavaVersion}
+{/if}
 //DEPS info.picocli:picocli:4.6.3
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}

--- a/src/main/resources/init-hello.groovy.qute
+++ b/src/main/resources/init-hello.groovy.qute
@@ -1,4 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+{#if requestedJavaVersion}
+//JAVA {requestedJavaVersion}
+{/if}
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}

--- a/src/main/resources/init-hello.java.qute
+++ b/src/main/resources/init-hello.java.qute
@@ -1,19 +1,23 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
+{#if requestedJavaVersion}
+//JAVA {requestedJavaVersion}
+{#else if compactSourceFiles}
+//JAVA 25+
+{/if}
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}
 {#if dependencies.isEmpty()}// //DEPS <dependency1> <dependency2>{/if}
-
 {#if magiccontent}
 {magiccontent}
 {#else}
-import static java.lang.System.*;
-
 {#if compactSourceFiles}
 void main(String... args) {
-    out.println("Hello World");
+    IO.println("Hello World");
 }
 {#else}
+import static java.lang.System.*;
+
 public class {baseName} {
 
     public static void main(String... args) {

--- a/src/main/resources/init-hello.kt.qute
+++ b/src/main/resources/init-hello.kt.qute
@@ -1,5 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-
+{#if requestedJavaVersion}
+//JAVA {requestedJavaVersion}
+{/if}
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}

--- a/src/main/resources/init-readme.md.qute
+++ b/src/main/resources/init-readme.md.qute
@@ -3,6 +3,9 @@
 Welcome to a basic example on how to do a readme.md file that can be run with JBang:
 
 ```java
+{#if requestedJavaVersion}
+//JAVA {requestedJavaVersion}
+{/if}
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}
 {/for}


### PR DESCRIPTION
alternative/replacement of #2143 

in #2143 it was suggested to force add "//JAVA 25+" when compact source enabled (automatically enabled when Java > 25) but I turned it down as it was resulting in inconsistent behavior.

Since then I myself been caught by having done `jbang init --java 25 hello.java` and then when running `./hello.java` it didn't work because my environments java was less than Java 25.

so this PR suggests introducing a `requestedJavaVersion` property which will be set to null if no specific java version requested; and other set to the raw string of the arg value in `--java <arg>`

Then use that to generate `//JAVA ${requestedJavaVersion}` if requested version is present, and in the case of compact source files will get `//JAVA 25+` if you did not request a specific java file...meaning no matter how you get a compact source file - it will always have at least `//JAVA 25+` in it OR what you requested using `--java <arg>`

In addition I updated the compact source to use `IO.println()` to be able to cut out the import line.

```
///usr/bin/env jbang "$0" "$@" ; exit $?
//JAVA 25+

void main(String... args) {
    IO.println("Hello World");
}
```

I also added ```{#if requestedJavaVersion}
//JAVA {requestedJavaVersion}
{/if}```

to the templates I could see it being meaningful.

wdyt @wfouche and @quintesse - I think this should make us all more happy than annoyed ;)
