### PR TITLE
lock sha/digest POC

### DIFF
--- a/docs/modules/ROOT/pages/locking.adoc
+++ b/docs/modules/ROOT/pages/locking.adoc
@@ -1,0 +1,62 @@
+= Locking & Checksum Verification
+
+JBang supports lightweight integrity and reproducibility checks via digests and lock files.
+
+== Verify a single ref
+
+Use an inline digest suffix:
+
+[source,bash]
+----
+jbang run env@jbangdev#sha256:35a0c5c82720
+----
+
+You can also pass `--verify` explicitly:
+
+[source,bash]
+----
+jbang run --verify sha256:35a0c5c82720 env@jbangdev
+----
+
+NOTE: Digest prefixes are supported (minimum 12 hex chars).
+
+== Generate lock entries
+
+Create/update `.jbang.lock` for a ref:
+
+[source,bash]
+----
+jbang lock env@jbangdev
+jbang lock dev.tamboui:tamboui-toolkit:0.1.0
+----
+
+By default JBang stores:
+
+- `ref=sha256:...` (root digest)
+- `ref.sources=...` (resolved sources, when applicable)
+- `ref.deps=...` (resolved transitive dependency coordinates, when applicable)
+
+== Enforce lock checks
+
+Run in strict locked mode:
+
+[source,bash]
+----
+jbang --locked env@jbangdev
+jbang --locked dev.tamboui:tamboui-toolkit:0.1.0
+----
+
+Locked mode validates:
+
+- root digest
+- source manifest (if present)
+- dependency graph (if present)
+
+If any drift is detected, JBang fails with a clear mismatch error.
+
+== Use another lock file
+
+[source,bash]
+----
+jbang --lock-file /path/to/my.lock --locked env@jbangdev
+----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -15,6 +15,7 @@
 
 * Running & Execution
 ** xref:jbang:ROOT:execution-options.adoc[Execution Options]
+** xref:jbang:ROOT:locking.adoc[Locking & Checksums]
 ** xref:jbang:ROOT:remote-execution.adoc[Remote Execution]
 ** xref:jbang:ROOT:native-images.adoc[Native Images]
 ** xref:jbang:ROOT:self-contained-executables.adoc[Self-Contained Executables]

--- a/docs/modules/cli/pages/jbang-lock.adoc
+++ b/docs/modules/cli/pages/jbang-lock.adoc
@@ -1,0 +1,33 @@
+// Manual page for new lock command (until picocli docs are regenerated)
+:doctype: manpage
+:manmanual: jbang Manual
+:man-linkstyle: pass:[blue R < >]
+= jbang-lock(1)
+
+== Name
+
+jbang-lock - Generate or refresh lock entries for script references.
+
+== Synopsis
+
+*jbang lock* [*--lock-file*=_<lockFile>_] [*--algorithm*=_<algorithm>_] [_<scriptOrFile>_]
+
+== Description
+
+Resolves the given reference and writes lock metadata to a lock file.
+
+Entries include:
+
+- Root digest (`ref=sha256:...`)
+- Resolved source manifest (`ref.sources=...`) when available
+- Resolved transitive dependency coordinates (`ref.deps=...`) when available
+
+== Options
+
+*--algorithm*=_<algorithm>_: `sha256` by default.
+
+*--lock-file*=_<lockFile>_: path to lock file, default is `.jbang.lock`.
+
+== Arguments
+
+[_<scriptOrFile>_]: reference to lock (alias, URL, GAV, file, etc.).

--- a/docs/modules/cli/pages/jbang-run.adoc
+++ b/docs/modules/cli/pages/jbang-run.adoc
@@ -122,6 +122,15 @@ Builds and runs provided script. (default command)
 *--manifest*=_<String=String>_::
   
 
+*--lock-file*=_<lockFile>_::
+  Path to lock file (default: .jbang.lock)
+
+*--lock-write*::
+  Write/update digest entry in the lock file for this ref.
+
+*--locked*::
+  Require matching lock entry and enforce lock checks.
+
 *--module*[=_<module>_]::
   Treat resource as a module. Optionally with the given module name
 
@@ -148,6 +157,9 @@ Builds and runs provided script. (default command)
 
 *-T*, *--source-type*=_<forceType>_::
   Force input to be interpreted as the given type. Can be: java, jshell, groovy, kotlin, or markdown
+
+*--verify*=_<digest>_::
+  Verify script content with digest, e.g. `sha256:abc123`.
 
 *--verbose*::
   jbang will be verbose on what it does.

