### PR TITLE
docs: cross-platform compatibility updates

### DIFF
--- a/docs/modules/ROOT/pages/execution-options.adoc
+++ b/docs/modules/ROOT/pages/execution-options.adoc
@@ -41,7 +41,7 @@ jbang --runtime-option="-Xmx2g" --runtime-option="--enable-preview" myapp.java
 
 === Runtime Options (Cross-Platform Compatibility)
 
-Most standard Java VM (JVM) options are generic and can be used on all Java versions and on all OS platforms, but some JVM options are platform-specific. If a OS specific option is used on a OS platform that do not support the specific option, JBang will fail to start and an error message will be displayed by the JVM. To prevent this from happening, also add JVM option
+Most standard Java VM (JVM) options are generic and can be used on all Java versions and on all OS platforms, but some JVM options are platform-specific. If a OS specific option is used on a OS platform that do not support the specific option, the JVM will display an error message and terminate. To prevent this from happening, also add JVM option
 
 * `-XX:+IgnoreUnrecognizedVMOptions`
 


### PR DESCRIPTION
Document the use of JVM runtime option -XX:+IgnoreUnrecognizedVMOptions to allow platform specific options to be used generically across platforms.
