### PR TITLE
scala language support

### DIFF
--- a/docs/modules/ROOT/pages/caching.adoc
+++ b/docs/modules/ROOT/pages/caching.adoc
@@ -16,4 +16,18 @@ In previous versions of `jbang`, Java 10+ direct launch of `.java` was used, but
 
 The caching goes to `~/.jbang/cache` by default, you can run `jbang cache clear` to remove all cache data from this folder.
 
+You can also clear individual cache categories:
+
+[source,bash]
+----
+# Clear compiled jars only
+jbang cache clear --jar
+
+# Clear dependency metadata cache
+jbang cache clear --deps
+
+# Clear downloaded Scala compiler cache
+jbang cache clear --scalac
+----
+
 The default cache location can be overwritten by the environment variable `JBANG_CACHE_DIR`. If `JBANG_DIR` environment variable is set, the `cache` folder will be placed there.

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -50,7 +50,7 @@ JBang is a tool that makes it easy to write and run Java scripts without the tra
 
 | **Zero Setup** | Run Java files directly - no project setup needed
 | **Dependency Management** | Declare dependencies with `//DEPS` - automatic resolution
-| **Multiple Languages** | Support for `.java`, `.jsh`, `.kt`, `.groovy`, and `.md` files
+| **Multiple Languages** | Support for `.java`, `.jsh`, `.kt`, `.groovy`, `.scala`, and `.md` files
 | **Native Images** | Generate native binaries with GraalVM
 | **IDE Integration** | Edit with full IDE support using `jbang edit`
 | **Templates** | Quick start with built-in templates

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ image:jbang_logo.svg[JBang Logo, title="JBang Logo"]
 
 Want to learn, explore or use Java instantly without setup?
 
-Do you like Java but use Python, Groovy, Kotlin or similar languages for scripts, experimentation and exploration?
+Do you like Java but use Python, Groovy, Kotlin, Scala or similar languages for scripts, experimentation and exploration?
 
 Ever wanted to just be able to run Java from anywhere without any or very minimal setup?
 

--- a/docs/modules/ROOT/pages/multiple-languages.adoc
+++ b/docs/modules/ROOT/pages/multiple-languages.adoc
@@ -158,7 +158,14 @@ Control the Kotlin version used:
 
 == Scala Scripts (.scala) [EXPERIMENTAL]
 
-JBang supports Scala scripts using the Scala compiler.
+JBang supports Scala using the Scala compiler. Scala support in JBang is provided to complement Java, Kotlin, and Groovy in the same workflow—same directives, same tool, same jbang-catalogs—so you can mix JVM languages in one project or catalog.
+
+[NOTE]
+====
+**Scala-first scripting**: If you want truly first-class Scala scripting via .sc files (Scala-native tooling, best-in-class Scala UX, and the full Scala ecosystem focus), we recommend using https://scala-cli.virtuslab.org/[scala-cli]. `scala-cli` is fully integrated in Scala ecosystem and is very close to how one could imagine if jbang was the cli for Java :)
+====
+
+**Difference in approach**: scala-cli is Scala-centric and optimized for Scala projects and workflows. JBang is multi-language JVM–centric: one CLI for Java, JShell, Kotlin, Groovy, and Scala, with a unified model for dependencies, JDK selection, and catalogs. Choose scala-cli for Scala-only or Scala-primary work; choose JBang when Scala is one of several JVM languages in your scripts or catalogs. 
 
 === Basic Scala Usage
 

--- a/docs/modules/ROOT/pages/multiple-languages.adoc
+++ b/docs/modules/ROOT/pages/multiple-languages.adoc
@@ -156,6 +156,46 @@ Control the Kotlin version used:
 //KOTLIN 2.0.21
 ----
 
+== Scala Scripts (.scala) [EXPERIMENTAL]
+
+JBang supports Scala scripts using the Scala compiler.
+
+=== Basic Scala Usage
+
+Create a file called `hello.scala`:
+
+[source,scala]
+----
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//SCALA 3.8.1
+
+object hello {
+  def main(args: Array[String]): Unit = {
+    val name = args.headOption.getOrElse("World")
+    println(s"Hello $name")
+  }
+}
+----
+
+Run it:
+[source,bash]
+----
+jbang hello.scala
+# First time: Downloads and installs Scala
+# Output: Hello World
+
+jbang hello.scala JBang
+# Output: Hello JBang
+----
+
+=== Scala Version Control
+
+Control the Scala version used:
+[source,scala]
+----
+//SCALA 3.8.1
+----
+
 == Groovy Scripts (.groovy) [EXPERIMENTAL]
 
 JBang supports Groovy scripts using the Groovy compiler.
