### PR TITLE
chore(deps): update Groovy to 5.0.1

### DIFF
--- a/src/main/java/dev/jbang/net/GroovyManager.java
+++ b/src/main/java/dev/jbang/net/GroovyManager.java
@@ -15,7 +15,7 @@ import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
 
 public class GroovyManager {
-	public static final String DEFAULT_GROOVY_VERSION = "4.0.27";
+	public static final String DEFAULT_GROOVY_VERSION = "5.0.1";
 
 	public static String resolveInGroovyHome(String cmd, String requestedVersion) {
 		Path groovyHome = getGroovy(requestedVersion);


### PR DESCRIPTION
Groovy 5.0 supports Java 25. 

Groovy 5.0.1 is the first Groovy 5.0 bug fix release.