--- a/docs/modules/cli/pages/jbang.adoc
+++ b/docs/modules/cli/pages/jbang.adoc
@@ -134,6 +134,9 @@ xref:jbang:cli:jbang-export.adoc[*export*]::
 xref:jbang:cli:jbang-config.adoc[*config*]::
   Read and write configuration options.
 
+xref:jbang:cli:jbang-lock.adoc[*lock*]::
+  Generate or refresh lock entries for script references.
+
 // end::picocli-generated-man-section-commands[]
 
 // tag::picocli-generated-man-section-exit-status[]

--- a/docs/modules/cli/partials/nav-jbang.adoc
+++ b/docs/modules/cli/partials/nav-jbang.adoc
@@ -58,3 +58,4 @@
 *** xref:jbang:cli:jbang-config-set.adoc[set]
 *** xref:jbang:cli:jbang-config-unset.adoc[unset]
 *** xref:jbang:cli:jbang-config-list.adoc[list]
+** xref:jbang:cli:jbang-lock.adoc[lock]

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -60,7 +60,7 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 		"" }, versionProvider = VersionProvider.class, subcommands = {
 				Run.class, Build.class, Edit.class, Init.class, Alias.class, Template.class, Catalog.class, Trust.class,
 				Cache.class, Completion.class, Jdk.class, Version.class, Wrapper.class, Info.class, App.class,
-				Export.class, Config.class, Deps.class })
+				Export.class, Config.class, Deps.class, Lock.class })
 public class JBang extends BaseCommand {
 
 	@CommandLine.Option(names = { "-V",

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -292,7 +292,7 @@ public class JBang extends BaseCommand {
 		private Map<String, List<String>> sections() {
 			if (sections == null) {
 				sections = new LinkedHashMap<>();
-				sections.put("Essentials", asList("run", "build"));
+				sections.put("Essentials", asList("run", "build", "lock"));
 				sections.put("Editing", asList("init", "edit", "deps"));
 				sections.put("Caching", asList("cache", "export", "jdk"));
 				sections.put("Configuration", asList("config", "trust", "alias", "template", "catalog", "app"));

--- a/src/main/java/dev/jbang/cli/Lock.java
+++ b/src/main/java/dev/jbang/cli/Lock.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
+import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.LockFileUtil;
@@ -39,7 +40,11 @@ public class Lock extends BaseBuildCommand {
 		List<String> sources = prj.getMainSourceSet().getSources().stream()
 				.map(s -> relativizeSafe(s.getOriginalResource()))
 				.collect(Collectors.toList());
-		LockFileUtil.write(effectiveLockFile, ref, digest, sources);
+		List<String> deps = BuildContext.forProject(prj).resolveClassPath().getArtifacts().stream()
+				.map(a -> a.getCoordinate() == null ? "" : a.getCoordinate().toCanonicalForm())
+				.filter(s -> !s.isEmpty())
+				.collect(Collectors.toList());
+		LockFileUtil.write(effectiveLockFile, ref, digest, sources, deps);
 		info("Locked " + ref + " => " + digest + " in " + effectiveLockFile);
 		return EXIT_OK;
 	}

--- a/src/main/java/dev/jbang/cli/Lock.java
+++ b/src/main/java/dev/jbang/cli/Lock.java
@@ -2,13 +2,15 @@ package dev.jbang.cli;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import dev.jbang.source.BuildContext;
@@ -72,10 +74,10 @@ public class Lock extends BaseBuildCommand {
 		if (lockFile != null) {
 			return lockFile;
 		}
-		java.nio.file.Path p = java.nio.file.Paths.get(ref);
-		java.nio.file.Path candidate = p.isAbsolute() ? p : Util.getCwd().resolve(p);
-		if (java.nio.file.Files.exists(candidate) && java.nio.file.Files.isRegularFile(candidate)) {
-			return java.nio.file.Paths.get(ref + ".lock");
+		Path p = Paths.get(ref);
+		Path candidate = p.isAbsolute() ? p : Util.getCwd().resolve(p);
+		if (Files.exists(candidate) && Files.isRegularFile(candidate)) {
+			return Paths.get(ref + ".lock");
 		}
 		return Util.getCwd().resolve(".jbang.lock");
 	}
@@ -87,11 +89,10 @@ public class Lock extends BaseBuildCommand {
 		return val;
 	}
 
-
-	private static String digestPath(java.nio.file.Path path, String algorithm) throws IOException {
+	private static String digestPath(Path path, String algorithm) throws IOException {
 		try {
 			MessageDigest md = MessageDigest.getInstance(algorithm.toUpperCase(Locale.ROOT));
-			try (InputStream in = java.nio.file.Files.newInputStream(path)) {
+			try (InputStream in = Files.newInputStream(path)) {
 				byte[] buffer = new byte[8192];
 				int read;
 				while ((read = in.read(buffer)) >= 0) {

--- a/src/main/java/dev/jbang/cli/Lock.java
+++ b/src/main/java/dev/jbang/cli/Lock.java
@@ -1,0 +1,77 @@
+package dev.jbang.cli;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import dev.jbang.source.Project;
+import dev.jbang.source.ProjectBuilder;
+import dev.jbang.util.LockFileUtil;
+import dev.jbang.util.Util;
+import picocli.CommandLine;
+
+@CommandLine.Command(name = "lock", description = "Generate or refresh lock entries for script references")
+public class Lock extends BaseBuildCommand {
+
+	@CommandLine.Option(names = { "--lock-file" }, description = "Path to lock file (default: .jbang.lock)")
+	Path lockFile;
+
+	@CommandLine.Option(names = { "--algorithm" }, description = "Digest algorithm (default: sha256)")
+	String algorithm = "sha256";
+
+	@Override
+	public Integer doCall() throws IOException {
+		scriptMixin.validate(true);
+		String ref = scriptMixin.scriptOrFile;
+		Run.RefWithChecksum parsed = Run.splitRefAndChecksum(ref);
+		ref = parsed.ref;
+
+		ProjectBuilder pb = createBaseProjectBuilder();
+		Project prj = pb.build(ref);
+
+		String digest = digestResource(prj, algorithm);
+		Path effectiveLockFile = lockFile != null ? lockFile : Util.getCwd().resolve(".jbang.lock");
+		List<String> sources = prj.getMainSourceSet().getSources().stream()
+				.map(s -> relativizeSafe(s.getOriginalResource()))
+				.collect(Collectors.toList());
+		LockFileUtil.write(effectiveLockFile, ref, digest, sources);
+		info("Locked " + ref + " => " + digest + " in " + effectiveLockFile);
+		return EXIT_OK;
+	}
+
+	private static String relativizeSafe(String val) {
+		if (val == null) {
+			return "";
+		}
+		return val;
+	}
+
+	private static String digestResource(Project prj, String algorithm) throws IOException {
+		try {
+			MessageDigest md = MessageDigest.getInstance(algorithm.toUpperCase(Locale.ROOT));
+			try (InputStream in = prj.getResourceRef().getInputStream()) {
+				byte[] buffer = new byte[8192];
+				int read;
+				while ((read = in.read(buffer)) >= 0) {
+					md.update(buffer, 0, read);
+				}
+			}
+			return algorithm.toLowerCase(Locale.ROOT) + ":" + toHex(md.digest());
+		} catch (NoSuchAlgorithmException e) {
+			throw new ExitException(EXIT_INVALID_INPUT, "Unsupported digest algorithm: " + algorithm, e);
+		}
+	}
+
+	private static String toHex(byte[] bytes) {
+		StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for (byte b : bytes) {
+			sb.append(String.format("%02x", b));
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -237,10 +237,8 @@ public class Run extends BaseBuildCommand {
 		if (idx < 0 || idx == ref.length() - 1) {
 			return new RefWithChecksum(ref, null);
 		}
-		String digest = ref.substring(idx + 1);
-		if (!digest.contains(":")) {
-			return new RefWithChecksum(ref, null);
-		}
+		String suffix = ref.substring(idx + 1);
+		String digest = suffix.contains(":") ? suffix : "sha256:" + suffix;
 		return new RefWithChecksum(ref.substring(0, idx), digest);
 	}
 

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -128,11 +128,7 @@ public class Run extends BaseBuildCommand {
 					Set<String> actual = prj.getMainSourceSet().getSources().stream()
 							.map(s -> s.getOriginalResource() == null ? "" : s.getOriginalResource())
 							.collect(Collectors.toCollection(LinkedHashSet::new));
-					if (!actual.equals(expected)) {
-						throw new ExitException(EXIT_INVALID_INPUT,
-								"Locked sources mismatch for " + scriptOrFile + ". Expected " + expected + " but got " + actual,
-								null);
-					}
+					verifyLockedSet("sources", scriptOrFile, expected, actual);
 				}
 				if (!lockDeps.isEmpty()) {
 					Set<String> expectedDeps = new LinkedHashSet<>(lockDeps);
@@ -140,12 +136,7 @@ public class Run extends BaseBuildCommand {
 							.map(a -> a.getCoordinate() == null ? "" : a.getCoordinate().toCanonicalForm())
 							.filter(s -> !s.isEmpty())
 							.collect(Collectors.toCollection(LinkedHashSet::new));
-					if (!actualDeps.equals(expectedDeps)) {
-						throw new ExitException(EXIT_INVALID_INPUT,
-								"Locked dependency graph mismatch for " + scriptOrFile + ". Expected " + expectedDeps + " but got "
-										+ actualDeps,
-								null);
-					}
+					verifyLockedSet("dependency graph", scriptOrFile, expectedDeps, actualDeps);
 				}
 			}
 			if (lockWrite) {
@@ -279,6 +270,14 @@ public class Run extends BaseBuildCommand {
 			sb.append(String.format("%02x", b));
 		}
 		return sb.toString();
+	}
+
+	static void verifyLockedSet(String kind, String ref, Set<String> expected, Set<String> actual) {
+		if (!actual.equals(expected)) {
+			throw new ExitException(EXIT_INVALID_INPUT,
+					"Locked " + kind + " mismatch for " + ref + ". Expected " + expected + " but got " + actual,
+					null);
+		}
 	}
 
 	static void verifyDigestSpec(String actualDigest, String expectedDigest, String source) {

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -76,7 +76,16 @@ public class Run extends BaseBuildCommand {
 			scriptOrFile = refWithChecksum.ref;
 		}
 
+		Path effectiveLockFile = lockFile != null ? lockFile : Util.getCwd().resolve(".jbang.lock");
+		List<String> preLockSources = Collections.emptyList();
+		if (locked && scriptOrFile != null) {
+			preLockSources = LockFileUtil.readSources(effectiveLockFile, scriptOrFile);
+		}
+
 		ProjectBuilder pb = createProjectBuilderForRun();
+		if (!preLockSources.isEmpty()) {
+			pb.lockedSourcesOverride(preLockSources);
+		}
 
 		Project prj;
 		if (literalScript.isPresent()) {
@@ -100,7 +109,6 @@ public class Run extends BaseBuildCommand {
 		}
 
 		if (!literalScript.isPresent() && scriptOrFile != null) {
-			Path effectiveLockFile = lockFile != null ? lockFile : Util.getCwd().resolve(".jbang.lock");
 			String actualDigest = digestResource(prj, "sha256");
 			String lockDigest = null;
 			List<String> lockSources = Collections.emptyList();

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -66,6 +66,7 @@ import dev.jbang.util.Util;
  */
 public class ProjectBuilder {
 	private List<String> additionalSources = new ArrayList<>();
+	private List<String> lockedSourcesOverride = Collections.emptyList();
 	private List<String> additionalResources = new ArrayList<>();
 	private List<String> additionalDeps = new ArrayList<>();
 	private List<String> additionalRepos = new ArrayList<>();
@@ -112,6 +113,15 @@ public class ProjectBuilder {
 			this.additionalSources = new ArrayList<>(sources);
 		} else {
 			this.additionalSources = Collections.emptyList();
+		}
+		return this;
+	}
+
+	public ProjectBuilder lockedSourcesOverride(List<String> sources) {
+		if (sources != null) {
+			this.lockedSourcesOverride = new ArrayList<>(sources);
+		} else {
+			this.lockedSourcesOverride = Collections.emptyList();
 		}
 		return this;
 	}
@@ -684,7 +694,12 @@ public class ProjectBuilder {
 				prj.addSubProject(new ProjectBuilder(buildRefs).build(subRef));
 			}
 			ResourceResolver sibRes2 = getSiblingResolver(srcRef, resolver);
-			List<Source> includedSources = allToSource(src.getDirectives().sources(), srcRef, sibRes2);
+			List<String> sourceRefs = src.getDirectives().sources();
+			if (!lockedSourcesOverride.isEmpty() && prj.getMainSource() != null
+					&& srcRef.equals(prj.getMainSource().getResourceRef())) {
+				sourceRefs = lockedSourcesOverride;
+			}
+			List<Source> includedSources = allToSource(sourceRefs, srcRef, sibRes2);
 			for (Source includedSource : includedSources) {
 				updateProject(includedSource, prj, resolver);
 			}

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -1,0 +1,41 @@
+package dev.jbang.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+public final class LockFileUtil {
+
+	private LockFileUtil() {
+	}
+
+	public static String readDigest(Path lockFile, String ref) throws IOException {
+		if (!Files.exists(lockFile)) {
+			return null;
+		}
+		Properties p = new Properties();
+		try (InputStream in = Files.newInputStream(lockFile)) {
+			p.load(in);
+		}
+		return p.getProperty(ref);
+	}
+
+	public static void writeDigest(Path lockFile, String ref, String digest) throws IOException {
+		Properties p = new Properties();
+		if (Files.exists(lockFile)) {
+			try (InputStream in = Files.newInputStream(lockFile)) {
+				p.load(in);
+			}
+		}
+		p.setProperty(ref, digest);
+		if (lockFile.getParent() != null) {
+			Files.createDirectories(lockFile.getParent());
+		}
+		try (OutputStream out = Files.newOutputStream(lockFile)) {
+			p.store(out, "JBang lockfile v1");
+		}
+	}
+}

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -6,6 +6,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ public final class LockFileUtil {
 
 	private static List<String> readList(Path lockFile, String key) throws IOException {
 		if (!Files.exists(lockFile)) {
-			return java.util.Collections.emptyList();
+			return Collections.emptyList();
 		}
 		Properties p = new Properties();
 		try (InputStream in = Files.newInputStream(lockFile)) {
@@ -46,7 +47,7 @@ public final class LockFileUtil {
 		}
 		String val = p.getProperty(key);
 		if (val == null || val.trim().isEmpty()) {
-			return java.util.Collections.emptyList();
+			return Collections.emptyList();
 		}
 		return Arrays.stream(val.split(",")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toList());
 	}

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -53,7 +53,8 @@ public final class LockFileUtil {
 		write(lockFile, ref, digest, null, null);
 	}
 
-	public static void write(Path lockFile, String ref, String digest, List<String> sources, List<String> deps) throws IOException {
+	public static void write(Path lockFile, String ref, String digest, List<String> sources, List<String> deps)
+			throws IOException {
 		Properties p = new Properties();
 		if (Files.exists(lockFile)) {
 			try (InputStream in = Files.newInputStream(lockFile)) {

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -51,7 +51,6 @@ public final class LockFileUtil {
 		return Arrays.stream(val.split(",")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toList());
 	}
 
-
 	public static Map<String, String> readDepDigests(Path lockFile, String ref) throws IOException {
 		Map<String, String> result = new LinkedHashMap<>();
 		if (!Files.exists(lockFile)) {

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -5,7 +5,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public final class LockFileUtil {
 
@@ -23,7 +26,26 @@ public final class LockFileUtil {
 		return p.getProperty(ref);
 	}
 
+	public static List<String> readSources(Path lockFile, String ref) throws IOException {
+		if (!Files.exists(lockFile)) {
+			return java.util.Collections.emptyList();
+		}
+		Properties p = new Properties();
+		try (InputStream in = Files.newInputStream(lockFile)) {
+			p.load(in);
+		}
+		String val = p.getProperty(ref + ".sources");
+		if (val == null || val.trim().isEmpty()) {
+			return java.util.Collections.emptyList();
+		}
+		return Arrays.stream(val.split(",")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toList());
+	}
+
 	public static void writeDigest(Path lockFile, String ref, String digest) throws IOException {
+		write(lockFile, ref, digest, null);
+	}
+
+	public static void write(Path lockFile, String ref, String digest, List<String> sources) throws IOException {
 		Properties p = new Properties();
 		if (Files.exists(lockFile)) {
 			try (InputStream in = Files.newInputStream(lockFile)) {
@@ -31,6 +53,9 @@ public final class LockFileUtil {
 			}
 		}
 		p.setProperty(ref, digest);
+		if (sources != null && !sources.isEmpty()) {
+			p.setProperty(ref + ".sources", String.join(",", sources));
+		}
 		if (lockFile.getParent() != null) {
 			Files.createDirectories(lockFile.getParent());
 		}

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -27,6 +27,14 @@ public final class LockFileUtil {
 	}
 
 	public static List<String> readSources(Path lockFile, String ref) throws IOException {
+		return readList(lockFile, ref + ".sources");
+	}
+
+	public static List<String> readDeps(Path lockFile, String ref) throws IOException {
+		return readList(lockFile, ref + ".deps");
+	}
+
+	private static List<String> readList(Path lockFile, String key) throws IOException {
 		if (!Files.exists(lockFile)) {
 			return java.util.Collections.emptyList();
 		}
@@ -34,7 +42,7 @@ public final class LockFileUtil {
 		try (InputStream in = Files.newInputStream(lockFile)) {
 			p.load(in);
 		}
-		String val = p.getProperty(ref + ".sources");
+		String val = p.getProperty(key);
 		if (val == null || val.trim().isEmpty()) {
 			return java.util.Collections.emptyList();
 		}
@@ -42,10 +50,10 @@ public final class LockFileUtil {
 	}
 
 	public static void writeDigest(Path lockFile, String ref, String digest) throws IOException {
-		write(lockFile, ref, digest, null);
+		write(lockFile, ref, digest, null, null);
 	}
 
-	public static void write(Path lockFile, String ref, String digest, List<String> sources) throws IOException {
+	public static void write(Path lockFile, String ref, String digest, List<String> sources, List<String> deps) throws IOException {
 		Properties p = new Properties();
 		if (Files.exists(lockFile)) {
 			try (InputStream in = Files.newInputStream(lockFile)) {
@@ -55,6 +63,9 @@ public final class LockFileUtil {
 		p.setProperty(ref, digest);
 		if (sources != null && !sources.isEmpty()) {
 			p.setProperty(ref + ".sources", String.join(",", sources));
+		}
+		if (deps != null && !deps.isEmpty()) {
+			p.setProperty(ref + ".deps", String.join(",", deps));
 		}
 		if (lockFile.getParent() != null) {
 			Files.createDirectories(lockFile.getParent());

--- a/src/native-image/config/reachability-metadata.json
+++ b/src/native-image/config/reachability-metadata.json
@@ -235,6 +235,9 @@
       "type": "dev.jbang.cli.DepsSearch"
     },
     {
+      "type": "dev.jbang.cli.Lock"
+    },
+    {
       "type": "dev.jbang.search.MvnSearchResult",
       "allDeclaredConstructors" : true,
       "allPublicConstructors" : true,

--- a/src/test/java/dev/jbang/cli/TestRunChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestRunChecksum.java
@@ -1,0 +1,40 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class TestRunChecksum {
+
+	@Test
+	void splitRefAndChecksumParsesDigestSuffix() {
+		Run.RefWithChecksum ref = Run.splitRefAndChecksum("alias@catalog#sha256:abcdef123456");
+		assertEquals("alias@catalog", ref.ref);
+		assertEquals("sha256:abcdef123456", ref.checksum);
+	}
+
+	@Test
+	void splitRefAndChecksumLeavesUrlsWithoutDigestUntouched() {
+		Run.RefWithChecksum ref = Run.splitRefAndChecksum("https://example.org/foo#frag");
+		assertEquals("https://example.org/foo#frag", ref.ref);
+		assertEquals(null, ref.checksum);
+	}
+
+	@Test
+	void verifyDigestSpecAcceptsPrefix() {
+		Run.verifyDigestSpec("sha256:abcdef1234567890", "sha256:abcdef123456", "test");
+	}
+
+	@Test
+	void verifyDigestSpecRejectsShortPrefix() {
+		assertThrows(ExitException.class,
+				() -> Run.verifyDigestSpec("sha256:abcdef1234567890", "sha256:abcd", "test"));
+	}
+
+	@Test
+	void verifyDigestSpecRejectsMismatch() {
+		assertThrows(ExitException.class,
+				() -> Run.verifyDigestSpec("sha256:abcdef1234567890", "sha256:bbbbbbbbbbbb", "test"));
+	}
+}

--- a/src/test/java/dev/jbang/cli/TestRunChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestRunChecksum.java
@@ -15,10 +15,10 @@ public class TestRunChecksum {
 	}
 
 	@Test
-	void splitRefAndChecksumLeavesUrlsWithoutDigestUntouched() {
-		Run.RefWithChecksum ref = Run.splitRefAndChecksum("https://example.org/foo#frag");
-		assertEquals("https://example.org/foo#frag", ref.ref);
-		assertEquals(null, ref.checksum);
+	void splitRefAndChecksumTreatsBareSuffixAsSha256Prefix() {
+		Run.RefWithChecksum ref = Run.splitRefAndChecksum("env@jbangdev#blanah");
+		assertEquals("env@jbangdev", ref.ref);
+		assertEquals("sha256:blanah", ref.checksum);
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRunChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestRunChecksum.java
@@ -52,7 +52,7 @@ public class TestRunChecksum {
 		actual.add("x:y:jar:3");
 		ExitException ex = assertThrows(ExitException.class,
 				() -> Run.verifyLockedSet("dependency graph", "demo@cat", expected, actual));
-		assertTrue(ex.getMessage().contains("Locked dependency graph mismatch for demo@cat"));
+		assertTrue(ex.getMessage().contains("Lock verification failed for demo@cat (dependency graph mismatch)"));
 	}
 
 	@Test
@@ -63,6 +63,6 @@ public class TestRunChecksum {
 		actual.add("https://example/b.java");
 		ExitException ex = assertThrows(ExitException.class,
 				() -> Run.verifyLockedSet("sources", "env@jbangdev", expected, actual));
-		assertTrue(ex.getMessage().contains("Locked sources mismatch for env@jbangdev"));
+		assertTrue(ex.getMessage().contains("Lock verification failed for env@jbangdev (sources mismatch)"));
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestRunChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestRunChecksum.java
@@ -2,6 +2,10 @@ package dev.jbang.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -36,5 +40,29 @@ public class TestRunChecksum {
 	void verifyDigestSpecRejectsMismatch() {
 		assertThrows(ExitException.class,
 				() -> Run.verifyDigestSpec("sha256:abcdef1234567890", "sha256:bbbbbbbbbbbb", "test"));
+	}
+
+	@Test
+	void verifyLockedSetRejectsDependencyDrift() {
+		Set<String> expected = new LinkedHashSet<>();
+		expected.add("a:b:jar:1");
+		expected.add("x:y:jar:2");
+		Set<String> actual = new LinkedHashSet<>();
+		actual.add("a:b:jar:1");
+		actual.add("x:y:jar:3");
+		ExitException ex = assertThrows(ExitException.class,
+				() -> Run.verifyLockedSet("dependency graph", "demo@cat", expected, actual));
+		assertTrue(ex.getMessage().contains("Locked dependency graph mismatch for demo@cat"));
+	}
+
+	@Test
+	void verifyLockedSetRejectsSourcesDrift() {
+		Set<String> expected = new LinkedHashSet<>();
+		expected.add("https://example/a.java");
+		Set<String> actual = new LinkedHashSet<>();
+		actual.add("https://example/b.java");
+		ExitException ex = assertThrows(ExitException.class,
+				() -> Run.verifyLockedSet("sources", "env@jbangdev", expected, actual));
+		assertTrue(ex.getMessage().contains("Locked sources mismatch for env@jbangdev"));
 	}
 }

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +16,7 @@ public class TestLockFileUtil {
 	@Test
 	void writesAndReadsDigestAndSources() throws Exception {
 		Path tmp = Files.createTempFile("jbang-lock", ".lock");
-		java.util.Map<String, String> depDigests = new java.util.LinkedHashMap<>();
+		Map<String, String> depDigests = new LinkedHashMap<>();
 		depDigests.put("g:a:1", "sha256:aaaabbbbcccc");
 		depDigests.put("g:b:2", "sha256:ddddeeeeffff");
 		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", Arrays.asList("a.java", "b.java"),
@@ -28,8 +31,8 @@ public class TestLockFileUtil {
 	void missingEntriesReturnEmptyCollectionsOrNull() throws Exception {
 		Path tmp = Files.createTempFile("jbang-lock-empty", ".lock");
 		assertEquals(null, LockFileUtil.readDigest(tmp, "missing@ref"));
-		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readSources(tmp, "missing@ref"));
-		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readDeps(tmp, "missing@ref"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readSources(tmp, "missing@ref"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readDeps(tmp, "missing@ref"));
 	}
 
 	@Test
@@ -37,7 +40,7 @@ public class TestLockFileUtil {
 		Path tmp = Files.createTempFile("jbang-lock-digest", ".lock");
 		LockFileUtil.writeDigest(tmp, "x:y:z", "sha256:deadbeefdead");
 		assertEquals("sha256:deadbeefdead", LockFileUtil.readDigest(tmp, "x:y:z"));
-		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readSources(tmp, "x:y:z"));
-		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readDeps(tmp, "x:y:z"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readSources(tmp, "x:y:z"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readDeps(tmp, "x:y:z"));
 	}
 }

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -13,11 +13,15 @@ public class TestLockFileUtil {
 	@Test
 	void writesAndReadsDigestAndSources() throws Exception {
 		Path tmp = Files.createTempFile("jbang-lock", ".lock");
+		java.util.Map<String, String> depDigests = new java.util.LinkedHashMap<>();
+		depDigests.put("g:a:1", "sha256:aaaabbbbcccc");
+		depDigests.put("g:b:2", "sha256:ddddeeeeffff");
 		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", Arrays.asList("a.java", "b.java"),
-				Arrays.asList("g:a:1", "g:b:2"));
+				Arrays.asList("g:a:1", "g:b:2"), depDigests);
 		assertEquals("sha256:abcdef123456", LockFileUtil.readDigest(tmp, "alias@catalog"));
 		assertEquals(Arrays.asList("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
 		assertEquals(Arrays.asList("g:a:1", "g:b:2"), LockFileUtil.readDeps(tmp, "alias@catalog"));
+		assertEquals(depDigests, LockFileUtil.readDepDigests(tmp, "alias@catalog"));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -20,4 +20,21 @@ public class TestLockFileUtil {
 		assertEquals(Arrays.asList("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
 		assertEquals(Arrays.asList("g:a:1", "g:b:2"), LockFileUtil.readDeps(tmp, "alias@catalog"));
 	}
+
+	@Test
+	void missingEntriesReturnEmptyCollectionsOrNull() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock-empty", ".lock");
+		assertEquals(null, LockFileUtil.readDigest(tmp, "missing@ref"));
+		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readSources(tmp, "missing@ref"));
+		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readDeps(tmp, "missing@ref"));
+	}
+
+	@Test
+	void writeDigestDoesNotRequireSourcesOrDeps() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock-digest", ".lock");
+		LockFileUtil.writeDigest(tmp, "x:y:z", "sha256:deadbeefdead");
+		assertEquals("sha256:deadbeefdead", LockFileUtil.readDigest(tmp, "x:y:z"));
+		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readSources(tmp, "x:y:z"));
+		assertEquals(java.util.Collections.emptyList(), LockFileUtil.readDeps(tmp, "x:y:z"));
+	}
 }

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -1,0 +1,20 @@
+package dev.jbang.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class TestLockFileUtil {
+
+	@Test
+	void writesAndReadsDigestAndSources() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock", ".lock");
+		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", List.of("a.java", "b.java"));
+		assertEquals("sha256:abcdef123456", LockFileUtil.readDigest(tmp, "alias@catalog"));
+		assertEquals(List.of("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
+	}
+}

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -13,8 +14,10 @@ public class TestLockFileUtil {
 	@Test
 	void writesAndReadsDigestAndSources() throws Exception {
 		Path tmp = Files.createTempFile("jbang-lock", ".lock");
-		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", List.of("a.java", "b.java"));
+		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", Arrays.asList("a.java", "b.java"),
+				Arrays.asList("g:a:1", "g:b:2"));
 		assertEquals("sha256:abcdef123456", LockFileUtil.readDigest(tmp, "alias@catalog"));
-		assertEquals(List.of("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
+		assertEquals(Arrays.asList("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
+		assertEquals(Arrays.asList("g:a:1", "g:b:2"), LockFileUtil.readDeps(tmp, "alias@catalog"));
 	}
 }

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION

This PR adds lock-based integrity + reproducibility checks for JBang refs, while preserving normal run behavior when no lock file exists.

p.s. I was not actually expecting to have this in now but implementation shaped up nicely while I was assembling an IKEA table and having a chat with an LLM (brave new world :) - opening as draft PR to get feedback

## What’s included

- New command: `jbang lock <ref>`
- Default lock file behavior:
- local file refs (`app.java`) -> `app.java.lock`
- alias/GAV/URL refs -> `.jbang.lock`
- override via `--lock-file=...`
- Run policy flag: `--locked=<none|lenient|strict>`
  - `none`: ignore lock checks
  - `lenient` (default): if lock data exists, enforce it; if lock missing, run normally
  - `strict`: require lock entry when lock file exists and enforce strict matching
- Lock structure per ref:
  - `ref=sha256:...` (main resource digest)
  - `ref.sources=...` (resolved source manifest)
  - `ref.deps=...` (resolved transitive dependency coordinates)
  - `ref.dep.<gav>=sha256:...` (per-artifact dependency digests)

## Verification behavior

When lock data exists, JBang validates:

1. Main resource digest
2. Source manifest (`.sources`) consistency
3. Dependency graph (`.deps`) consistency
4. Per-artifact dependency digests (`.dep.<gav>`)

Mismatch -> fail with explicit error.
Digest mismatch errors include the resolved file path.

## Why this design

- Keeps “just run it” workflow intact when no lock is present.
- Provides stronger guarantees as soon as lock data exists.
- Separates mutation (`jbang lock`) from execution (`jbang run ...`).

## Feedback requested

1. Are `--locked` mode semantics (`none|lenient|strict`) right?
2. Is `<script>.lock` the right default for local file refs?
3. Is properties-based lock format acceptable for v1 with these keys?
4. Should strict mode require complete per-artifact digests for every locked dep (current behavior)?

### Related issues

Relates to:
- #1989 (script/alias SHA verification)
- #1979 (pinning behavior for aliases/scripts)

Supersedes / consolidates discussion from:
- #938 (catalog checksums)
- #687 (older checksum/integrity thread)