### PR TITLE
feat: use gradle-versions-plugin to show deps with updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
+	id "com.github.ben-manes.versions" version "0.51.0"
 }
 
 def allureVersion = '2.29.1'


### PR DESCRIPTION
Run as `./gradlew dependencyUpdates`

```
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.geoffgranum.gradle-conventional-changelog:com.geoffgranum.gradle-conventional-changelog.gradle.plugin:0.3.1
 - com.google.code.gson:gson:2.13.2
 - info.picocli:picocli:4.7.7
 - info.picocli:picocli-codegen:4.7.7
 - io.qameta.allure:allure-commandline:2.33.0
 - io.toolebox.git-versioner:io.toolebox.git-versioner.gradle.plugin:1.6.7
 - org.apache.commons:commons-compress:1.28.0
 - org.apache.commons:commons-text:1.15.0
 - org.codejive:java-properties:0.0.7
 - org.gradle.crypto.checksum:org.gradle.crypto.checksum.gradle.plugin:1.4.0
 - org.jacoco:org.jacoco.agent:0.8.14
 - org.jacoco:org.jacoco.ant:0.8.14
 - org.jspecify:jspecify:1.0.0
 - org.zeroturnaround:zt-exec:1.12

The following dependencies have later milestone versions:
 - com.diffplug.spotless:com.diffplug.spotless.gradle.plugin [7.2.1 -> 8.4.0]
 - com.dorongold.task-tree:com.dorongold.task-tree.gradle.plugin [2.1.1 -> 4.0.1]
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin [0.51.0 -> 0.53.0]
 - com.github.breadmoirai.github-release:com.github.breadmoirai.github-release.gradle.plugin [2.4.1 -> 2.5.2]
 - com.github.gmazzo.buildconfig:com.github.gmazzo.buildconfig.gradle.plugin [3.1.0 -> 6.0.9]
     https://github.com/gmazzo/gradle-buildconfig-plugin
 - com.github.stefanbirkner:system-rules [1.17.2 -> 1.19.0]
     http://stefanbirkner.github.io/system-rules/
 - com.gradleup.shadow:com.gradleup.shadow.gradle.plugin [8.3.9 -> 9.4.0]
     https://github.com/GradleUp/shadow
 - dev.jbang:devkitman [0.3.3 -> 0.4.6]
     https://github.com/jbangdev/jbang-devkitman
 - ......
```