@@ -294,6 +334,12 @@ jbang readme.md YOLO
 - Coroutines support
 - Interop with Java libraries
 
+=== Scala (.scala)
+- Powerful static type system
+- Functional programming support
+- Rich collections and pattern matching
+- Interop with Java libraries
+
 === Groovy (.groovy)
 - Dynamic scripting
 - Powerful metaprogramming
@@ -337,6 +383,7 @@ echo 'System.out.println("Hello World")' | jbang -
 - **Java**: For production scripts, complex logic, performance-critical code
 - **JShell**: For quick experiments, interactive exploration, simple scripts
 - **Kotlin**: For modern language features, null safety, functional programming
+- **Scala**: For advanced type systems, FP-heavy code, and concise JVM applications
 - **Groovy**: For dynamic scripting, text processing, DSLs
 - **Markdown**: For documentation, tutorials, literate programming
 
@@ -344,7 +391,7 @@ echo 'System.out.println("Hello World")' | jbang -
 
 **Compilation vs. Interpretation**:
 
-- Java/Kotlin/Groovy: Compiled and cached (faster execution)
+- Java/Kotlin/Groovy/Scala: Compiled and cached (faster execution)
 - JShell: Interpreted (faster development)
 - Markdown: Depends on extracted code
 
@@ -352,13 +399,13 @@ echo 'System.out.println("Hello World")' | jbang -
 
 - Java: Fastest after first compilation
 - JShell: Moderate
-- Kotlin/Groovy: Slower first time (compiler download)
+- Kotlin/Groovy/Scala: Slower first time (compiler download)
 
 == Common Issues and Solutions
 
 === Language Not Found
 
-**Problem**: "kotlinc not found" or similar
+**Problem**: "kotlinc not found", "scalac not found" or similar
 **Solution**: JBang automatically downloads language compilers on first use
 
 === Version Conflicts
@@ -369,6 +416,7 @@ echo 'System.out.println("Hello World")' | jbang -
 ----
 //KOTLIN 2.0.21
 //GROOVY 3.0.19
+//SCALA 3.8.1
 ----
 
 === Dependencies Not Working

--- a/docs/modules/ROOT/pages/script-directives.adoc
+++ b/docs/modules/ROOT/pages/script-directives.adoc
@@ -448,6 +448,26 @@ def name = args.length > 0 ? args[0] : "World"
 println "Hello from Groovy $name"
 ----
 
+=== //SCALA
+
+Specifies Scala compiler version.
+
+**Syntax**: `//SCALA version`
+
+**Example**:
+[source,scala]
+----
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//SCALA 3.8.1
+//DEPS org.scala-lang:scala3-library_3:3.8.1
+
+object hello {
+  def main(args: Array[String]): Unit = {
+    println("Hello from Scala " + args.headOption.getOrElse("World"))
+  }
+}
+----
+
 == File and Resource Management
 
 === //SOURCES
@@ -620,9 +640,10 @@ The `--docs` CLI argument can accept a list of comma separated references to ove
 [source,java]
 ----
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//SOURCES kotlin/Utils.kt groovy/Scripts.groovy
+//SOURCES kotlin/Utils.kt groovy/Scripts.groovy scala/Utils.scala
 //DEPS org.jetbrains.kotlin:kotlin-stdlib:2.0.21
 //DEPS org.codehaus.groovy:groovy:3.0.19
+//DEPS org.scala-lang:scala3-library_3:3.8.1
 //FILES config/ templates/
 
 // Mixed-language application
@@ -697,6 +718,7 @@ Some directives can be conditionally applied:
 |`//JAVAAGENT` |Java agent |`//JAVAAGENT agent.jar`
 |`//KOTLIN` |Kotlin version |`//KOTLIN 2.0.21`
 |`//GROOVY` |Groovy version |`//GROOVY 3.0.19`
