### PR TITLE
feat: dont fail on concurrent build cache access

### DIFF
--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -89,6 +89,13 @@ public class JBang extends BaseCommand {
 		}
 	}
 
+	@CommandLine.Option(names = {
+			"-x",
+			"--stacktrace" }, description = "Print exceptions stacktraces to stderr (even when quiet).", scope = ScopeType.INHERIT)
+	void printExceptions(boolean printExceptions) {
+		Util.setPrintExceptions(printExceptions);
+	}
+
 	@CommandLine.ArgGroup(exclusive = true)
 	OfflineFreshExclusive offlineFreshExclusive = new OfflineFreshExclusive();
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -114,6 +114,7 @@ public class Util {
 	private static Path cwd;
 	private static Boolean downloadSources;
 	private static Instant startTime = Instant.now();
+	private static boolean printExceptions = false;
 
 	public static void setVerbose(boolean verbose) {
 		Util.verbose = verbose;
@@ -140,6 +141,14 @@ public class Util {
 
 	public static boolean isQuiet() {
 		return quiet;
+	}
+
+	public static void setPrintExceptions(boolean printExceptions) {
+		Util.printExceptions = printExceptions;
+	}
+
+	public static boolean printExceptions() {
+		return printExceptions;
 	}
 
 	public static void setOffline(boolean offline) {
@@ -448,7 +457,9 @@ public class Util {
 		if (isVerbose()) {
 			System.err.print(getMsgHeader());
 			System.err.println(msg);
-			e.printStackTrace();
+			if (printExceptions() || isVerbose()) {
+				e.printStackTrace();
+			}
 		}
 	}
 
@@ -472,7 +483,7 @@ public class Util {
 			System.err.print(getMsgHeader());
 			System.err.print("[WARN] ");
 			System.err.println(msg);
-			if (isVerbose()) {
+			if (printExceptions()) {
 				verboseInfo.printStackTrace();
 			}
 		}
@@ -494,13 +505,13 @@ public class Util {
 		} else {
 			System.err.println(e.getClass().toGenericString());
 		}
-		if (isVerbose()) {
+		if (isVerbose() || printExceptions()) {
 			e.printStackTrace();
 		} else {
 			if (msg != null) {
 				infoMsg(e.getMessage());
 			}
-			infoMsg("Run with --verbose for more details. The --verbose must be placed before the jbang command. I.e. jbang --verbose run [...]");
+			infoMsg("Run with --verbose or -x for more details. The --verbose or -x must be placed before the jbang command. I.e. jbang --verbose run [...]");
 		}
 	}
 
@@ -1505,4 +1516,5 @@ public class Util {
 	public static boolean isJavaKeyword(String s) {
 		return JAVA_KEYWORDS.contains(s);
 	}
+
 }


### PR DESCRIPTION
found that when building with jbang concurrently (like 50+ threads) its quite easy to hit case where dependency cache json gets corrupted and gson starts returning null if hits EOF (code assumed it would throw exception)

ultimately having that single file for all the things is not scalable (but works fine 95% of time) but at least we shouldn't fail.

This PR does two things:

1) Don't fail hard if EOF hit
2) Use atomic moves, fallback to non-atomic to reduce likelihood of #1 ever happening

note: #1 does print a warning that cache is bad - it does not hurt user; but it would be good for us to know if it ever happens again (it shouldn't)

Also introduce '-x' and '--print-stack-trace' to have stacktrace printed for errors even if verbose not enabled.


