### PR TITLE
feat: if no main found; print out possible candidates

### DIFF
--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -272,7 +272,7 @@ public abstract class CompileBuildStep implements Builder<Project> {
 
 	protected abstract String getMainExtension();
 
-	protected Predicate<ClassInfo> getMainFinder() {
+	public static Predicate<ClassInfo> getMainFinder() {
 		return pubClass -> (pubClass.method("main", STRINGARRAYTYPE) != null
 				|| pubClass.method("main") != null);
 	}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -407,8 +407,8 @@ public class TestRun extends BaseTest {
 		ExitException e = Assertions.assertThrows(ExitException.class,
 				() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
 
-		assertThat(e.getMessage(), startsWith("no main class"));
-
+		assertThat(e.getMessage(), startsWith("No main class"));
+		assertThat(e.getMessage(), containsString("- picocli.codegen.docgen.manpage.ManPageGenerator"));
 	}
 
 	@Test
@@ -2533,7 +2533,8 @@ public class TestRun extends BaseTest {
 		ExitException e = Assertions.assertThrows(ExitException.class,
 				() -> run.updateGeneratorForRun(CmdGenerator.builder(code)).build().generate());
 
-		assertThat(e.getMessage(), startsWith("no main class"));
+		assertThat(e.getMessage(), startsWith("No main class"));
+		assertThat(e.getMessage(), containsString("- com.oracle.graal.python.shell.GraalPythonMain"));
 	}
 
 	@Test


### PR DESCRIPTION
just a quick idea. wdyt?

before:

```
$ jbang org.jbox2d:jbox2d-testbed:2.2.1.1
[jbang] [ERROR] no main class deduced, specified nor found in a manifest
[jbang] Run with --verbose for more details. The --verbose must be placed before the jbang command. I.e. jbang --verbose run [...]
```

after:

```
$ jbang org.jbox2d:jbox2d-testbed:2.2.1.1
[jbang] [ERROR] No main class deduced, specified nor found in a manifest, but found these candidates:

 - org.jbox2d.testbed.perf.MathPerf
 - org.jbox2d.testbed.framework.TestbedMain
 - org.jbox2d.testbed.perf.PoolingPerf
 - org.jbox2d.testbed.perf.StackTest
 - org.jbox2d.tests.math.SinCosTest

Use -m to specify the main class
[jbang] Run with --verbose for more details. The --verbose must be placed before the jbang command. I.e. jbang --verbose run [...]
```
