### PR TITLE
fix: enable UTF-8 console support in exported gradle projects

### DIFF
--- a/src/main/resources/export-build.qute.gradle
+++ b/src/main/resources/export-build.qute.gradle
@@ -44,6 +44,7 @@ dependencies {
 application {
 	mainClass = '{fullClassName}'
 	applicationDefaultJvmArgs = [{jvmArgs}]
+	applicationDefaultJvmArgs += ['-Dstdout.encoding=UTF-8', '-Dstderr.encoding=UTF-8']
 {#if enablePreview eq 'true'}
 	applicationDefaultJvmArgs += ['--enable-preview']
 {/if}


### PR DESCRIPTION
Fixes #2359