+|`//SCALA` |Scala version |`//SCALA 3.8.1`
 |`//SOURCES` |Additional sources |`//SOURCES util/Helper.java`
 |`//FILES` |Include files |`//FILES config.properties`
 |`//DESCRIPTION` |Script description |`//DESCRIPTION My utility`

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -330,8 +330,9 @@ jbang --verbose script.java
 jbang cache clear
 
 # Clear specific cache types
-jbang cache clear jars
-jbang cache clear deps
+jbang cache clear --jar
+jbang cache clear --deps
+jbang cache clear --scalac
 
 # Check cache location
 jbang cache list

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -455,6 +455,7 @@ Yes! JBang supports:
 
 - **Kotlin** (`.kt` files)
 - **Groovy** (`.groovy` files)  
+- **Scala** (`.scala` files)
 - **JShell** (`.jsh` files)
 - **Markdown** (`.md` files with code blocks)
 

--- a/docs/modules/cli/pages/jbang-alias-add.adoc
+++ b/docs/modules/cli/pages/jbang-alias-add.adoc
@@ -161,7 +161,7 @@ Add alias for script reference.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-app-install.adoc
+++ b/docs/modules/cli/pages/jbang-app-install.adoc
@@ -154,7 +154,7 @@ Install a script as a command.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-build.adoc
+++ b/docs/modules/cli/pages/jbang-build.adoc
@@ -117,7 +117,7 @@ Compiles and stores script in the cache.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-cache-clear.adoc
+++ b/docs/modules/cli/pages/jbang-cache-clear.adoc
@@ -20,8 +20,9 @@ jbang-cache-clear - Clear the various caches used by jbang. By default this will
 == Synopsis
 
 *jbang cache clear* *-o* [*--all*] [*--[no-]deps*] *--fresh* [*--[no-]groovyc*] [*--[no-]*
-           *       jar*] [*--[no-]jdk*] [*--[no-]kotlinc*] [*--[no-]project*] *--quiet*
-                  [*--[no-]script*] [*--[no-]stdin*] [*--[no-]url*] *--verbose*
+           *       jar*] [*--[no-]jdk*] [*--[no-]kotlinc*] [*--[no-]scalac*] [*--[no-]*
+           *       project*] *--quiet* [*--[no-]script*] [*--[no-]stdin*] [*--[no-]url*]
+                  *--verbose*
 
 // end::picocli-generated-man-section-synopsis[]
 
@@ -55,6 +56,9 @@ Clear the various caches used by jbang. By default this will clear the JAR, scri
 
 *--[no-]kotlinc*::
   clear kotlinc cache only
+
+*--[no-]scalac*::
+  clear scalac cache only
 
 *-o*, *--offline*::
   Work offline. Fail-fast if dependencies are missing. No connections will be attempted

--- a/docs/modules/cli/pages/jbang-edit.adoc
+++ b/docs/modules/cli/pages/jbang-edit.adoc
@@ -96,7 +96,7 @@ Setup a temporary project to edit script in an IDE.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-export-fatjar.adoc
+++ b/docs/modules/cli/pages/jbang-export-fatjar.adoc
@@ -111,7 +111,7 @@ Exports an executable jar with all necessary dependencies included inside
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-export-gradle.adoc
+++ b/docs/modules/cli/pages/jbang-export-gradle.adoc
@@ -118,7 +118,7 @@ Exports a Gradle project
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *-v*, *--version*=_<version>_::
   The version to use for the exported project.

--- a/docs/modules/cli/pages/jbang-export-jlink.adoc
+++ b/docs/modules/cli/pages/jbang-export-jlink.adoc
@@ -111,7 +111,7 @@ Exports a minimized JDK distribution
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-export-local.adoc
+++ b/docs/modules/cli/pages/jbang-export-local.adoc
@@ -111,7 +111,7 @@ Exports jar with classpath referring to local machine dependent locations
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-export-maven.adoc
+++ b/docs/modules/cli/pages/jbang-export-maven.adoc
@@ -118,7 +118,7 @@ Exports a Maven project
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *-v*, *--version*=_<version>_::
   The version to use for the exported project.

