### PR TITLE
docs: link to JBang documentation in DeepWiki

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -181,7 +181,9 @@ Beyond scripting, JBang can launch any Java application packaged as a JAR. Check
 
 == Documentation
 
-📖 **Full documentation:** https://jbang.dev/documentation
+📖 **User documentation:** https://jbang.dev/documentation
+
+📖 **Technical documentation:** https://deepwiki.com/jbangdev/jbang
 
 Quick links:
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -183,7 +183,10 @@ Beyond scripting, JBang can launch any Java application packaged as a JAR. Check
 
 📖 **User documentation:** https://jbang.dev/documentation
 
-📖 **Technical documentation:** https://deepwiki.com/jbangdev/jbang
+📖 **Technical documentation:** https://deepwiki.com/jbangdev/jbang, AI generated from source code.
+
+
+
 
 Quick links:
 


### PR DESCRIPTION
Create a link in readme.adoc to the DeepWiki JBang documentation wiki.

- https://deepwiki.com/jbangdev/jbang

Deepwiki creates technical developer documentation for JBang. I think this is rather useful.

Adding a link to the documentation generated by DeepWiki to rhe README file in Github, ensures that the documentation is automatically freshed every week.