### PR TITLE
fix: better logging for jdk providers

### DIFF
--- a/src/main/java/dev/jbang/util/JavaUtil.java
+++ b/src/main/java/dev/jbang/util/JavaUtil.java
@@ -47,6 +47,8 @@ public class JavaUtil {
 				for (String providerName : names) {
 					if (PROVIDERS_ALL.contains(providerName)) {
 						providerNames.add(providerName);
+					} else {
+						Util.warnMsg("Unknown JDK provider: " + providerName);
 					}
 				}
 			}
@@ -55,13 +57,26 @@ public class JavaUtil {
 
 		public JdkManager build() {
 			if (providerNames.isEmpty() && providers.isEmpty()) {
+				Util.verboseMsg("No JDK providers specified, using default providers");
 				provider(PROVIDERS_DEFAULT);
 			}
 			for (String providerName : providerNames) {
 				JdkProvider provider = createProvider(providerName);
-				if (provider != null && provider.canUse()) {
-					providers(provider);
+				if (provider != null) {
+					if (provider.canUse()) {
+						providers(provider);
+					} else {
+						Util.verboseMsg("JDK provider '" + providerName + "' cannot be used");
+					}
+				} else {
+					Util.warnMsg("Unknown JDK provider: " + providerName);
 				}
+
+			}
+
+			if (providers.size() == 0) {
+				Util.warnMsg("No JDK providers selected or available. Run with --verbose for more details.");
+				Util.verboseMsg("Available JDK providers: " + PROVIDERS_ALL);
 			}
 			return super.build();
 		}


### PR DESCRIPTION
this provides some basic logging/help when using --jdk-providers.

i.e. --jdk-providers=donotexist silently use default but --jdk-providers=mise when no mise dirs (yet) fails...so needed some help figuring out what was doing wrong.

+ prints available providers so i dont have to go look in the code :)