### PR TITLE
docs: set compact_banner to true

### DIFF
--- a/docs/modules/ROOT/pages/self-contained-executables.adoc
+++ b/docs/modules/ROOT/pages/self-contained-executables.adoc
@@ -47,7 +47,7 @@ Hello World
 
 Additional https://jbundle.avelino.run/user-guide/configuration[configuration options] can be specified on the command-line or stored in a `jbundle.toml` file in the local folder.
 
-[source, toml]
+[source,properties]
 ----
 # jbundle.toml
 
@@ -57,6 +57,7 @@ jvm_args = ["-Xmx512m", "-XX:+UseZGC"]
 shrink = true
 appcds = false
 crac = false
+compact_banner = true
 ----
 
 === Limitations


### PR DESCRIPTION
Also fixing *jbundle.toml* config file formatting:

<img width="800" height="81" alt="image" src="https://github.com/user-attachments/assets/763b4895-95b7-49eb-84cc-bab0eab6d981" />

to

<img width="389" height="231" alt="image" src="https://github.com/user-attachments/assets/cbfa3f62-e6cf-48d5-bf57-0453dde35330" />
