### PR TITLE
docs: upgrade to Javalin 7.1.0

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -131,17 +131,18 @@ class hello implements Runnable {
 [source, java]
 ----
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.javalin:javalin:6.7.0
+//DEPS io.javalin:javalin:7.0.0
 //DEPS org.slf4j:slf4j-simple:2.0.17
+//JAVA 17
 
 import io.javalin.Javalin;
 
 class WebServer {
     public static void main(String[] args) {
         String response  = "Hello from JBang!";
-        Javalin.create(/*config*/)
-            .get("/", ctx -> ctx.result(response))
-            .start(8000);
+        var app = Javalin.create(config -> {
+            config.routes.get("/", ctx -> ctx.result(response));
+        }).start(8000);
     }
 }
 ----

--- a/readme.adoc
+++ b/readme.adoc
@@ -133,7 +133,7 @@ class hello implements Runnable {
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.javalin:javalin:7.0.0
 //DEPS org.slf4j:slf4j-simple:2.0.17
-//JAVA 17
+//JAVA 21
 
 import io.javalin.Javalin;
 
@@ -141,6 +141,7 @@ class WebServer {
     public static void main(String[] args) {
         String response  = "Hello from JBang!";
         var app = Javalin.create(config -> {
+            config.concurrency.useVirtualThreads = true;
             config.routes.get("/", ctx -> ctx.result(response));
         }).start(8000);
     }

--- a/readme.adoc
+++ b/readme.adoc
@@ -133,7 +133,7 @@ class hello implements Runnable {
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.javalin:javalin:7.0.1
 //DEPS org.slf4j:slf4j-simple:2.0.17
-//JAVA 21
+//JAVA 21+
 
 import io.javalin.Javalin;
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -131,7 +131,7 @@ class hello implements Runnable {
 [source, java]
 ----
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.javalin:javalin:7.0.0
+//DEPS io.javalin:javalin:7.0.1
 //DEPS org.slf4j:slf4j-simple:2.0.17
 //JAVA 17
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -131,7 +131,7 @@ class hello implements Runnable {
 [source, java]
 ----
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.javalin:javalin:7.0.1
+//DEPS io.javalin:javalin:7.1.0
 //DEPS org.slf4j:slf4j-simple:2.0.17
 //JAVA 21+
 


### PR DESCRIPTION
A much improved Javalin 7.0 is now available. Reworked the WebServer example to use Javalin 7.0, Java 21 and Virtual Threads.