### PR TITLE
feat: print commands

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -279,7 +279,7 @@ public class Edit extends BaseCommand {
 				cmd = new String[] { "cmd", "/c", editorCommand };
 			}
 			verboseMsg("Running `" + String.join(" ", cmd) + "`");
-			new ProcessBuilder(cmd).start();
+			Util.run(new ProcessBuilder(cmd));
 		}
 		return true;
 	}
@@ -376,7 +376,7 @@ public class Edit extends BaseCommand {
 				"--install-extension", "vscjava.vscode-java-dependency",
 				"--install-extension", "jbangdev.jbang-vscode");
 		pb.inheritIO();
-		Process process = pb.start();
+		Process process = Util.run(pb);
 		try {
 			int exit = process.waitFor();
 			if (exit > 0) {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -110,7 +110,6 @@ public class Run extends BaseBuildCommand {
 		String cmdline = updateGeneratorForRun(genb).build().generate();
 
 		Util.verboseMsg("run: " + cmdline);
-		Util.infoMsg(cmdline);
 		realOut.println(cmdline);
 
 		return EXIT_EXECUTE;

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -110,6 +110,7 @@ public class Run extends BaseBuildCommand {
 		String cmdline = updateGeneratorForRun(genb).build().generate();
 
 		Util.verboseMsg("run: " + cmdline);
+		Util.infoMsg(cmdline);
 		realOut.println(cmdline);
 
 		return EXIT_EXECUTE;

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -124,7 +124,7 @@ public abstract class CompileBuildStep implements Builder<Project> {
 	}
 
 	protected void runCompiler(ProcessBuilder processBuilder) throws IOException {
-		Process process = processBuilder.start();
+		Process process = Util.run(processBuilder);
 		try {
 			process.waitFor();
 		} catch (InterruptedException e) {

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -81,7 +81,7 @@ public class NativeBuildStep implements Builder<Project> {
 		Util.infoMsg("log: " + nilog.toString());
 		pb.redirectOutput(nilog.toFile());
 
-		Process process = pb.start();
+		Process process = Util.run(pb);
 		try {
 			process.waitFor();
 		} catch (InterruptedException e) {

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -269,9 +269,8 @@ public class IntegrationManager {
 			Util.verboseMsg("Input: " + parser.toJson(input));
 		}
 
-		Process process = new ProcessBuilder(args)
-			.redirectError(ProcessBuilder.Redirect.INHERIT)
-			.start();
+		Process process = Util.run(new ProcessBuilder(args)
+			.redirectError(ProcessBuilder.Redirect.INHERIT));
 
 		try (Writer w = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()))) {
 			parser.toJson(input, w);

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -953,7 +953,7 @@ public class Util {
 	}
 
 	public static Process run(ProcessBuilder pb) throws IOException {
-		infoMsg(String.join(" ", pb.command()));
+		verboseMsg(String.join(" ", pb.command()));
 		return pb.start();
 	}
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -952,6 +952,11 @@ public class Util {
 		String version;
 	}
 
+	public static Process run(ProcessBuilder pb) throws IOException {
+		infoMsg(String.join(" ", pb.command()));
+		return pb.start();
+	}
+
 	/**
 	 * Runs the given command + arguments and returns its output (both stdout and
 	 * stderr) as a string
@@ -989,7 +994,7 @@ public class Util {
 				pb.environment().putAll(env);
 			}
 			pb.redirectErrorStream(true);
-			Process p = pb.start();
+			Process p = Util.run(pb);
 			if (stdin != null) {
 				try (OutputStream os = p.getOutputStream()) {
 					os.write(stdin.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
veles has a `-N` option that enables printing of commands - we have that with --verbose too but could be nice being able to just get the commands and not everything else.

this pr just adds the needed wrappers - but does not handle enabling it (its just always on)