--- a/docs/modules/cli/pages/jbang-export-mavenrepo.adoc
+++ b/docs/modules/cli/pages/jbang-export-mavenrepo.adoc
@@ -119,7 +119,7 @@ Exports directory that can be used to publish as a maven repository
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *-v*, *--version*=_<version>_::
   The version to use for the generated POM.

--- a/docs/modules/cli/pages/jbang-export-native.adoc
+++ b/docs/modules/cli/pages/jbang-export-native.adoc
@@ -111,7 +111,7 @@ Exports native executable
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-export-portable.adoc
+++ b/docs/modules/cli/pages/jbang-export-portable.adoc
@@ -112,7 +112,7 @@ Exports jar together with dependencies in way that makes it portable
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-info-classpath.adoc
+++ b/docs/modules/cli/pages/jbang-info-classpath.adoc
@@ -95,7 +95,7 @@ Prints class-path used for this application using operating system specific path
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-info-docs.adoc
+++ b/docs/modules/cli/pages/jbang-info-docs.adoc
@@ -94,7 +94,7 @@ Open the documentation file in the default browser.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-info-jar.adoc
+++ b/docs/modules/cli/pages/jbang-info-jar.adoc
@@ -90,7 +90,7 @@ Prints the path to this application's JAR file.
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-info-tools.adoc
+++ b/docs/modules/cli/pages/jbang-info-tools.adoc
@@ -94,7 +94,7 @@ Prints a json description usable for tools/IDE's to get classpath and more info 
   Indicate the name of the field to select and return from the full info result
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang-run.adoc
+++ b/docs/modules/cli/pages/jbang-run.adoc
@@ -147,7 +147,7 @@ Builds and runs provided script. (default command)
   Add additional sources.
 
 *-T*, *--source-type*=_<forceType>_::
-  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+  Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/itests/runscala.scala
+++ b/itests/runscala.scala
@@ -1,0 +1,7 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+object runscala {
+	def main(args: Array[String]): Unit = {
+		println("SUCCESS!")
+	}
+}

--- a/readme.adoc
+++ b/readme.adoc
@@ -30,7 +30,7 @@ image:images/jbang_logo.svg[JBang Logo, title="JBang Logo"]
 
 Want to learn, explore or use Java instantly without setup?
 
-Do you like Java but use Python, Groovy, Kotlin or similar languages for scripts, experimentation and exploration?
+Do you like Java but use Python, Groovy, Kotlin, Scala or similar languages for scripts, experimentation and exploration?
 
 Ever wanted to just be able to run Java from anywhere without any or very minimal setup?
 
@@ -56,7 +56,7 @@ JBang makes it easy to write and run Java scripts without traditional project se
 
 - **Zero setup** - Run `.java` files directly
 - **Dependency management** - Declare with `//DEPS`, auto-resolve from Maven
-- **Multiple languages** - Java, Kotlin, Groovy, JShell, Markdown  
+- **Multiple languages** - Java, Kotlin, Groovy, Scala, JShell, Markdown  
 - **IDE integration** - Full IDE support with `jbang edit`
 - **Native compilation** - Generate native binaries with GraalVM
 - **Script sharing** - Via GitHub, catalogs, and aliases
@@ -65,7 +65,7 @@ JBang makes it easy to write and run Java scripts without traditional project se
 
 ✅ **Instant Java scripting** - No build files, no project setup
 ✅ **Dependency management** - Maven-style deps with `//DEPS`
-✅ **Multiple file types** - `.java`, `.jsh`, `.kt`, `.groovy`, `.md`
+✅ **Multiple file types** - `.java`, `.jsh`, `.kt`, `.groovy`, `.scala`, `.md`
 ✅ **IDE support** - Full IntelliSense with `jbang edit`
 ✅ **Cross-platform** - Windows, macOS, Linux, AIX
 ✅ **Native images** - GraalVM native-image support

