### PR TITLE
chore(deps): upgrade default Groovy version to 4.0.30

### DIFF
--- a/src/main/java/dev/jbang/net/GroovyManager.java
+++ b/src/main/java/dev/jbang/net/GroovyManager.java
@@ -16,7 +16,7 @@ import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
 
 public class GroovyManager {
-	public static final String DEFAULT_GROOVY_VERSION = "4.0.27";
+	public static final String DEFAULT_GROOVY_VERSION = "4.0.30";
 
 	public static String resolveInGroovyHome(String cmd, String requestedVersion) {
 		Path groovyHome = getGroovy(requestedVersion);


### PR DESCRIPTION
Cannot yet upgrade to Groovy 5, because JBang only has Groovy 4 test cases.