### PR TITLE
fix: use JBANG_APP_* rather than JBANG_* for env config

### DIFF
--- a/src/main/java/dev/jbang/source/parser/Directives.java
+++ b/src/main/java/dev/jbang/source/parser/Directives.java
@@ -269,7 +269,7 @@ public abstract class Directives {
 			.filter(d -> d.getName().equals(name))
 			.map(Directive::getValue);
 
-		String envOptions = System.getenv("JBANG_" + name);
+		String envOptions = System.getenv("JBANG_APP_" + name);
 		if (envOptions != null) {
 			javaOptions = Stream.concat(javaOptions, Stream.of(envOptions));
 		}


### PR DESCRIPTION
This is mainly to see if removal of the 6+ year old sideffect found in #2341 actually breaks any tests.