--- a/src/it/java/dev/jbang/it/CacheIT.java
+++ b/src/it/java/dev/jbang/it/CacheIT.java
@@ -27,25 +27,25 @@ public class CacheIT extends AbstractHelpBaseIT {
 // Scenario: clear cache default
 // When command('jbang cache clear --all')
 // * match exit == 0
-// * match err == "[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for kotlincs\n[jbang] Clearing cache for groovycs\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n[jbang] Clearing cache for deps\n"
+// * match err == "[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for kotlincs\n[jbang] Clearing cache for scalacs\n[jbang] Clearing cache for groovycs\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n[jbang] Clearing cache for deps\n"
 	@Test
 	public void clearCacheAll() {
 		assertThat(shell("jbang cache clear --all"))
 			.succeeded()
 			.errContains(
-					"[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for kotlincs\n[jbang] Clearing cache for groovycs\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n[jbang] Clearing cache for deps\n"
+					"[jbang] Clearing cache for urls\n[jbang] Clearing cache for jars\n[jbang] Clearing cache for jdks\n[jbang] Clearing cache for kotlincs\n[jbang] Clearing cache for scalacs\n[jbang] Clearing cache for groovycs\n[jbang] Clearing cache for projects\n[jbang] Clearing cache for scripts\n[jbang] Clearing cache for stdins\n[jbang] Clearing cache for deps\n"
 						.replace(
 								"\n", lineSeparator()));
 	}
 
 // Scenario: clear cache default
-// When command('jbang cache clear --all --no-jdk --no-url --no-jar --no-project --no-script --no-stdin --no-deps --no-kotlinc --groovyc')
+// When command('jbang cache clear --all --no-jdk --no-url --no-jar --no-project --no-script --no-stdin --no-deps --no-kotlinc --no-scalac --no-groovyc')
 // * match exit == 0
 // * match err == ""
 	@Test
 	public void clearNoCache() {
 		assertThat(shell(
-				"jbang cache clear --all --no-jdk --no-url --no-jar --no-project --no-script --no-stdin --no-deps --no-kotlinc --groovyc"))
+				"jbang cache clear --all --no-jdk --no-url --no-jar --no-project --no-script --no-stdin --no-deps --no-kotlinc --no-scalac --no-groovyc"))
 			.succeeded()
 			.errContains(
 					"");

--- a/src/it/java/dev/jbang/it/RunScalaIT.java
+++ b/src/it/java/dev/jbang/it/RunScalaIT.java
@@ -1,0 +1,14 @@
+package dev.jbang.it;
+
+import static dev.jbang.it.CommandResultAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class RunScalaIT extends BaseIT {
+
+	@Test
+	public void shouldRunScala() {
+		assertThat(shell("jbang runscala.scala")).outContains("SUCCESS!").exitedWith(0);
+	}
+
+}

