### PR TITLE
chore: enable errorprone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ plugins {
 	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.9.2'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
+	id "net.ltgt.errorprone" version "5.1.0"
 }
 
 def allureVersion = '2.29.1'
@@ -152,6 +153,8 @@ sourceSets {
 sourceSets.main.compileClasspath += sourceSets.java9.output.classesDirs;
 
 dependencies {
+	errorprone "com.google.errorprone:error_prone_core:2.50.0"
+
 	implementation "dev.jbang:devkitman:${devkitmanVersion}"
 
 	implementation 'org.jspecify:jspecify:1.0.0'

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -320,7 +320,7 @@ public class Catalog {
 
 	static Catalog findImportedCatalogsWith(Catalog catalog, Function<Catalog, Catalog> accept) {
 		for (CatalogRef cr : catalog.catalogs.values()) {
-			if (cr.importItems == Boolean.TRUE) {
+			if (Boolean.TRUE.equals(cr.importItems)) {
 				try {
 					Catalog cat = Catalog.getByRef(cr.catalogRef);
 					Catalog result = accept.apply(cat);

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -45,7 +45,7 @@ public class Run extends BaseBuildCommand {
 	public List<String> userParams = new ArrayList<>();
 
 	protected void requireScriptArgument() {
-		if (scriptMixin.scriptOrFile == null && ((runMixin.interactive != Boolean.TRUE && literalScript == null)
+		if (scriptMixin.scriptOrFile == null && ((!Boolean.TRUE.equals(runMixin.interactive) && literalScript == null)
 				|| (literalScript != null && literalScript.isEmpty()))) {
 			if (commandInvocation != null) {
 				System.err.println(commandInvocation.getHelpInfo());

--- a/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
+++ b/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
@@ -102,7 +102,7 @@ public class CmdGeneratorBuilder {
 		}
 
 		CmdGenerator gen;
-		if (project.isJShell() || interactive == Boolean.TRUE) {
+		if (project.isJShell() || Boolean.TRUE.equals(interactive)) {
 			gen = createJshCmdGenerator();
 		} else {
 			if (Boolean.TRUE.equals(project.isNativeImage())) {
@@ -119,10 +119,10 @@ public class CmdGeneratorBuilder {
 			.arguments(arguments)
 			.runtimeOptions(runtimeOptions)
 			.mainClass(mainClass)
-			.mainRequired(interactive != Boolean.TRUE)
+			.mainRequired(!Boolean.TRUE.equals(interactive))
 			.moduleName(moduleName)
-			.assertions(enableAssertions == Boolean.TRUE)
-			.systemAssertions(enableSystemAssertions == Boolean.TRUE)
+			.assertions(Boolean.TRUE.equals(enableAssertions))
+			.systemAssertions(Boolean.TRUE.equals(enableSystemAssertions))
 			.classDataSharing(
 					Optional.ofNullable(classDataSharing).orElse(false))
 			.debugString(debugString)
@@ -134,7 +134,7 @@ public class CmdGeneratorBuilder {
 			.arguments(arguments)
 			.runtimeOptions(runtimeOptions)
 			.mainClass(mainClass)
-			.interactive(interactive == Boolean.TRUE)
+			.interactive(Boolean.TRUE.equals(interactive))
 			.debugString(debugString)
 			.flightRecorderString(flightRecorderString);
 	}


### PR DESCRIPTION
Enable [Error Prone](https://errorprone.info/) static analysis.

Now that the build uses JDK 25, the original blocker (errorprone requires JDK 21+) is gone. This is just the 2-line addition — no toolchain or sourceSet changes needed.

- `net.ltgt.errorprone` plugin v5.1.0
- `error_prone_core` v2.50.0

**Expected:** CI will fail with 7 `BoxedPrimitiveEquality` errors (comparing `Boolean` with `==`/`!=` instead of `.equals()`) — these are real bugs that will be fixed in follow-up commits.