### PR TITLE
fix: do not overwrite the main method parameters

### DIFF
--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -24,8 +24,8 @@ public class Main {
 		}
 
 		CommandLine cli = JBang.getCommandLine();
-		args = handleDefaultRun(cli.getCommandSpec(), args);
-		int exitcode = cli.execute(args);
+		String[] nargs = handleDefaultRun(cli.getCommandSpec(), args);
+		int exitcode = cli.execute(nargs);
 		System.exit(exitcode);
 	}
 

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -24,8 +24,8 @@ public class Main {
 		}
 
 		CommandLine cli = JBang.getCommandLine();
-		String[] nargs = handleDefaultRun(cli.getCommandSpec(), args);
-		int exitcode = cli.execute(nargs);
+		String[] new_args = handleDefaultRun(cli.getCommandSpec(), args);
+		int exitcode = cli.execute(new_args);
 		System.exit(exitcode);
 	}
 


### PR DESCRIPTION
The args to main should be viewed as readonly, and should not be modified.

When debugging one should be able to compare the original args to the modified (new_args) args.