--- a/src/main/java/dev/jbang/Cache.java
+++ b/src/main/java/dev/jbang/Cache.java
@@ -13,7 +13,7 @@ import dev.jbang.util.Util;
 public class Cache {
 
 	public enum CacheClass {
-		urls, jars, jdks, kotlincs, groovycs, projects, scripts, stdins, deps
+		urls, jars, jdks, kotlincs, scalacs, groovycs, projects, scripts, stdins, deps
 	}
 
 	static void setupCache(Path dir) {

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -27,6 +27,8 @@ public class Cache {
 			@CommandLine.Option(names = {
 					"--kotlinc" }, description = "clear kotlinc cache only", negatable = true) Boolean kotlincs,
 			@CommandLine.Option(names = {
+					"--scalac" }, description = "clear scalac cache only", negatable = true) Boolean scalacs,
+			@CommandLine.Option(names = {
 					"--groovyc" }, description = "clear groovyc cache only", negatable = true) Boolean groovys,
 			@CommandLine.Option(names = {
 					"--project" }, description = "clear temporary projects cache only", negatable = true) Boolean projects,
@@ -44,6 +46,7 @@ public class Cache {
 				&& jars == null
 				&& jdks == null
 				&& kotlincs == null
+				&& scalacs == null
 				&& groovys == null
 				&& projects == null
 				&& scripts == null
@@ -62,7 +65,8 @@ public class Cache {
 		toggleCache(jars, dev.jbang.Cache.CacheClass.jars, classes);
 		toggleCache(jdks, dev.jbang.Cache.CacheClass.jdks, classes);
 		toggleCache(kotlincs, dev.jbang.Cache.CacheClass.kotlincs, classes);
-		toggleCache(kotlincs, dev.jbang.Cache.CacheClass.groovycs, classes);
+		toggleCache(scalacs, dev.jbang.Cache.CacheClass.scalacs, classes);
+		toggleCache(groovys, dev.jbang.Cache.CacheClass.groovycs, classes);
 		toggleCache(deps, dev.jbang.Cache.CacheClass.deps, classes);
 		toggleCache(projects, dev.jbang.Cache.CacheClass.projects, classes);
 		toggleCache(scripts, dev.jbang.Cache.CacheClass.scripts, classes);

--- a/src/main/java/dev/jbang/cli/ScriptMixin.java
+++ b/src/main/java/dev/jbang/cli/ScriptMixin.java
@@ -18,7 +18,7 @@ public class ScriptMixin {
 	List<String> resources;
 
 	@CommandLine.Option(names = { "-T",
-			"--source-type" }, description = "Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown")
+			"--source-type" }, description = "Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, scala, or markdown")
 	Source.Type forceType;
 
 	@CommandLine.Option(names = {

--- a/src/main/java/dev/jbang/net/ScalaManager.java
+++ b/src/main/java/dev/jbang/net/ScalaManager.java
@@ -1,0 +1,118 @@
+package dev.jbang.net;
+
+import static dev.jbang.cli.BaseCommand.EXIT_UNEXPECTED_STATE;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import dev.jbang.Cache;
+import dev.jbang.Settings;
+import dev.jbang.cli.ExitException;
+import dev.jbang.util.NetUtil;
+import dev.jbang.util.UnpackUtil;
+import dev.jbang.util.Util;
+
+public class ScalaManager {
+	private static final String SCALA3_DOWNLOAD_URL = "https://github.com/scala/scala3/releases/download/%s/scala3-%s.zip";
+	private static final String SCALA2_DOWNLOAD_URL = "https://github.com/scala/scala/releases/download/v%s/scala-%s.zip";
+
+	public static final String DEFAULT_SCALA_VERSION = "3.8.1";
+	public static final String DEFAULT_SCALA_2_VERSION = "2.13.18";
+
+	public static String resolveInScalaHome(String cmd, String requestedVersion) {
+		Path scalaHome = getScala(requestedVersion);
+		if (Util.isWindows()) {
+			cmd = cmd + ".bat";
+		}
+		return scalaHome.resolve("bin").resolve(cmd).toAbsolutePath().toString();
+	}
+
+	public static Path getScala(String requestedVersion) {
+		String normalizedVersion = normalizeVersion(requestedVersion);
+		Path scalaPath = getScalaPath(normalizedVersion);
+		if (!Files.isDirectory(scalaPath)) {
+			scalaPath = downloadAndInstallScala(normalizedVersion);
+		}
+		return scalaPath.resolve(getScalaDirectoryName(normalizedVersion));
+	}
+
+	public static Path downloadAndInstallScala(String requestedVersion) {
+		String normalizedVersion = normalizeVersion(requestedVersion);
+		Util.infoMsg("Downloading Scala " + normalizedVersion + ". Be patient, this can take several minutes...");
+		String url = getScalaDownloadUrl(normalizedVersion);
+		Util.verboseMsg("Downloading " + url);
+		Path scalaDir = getScalaPath(normalizedVersion);
+		Path scalaTmpDir = scalaDir.getParent().resolve(scalaDir.getFileName().toString() + ".tmp");
+		Path scalaOldDir = scalaDir.getParent().resolve(scalaDir.getFileName().toString() + ".old");
+		Util.deletePath(scalaTmpDir, false);
+		Util.deletePath(scalaOldDir, false);
+		try {
+			Path scalaPkg = NetUtil.downloadAndCacheFile(url);
+			Util.infoMsg("Installing Scala " + normalizedVersion + "...");
+			Util.verboseMsg("Unpacking to " + scalaDir);
+			UnpackUtil.unpack(scalaPkg, scalaTmpDir);
+			if (Files.isDirectory(scalaDir)) {
+				Files.move(scalaDir, scalaOldDir);
+			}
+			Files.move(scalaTmpDir, scalaDir);
+			Util.deletePath(scalaOldDir, false);
+			return scalaDir;
+		} catch (Exception e) {
+			Util.deletePath(scalaTmpDir, true);
+			if (!Files.isDirectory(scalaDir) && Files.isDirectory(scalaOldDir)) {
+				try {
+					Files.move(scalaOldDir, scalaDir);
+				} catch (IOException ex) {
+					// Ignore
+				}
+			}
+			Util.errorMsg("Required Scala version not possible to download or install.");
+			throw new ExitException(EXIT_UNEXPECTED_STATE,
+					"Unable to download or install scalac version " + normalizedVersion, e);
+		}
+	}
+
+	public static Path getScalaPath(String version) {
+		return getScalacsPath().resolve(normalizeVersion(version));
+	}
+
+	public static String normalizeVersion(String requestedVersion) {
+		if (Util.isBlankString(requestedVersion)) {
+			return DEFAULT_SCALA_VERSION;
+		}
+		String version = requestedVersion.trim();
+		if (version.startsWith("v")) {
+			version = version.substring(1);
+		}
+		if ("3".equals(version)) {
+			return DEFAULT_SCALA_VERSION;
+		}
+		if ("2".equals(version) || "2.13".equals(version)) {
+			return DEFAULT_SCALA_2_VERSION;
+		}
+		return version;
+	}
+
+	private static Path getScalacsPath() {
+		return Settings.getCacheDir(Cache.CacheClass.scalacs);
+	}
+
+	private static String getScalaDownloadUrl(String version) {
+		if (isScala2(version)) {
+			return String.format(SCALA2_DOWNLOAD_URL, version, version);
+		}
+		return String.format(SCALA3_DOWNLOAD_URL, version, version);
+	}
+
+	private static String getScalaDirectoryName(String version) {
+		if (isScala2(version)) {
+			return "scala-" + version;
+		}
+		return "scala3-" + version;
+	}
+
+	private static boolean isScala2(String version) {
+		return version.startsWith("2.");
+	}
+}

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -383,6 +383,9 @@ public class ProjectBuilder {
 				if (resourceRef.resolve("src/main/groovy") != null) {
 					sources.add("src/main/groovy/**.groovy");
 				}
+				if (resourceRef.resolve("src/main/scala") != null) {
+					sources.add("src/main/scala/**.scala");
+				}
 			}
 		}
 		List<Source> includedSources = allToSource(sources, resourceRef, sibRes2);

--- a/src/main/java/dev/jbang/source/Source.java
+++ b/src/main/java/dev/jbang/source/Source.java
@@ -37,7 +37,7 @@ public abstract class Source {
 
 	public enum Type {
 		java("java", "java"), jshell("jsh", "java"),
-		kotlin("kt", "kotlin"), groovy("groovy", "groovy"),
+		kotlin("kt", "kotlin"), groovy("groovy", "groovy"), scala("scala", "scala"),
 		markdown("md", "java");
 
 		public final String extension;
@@ -148,6 +148,8 @@ public abstract class Source {
 			return new KotlinSource(resourceRef, replaceProperties);
 		} else if (ext.equals("groovy")) {
 			return new GroovySource(resourceRef, replaceProperties);
+		} else if (ext.equals("scala")) {
+			return new ScalaSource(resourceRef, replaceProperties);
 		} else if (ext.equals("jsh")) {
 			return new JshSource(resourceRef, replaceProperties);
 		} else if (ext.equals("md")) {

--- a/src/main/java/dev/jbang/source/parser/Directives.java
+++ b/src/main/java/dev/jbang/source/parser/Directives.java
@@ -52,6 +52,7 @@ public abstract class Directives {
 		// Directives introduced by non-Java source types extensions
 		public static final String GROOVY = "GROOVY";
 		public static final String KOTLIN = "KOTLIN";
+		public static final String SCALA = "SCALA";
 	}
 
 	public abstract Stream<Directive> getAll();

--- a/src/main/java/dev/jbang/source/sources/ScalaSource.java
+++ b/src/main/java/dev/jbang/source/sources/ScalaSource.java
@@ -1,0 +1,123 @@
+package dev.jbang.source.sources;
+
+import static dev.jbang.net.ScalaManager.resolveInScalaHome;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import org.jspecify.annotations.NonNull;
+
+import dev.jbang.net.ScalaManager;
+import dev.jbang.resources.ResourceRef;
+import dev.jbang.source.*;
+import dev.jbang.source.AppBuilder;
+import dev.jbang.source.buildsteps.CompileBuildStep;
+import dev.jbang.source.parser.Directives;
+import dev.jbang.util.Util;
+
+public class ScalaSource extends Source {
+
+	public ScalaSource(ResourceRef script, Function<String, String> replaceProperties) {
+		super(script, replaceProperties);
+	}
+
+	@Override
+	public @NonNull Type getType() {
+		return Type.scala;
+	}
+
+	@Override
+	protected List<String> collectBinaryDependencies() {
+		final List<String> allDependencies = super.collectBinaryDependencies();
+		final String scalaVersion = getScalaVersion();
+		if (scalaVersion.startsWith("2.")) {
+			allDependencies.add("org.scala-lang:scala-library:" + scalaVersion);
+		} else {
+			allDependencies.add("org.scala-lang:scala3-library_3:" + scalaVersion);
+		}
+		return allDependencies;
+	}
+
+	@Override
+	protected List<String> getCompileOptions() {
+		return getDirectives().compileOptions();
+	}
+
+	@Override
+	protected List<String> getNativeOptions() {
+		return getDirectives().nativeOptions();
+	}
+
+	@Override
+	protected List<String> getRuntimeOptions() {
+		return getDirectives().runtimeOptions();
+	}
+
+	@Override
+	public Builder<CmdGeneratorBuilder> getBuilder(BuildContext ctx) {
+		return new ScalaAppBuilder(ctx);
+	}
+
+	public String getScalaVersion() {
+		return getDirectives().collectDirectives(Directives.Names.SCALA)
+			.findFirst()
+			.map(ScalaManager::normalizeVersion)
+			.orElse(ScalaManager.DEFAULT_SCALA_VERSION);
+	}
+
+	public static class ScalaAppBuilder extends AppBuilder {
+		public ScalaAppBuilder(BuildContext ctx) {
+			super(ctx);
+		}
+
+		@Override
+		protected Builder<Project> getCompileBuildStep() {
+			return new ScalaCompileBuildStep();
+		}
+
+		protected class ScalaCompileBuildStep extends CompileBuildStep {
+
+			public ScalaCompileBuildStep() {
+				super(ScalaAppBuilder.this.ctx);
+			}
+
+			@Override
+			protected String getCompilerBinary() {
+				return resolveInScalaHome("scalac",
+						((ScalaSource) ctx.getProject().getMainSource()).getScalaVersion());
+			}
+
+			@Override
+			protected List<String> getCompileCommandOptions() throws IOException {
+				List<String> optionList = new ArrayList<>();
+				optionList.addAll(ctx.getProject().getMainSourceSet().getCompileOptions());
+				String path = ctx.resolveClassPath().getClassPath();
+				if (!Util.isBlankString(path)) {
+					optionList.addAll(Arrays.asList("-classpath", path));
+				}
+				optionList.addAll(Arrays.asList("-d", ctx.getCompileDir().toAbsolutePath().toString()));
+				return optionList;
+			}
+
+			@Override
+			protected void runCompiler(ProcessBuilder processBuilder) throws IOException {
+				processBuilder.environment()
+					.put("JAVA_HOME",
+							ctx.getProject()
+								.projectJdk()
+								.home()
+								.toString());
+				processBuilder.environment().remove("SCALA_HOME");
+				super.runCompiler(processBuilder);
+			}
+
+			@Override
+			protected String getMainExtension() {
+				return Type.scala.extension;
+			}
+		}
+	}
+}


### PR DESCRIPTION

Feedback welcome - I'm not a scala super user but thought why not try add it :)


scala-cli exists in scala world and is really good and heavily similar (possibly inspired by?) jbang but it doesn't supprot jbang catalog so I thought - why not make it possible in jbang. thus this is not trying to compete with scala-cli nor replace it - definitely use scala-cli where you can :)

For now this just add .scala support just like for .java and .kt, .groovy.

meaning, we dont do like scala-cli does and wrap .sc content in a magical main body nor do we at this time support: 
//DEPS com.lihaoyi::os-lib:0.9.1 but require user to be explicit about the package they need, i.e. //DEPS com.lihaoyi:os-lib_3:0.9.1.

I feel we should then rather call scala-cli directly and let it deal with that instead. 

Anyhow - feedback welcome :) 