### PR TITLE
fix(deps): upgrade to gradle plugin com.gradleup.shadow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.crypto.checksum.Checksum
 
 plugins {
 	id "distribution"
-	id "com.github.johnrengelman.shadow" version "8.0.0"
+	id "com.gradleup.shadow" version "9.0.2"
 	id "java"
 	id "jvm-test-suite"
 	id "com.github.breadmoirai.github-release" version "2.4.1"

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.crypto.checksum.Checksum
 
 plugins {
 	id "distribution"
-	id "com.gradleup.shadow" version "9.0.2"
+	id "com.gradleup.shadow" version "8.3.9"
 	id "java"
 	id "jvm-test-suite"
 	id "com.github.breadmoirai.github-release" version "2.4.1"


### PR DESCRIPTION
Gradle plugin `com.github.johnrengelman.shadow` is now called `com.gradleup.shadow`.

- Upgrade from 8.0.0 to 8.3.9 (and not yet to the 9.x release that may contain breaking changes)