### PR TITLE
fix: make tests faster by doing less

### DIFF
--- a/itests/runkotlin.kt
+++ b/itests/runkotlin.kt
@@ -1,36 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS com.github.zafarkhaja:java-semver:0.9.0
-//DEPS com.fasterxml.jackson.core:jackson-databind:2.15.2
-//DEPS com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2
-
-import com.fasterxml.jackson.databind.JsonNode
-import com.github.zafarkhaja.semver.Version
-import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import java.util.stream.StreamSupport
-import java.util.Spliterators
-
 fun main() {
-// props to Chris Dellaway for the pointer to this
-    val url = "https://oss.sonatype.org/content/repositories/snapshots/org/mongodb/mongodb-driver-sync/maven-metadata.xml"
-    val mapper = XmlMapper()
-    val min: String = System.getenv().getOrDefault("DRIVER_MIN", "5.0.0")
-    val driverMinimum = Version.valueOf(min)
-    var document = mapper.readTree(java.net.URL(url))
-    val versions: JsonNode = document
-        .get("versioning")
-        .get("versions")
-        .get("version")
-
-    val result = versions.elements()
-        .asSequence()
-        .map{ it.asText() }
-        .map { Version.valueOf(it) }
-        .filter { it.greaterThanOrEqualTo(driverMinimum) }
-        .sorted()
-        .toList()
-
-    println(result.last())
     println("SUCCESS!")
 }

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -118,9 +118,7 @@ public class TestEdit extends BaseTest {
 		JBang.getCommandLine().execute("init", s);
 		assertThat(new File(s).exists(), is(true));
 
-		Util.writeString(p, "//DEPS io.quarkus:quarkus-bom:2.0.0.Final@pom\n" +
-				"//DEPS io.quarkus:quarkus-rest-client-reactive\n" +
-				"//DEPS io.quarkus:quarkus-rest-client-reactive-jackson\n" + Util.readString(p));
+		Util.writeString(p, "//DEPS com.github.lalyos:jfiglet:0.0.8\n" + Util.readString(p));
 
 		ProjectBuilder pb = Project.builder();
 		Project prj = pb.build(s);

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -443,7 +443,7 @@ public class TestRun extends BaseTest {
 		final String aliases = "{\n" +
 				"  \"aliases\": {\n" +
 				"    \"qcli\": {\n" +
-				"      \"script-ref\": \"io.quarkus:quarkus-cli:1.9.0.Final:runner\"\n" +
+				"      \"script-ref\": \"com.github.lalyos:jfiglet:0.0.8\"\n" +
 				"    }\n" +
 				"  }\n" +
 				"}";
@@ -465,13 +465,13 @@ public class TestRun extends BaseTest {
 		String cmd = run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate();
 
 		if (Util.getShell() == Util.Shell.bash) {
-			assertThat(cmd, matchesPattern(".*quarkus-cli-1.9.0.Final-runner.jar.*"));
+			assertThat(cmd, matchesPattern(".*jfiglet-0.0.8.jar.*"));
 		} else {
 			// TODO On Windows the command is using an @file, we should parse
 			// the name, read the file and assert against it contents.
 		}
 
-		assertThat(code.getMainClass(), equalTo("io.quarkus.runner.GeneratedMain"));
+		assertThat(code.getMainClass(), equalTo("com.github.lalyos.jfiglet.JFiglet"));
 
 	}
 

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -205,13 +205,14 @@ class DependencyResolverTest extends BaseTest {
 
 	@Test
 	void testImportPOM() {
-		List<String> deps = Arrays.asList("com.microsoft.azure:azure-bom:1.0.0.M1@pom", "com.microsoft.azure:azure");
+
+		List<String> deps = Arrays.asList("org.slf4j:slf4j-bom:2.0.17@pom", "org.slf4j:slf4j-api");
 
 		ModularClassPath classpath = DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false,
 				false,
 				true, false);
 
-		assertEquals(62, classpath.getArtifacts().size());
+		assertEquals(1, classpath.getArtifacts().size());
 	}
 
 	@Test


### PR DESCRIPTION
used the perf graph in allure report to identify the top candidates for tests being slow.

reduced 3-4 tests of 15-30s length due to excessive dependency fetching which was not really needed for what they tested.

