### PR TITLE
fix: devkitman now passed default Java version

### DIFF
--- a/src/main/java/dev/jbang/util/JavaUtil.java
+++ b/src/main/java/dev/jbang/util/JavaUtil.java
@@ -29,7 +29,10 @@ public class JavaUtil {
 
 	@NonNull
 	public static JdkManager defaultJdkManager(List<String> names) {
-		return (new JdkManBuilder()).provider(names).build();
+		return (new JdkManBuilder())
+			.provider(names)
+			.defaultJavaVersion(Settings.getDefaultJavaVersion())
+			.build();
 	}
 
 	public static class JdkManBuilder extends JdkManager.Builder {


### PR DESCRIPTION
We weren't passing JBang's default Java version to devkitman, causing it to sue its own default version, which might be different. It also meant the user couldn't override this using JBANG_DEFAULT_JAVA_VERSION.
