### PR TITLE
feat: implement version pinning for JBang aliases

### DIFF
--- a/docs/modules/ROOT/pages/alias_catalogs.adoc
+++ b/docs/modules/ROOT/pages/alias_catalogs.adoc
@@ -98,6 +98,166 @@ The full format is `<alias>@<user/org>(/repository)(/branch)(~path)` or `<alias>
 
 |====
 
+== Version Pinning
+
+Version pinning allows you to specify a version when running an alias, enabling you to use different versions of the same tool without modifying the catalog definition. This is particularly useful for testing, compatibility checks, or using specific versions of tools.
+
+=== Syntax
+
+The version pinning syntax is: `alias:version@catalog`
+
+Examples:
+
+[source,bash]
+----
+jbang mytool:1.5.0@mycatalog      # Pin to version 1.5.0
+jbang tool:v2.0.0@jbangdev        # Pin to v2.0.0 from jbangdev catalog
+jbang app:1.2.3                   # Pin to 1.2.3 from local catalog
+----
+
+=== How It Works
+
+When you specify a version, JBang applies different replacement strategies depending on the alias's script reference:
+
+==== Maven GAV Coordinates
+
+For aliases that reference Maven artifacts, the version replaces the version component in the GAV coordinates:
+
+[source,json]
+----
+{
+  "aliases": {
+    "picocli": {
+      "script-ref": "info.picocli:picocli-codegen:4.6.0"
+    }
+  }
+}
+----
+
+Running `jbang picocli:4.7.0` resolves to `info.picocli:picocli-codegen:4.7.0`
+
+This works with:
+
+[cols="1,1,1",options="header"]
+|===
+|Alias `script-ref`
+|Invocation
+|Resolved `script-ref`
+
+|`group:artifact:version`
+|`jbang alias:newversion`
+|`group:artifact:newversion`
+
+|`group:artifact:version:classifier`
+|`jbang alias:newversion`
+|`group:artifact:newversion:classifier`
+
+|`group:artifact:version:classifier@type`
+|`jbang alias:newversion`
+|`group:artifact:newversion:classifier@type`
+
+|`group:artifact`
+|`jbang alias:newversion`
+|`group:artifact:newversion`
+|===
+
+==== Git URLs
+
+For aliases that reference GitHub, GitLab, or Bitbucket URLs, the version replaces the branch/tag/ref in the URL:
+
+[cols="1,1,1,1",options="header"]
+|===
+|Provider
+|Alias `script-ref`
+|Invocation
+|Resolved `script-ref`
+
+|GitHub
+|`https://github.com/org/repo/blob/main/script.java`
+|`jbang alias:v1.0.0`
+|`https://github.com/org/repo/blob/v1.0.0/script.java`
+
+|GitHub
+|`https://raw.githubusercontent.com/org/repo/main/script.java`
+|`jbang alias:v1.0.0`
+|`https://raw.githubusercontent.com/org/repo/v1.0.0/script.java`
+
+|GitHub
+|`https://github.com/org/repo/releases/download/v0.137.0/checksums_sha256.txt`
+|`jbang alias:v0.138.0`
+|`https://github.com/org/repo/releases/download/v0.138.0/checksums_sha256.txt`
+
+|GitLab
+|`https://gitlab.com/org/repo/-/blob/develop/script.java`
+|`jbang alias:v1.0`
+|`https://gitlab.com/org/repo/-/blob/v1.0/script.java`
+
+|GitLab
+|`https://gitlab.com/org/repo/-/raw/main/script.java`
+|`jbang alias:v1.0`
+|`https://gitlab.com/org/repo/-/raw/v1.0/script.java`
+
+|Bitbucket
+|`https://bitbucket.org/org/repo/src/master/script.java`
+|`jbang alias:1.0`
+|`https://bitbucket.org/org/repo/src/1.0/script.java`
+
+|Bitbucket
+|`https://bitbucket.org/org/repo/raw/master/script.java`
+|`jbang alias:1.0`
+|`https://bitbucket.org/org/repo/raw/1.0/script.java`
+|===
+
+==== Property-Based Versioning
+
+For maximum flexibility, aliases can use property placeholders that get replaced when a version is specified:
+
+[source,json]
+----
+{
+  "aliases": {
+    "quarkus": {
+      "script-ref": "io.quarkus:quarkus-cli:${jbang.app.version:3.0.0}"
+    },
+    "example": {
+      "script-ref": "https://downloads.example.com/tools/mytool-${jbang.app.version:latest}.zip"
+    }
+  }
+}
+----
+
+Running `jbang quarkus:3.5.0` resolves to `io.quarkus:quarkus-cli:3.5.0`
+
+Running `jbang example:1.2.3` resolves to `https://downloads.example.com/tools/mytool-1.2.3.zip`
+
+If no version is specified, the default value (after the colon) is used.
+
+NOTE: Property replacement takes precedence over automatic version replacement. If your alias uses `${jbang.app.version}`, automatic replacement is skipped.
+
+==== Alias Chains
+
+Version pinning does *not* work through alias chains. If an alias references another alias, you must apply the version to the final target alias.
+
+[source,json]
+----
+{
+  "aliases": {
+    "base-tool": {
+      "script-ref": "com.example:tool:1.0.0"
+    },
+    "tool": {
+      "script-ref": "base-tool"
+    }
+  }
+}
+----
+
+Running `jbang tool:2.0.0` fails with an error explaining that version pinning cannot be applied to an alias reference. Use the target alias directly, for example: `base-tool:2.0.0`.
+
+=== Backward Compatibility
+
+Aliases without version pinning work exactly as before. The version syntax is entirely optional and doesn't affect existing usage.
+
 == Local Alias Catalogs
 
 JBang will also look in the current directory for a `jbang-catalog.json` file and if it exists it will look up any aliases

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -179,7 +179,7 @@ public class Alias extends CatalogItem {
 	public static Alias get(String aliasName) {
 		HashSet<String> names = new HashSet<>();
 		Alias alias = new Alias();
-		Alias result = merge(alias, aliasName, Alias::getLocal, names);
+		Alias result = merge(alias, aliasName, Alias::getLocal, names, null);
 		return result.scriptRef != null ? result : null;
 	}
 
@@ -194,25 +194,37 @@ public class Alias extends CatalogItem {
 	public static Alias get(Catalog catalog, String aliasName) {
 		HashSet<String> names = new HashSet<>();
 		Alias alias = new Alias();
-		Alias result = merge(alias, aliasName, catalog.aliases::get, names);
+		Alias result = merge(alias, aliasName, catalog.aliases::get, names, null);
+		return result.scriptRef != null ? result : null;
+	}
+
+	public static Alias get(Catalog catalog, String aliasName, String requestedVersion) {
+		HashSet<String> names = new HashSet<>();
+		Alias alias = new Alias();
+		Alias result = merge(alias, aliasName, catalog.aliases::get, names, requestedVersion);
 		return result.scriptRef != null ? result : null;
 	}
 
 	private static Alias merge(Alias a1, String name, Function<String, Alias> findUnqualifiedAlias,
-			HashSet<String> names) {
-		// if this is a proper possible GAV, i.e.
-		// io.quarkiverse.mcp:artifact:1.0.0.Beta5@fatjar
-		// don't try interpret it.
+			HashSet<String> names, String requestedVersion) {
+		if (name.startsWith(":") || name.startsWith("@")) {
+			throw new RuntimeException("Invalid alias name '" + name + "'");
+		}
+
 		if (DependencyUtil.looksLikeAPossibleGav(name)) {
 			return a1;
 		}
+
 		if (names.contains(name)) {
 			throw new RuntimeException("Encountered alias loop on '" + name + "'");
 		}
+
 		String[] parts = name.split("@", 2);
-		if (parts[0].isEmpty()) {
+		if (parts[0].isEmpty() || parts[0].startsWith(":")) {
 			throw new RuntimeException("Invalid alias name '" + name + "'");
 		}
+
+		// EXISTING: Look up alias (unchanged)
 		Alias a2;
 		if (parts.length == 1) {
 			a2 = findUnqualifiedAlias.apply(name);
@@ -222,9 +234,29 @@ public class Alias extends CatalogItem {
 			}
 			a2 = fromCatalog(parts[1], parts[0]);
 		}
+
+		// EXISTING: Merge if found
 		if (a2 != null) {
 			names.add(name);
-			a2 = merge(a2, a2.scriptRef, findUnqualifiedAlias, names);
+
+			// If a version was requested for the alias invocation, it must apply to the
+			// final script-ref (GAV/URL/catalog-ref), not to an alias reference. We
+			// detect plain alias references by checking that the scriptRef looks like a
+			// valid alias name and does not contain URL/GAV/catalog special characters.
+			if (requestedVersion != null && Catalog.isValidName(a2.scriptRef)
+					&& !a2.scriptRef.contains(":")
+					&& !a2.scriptRef.contains("/")
+					&& !a2.scriptRef.contains("\\")
+					&& !a2.scriptRef.contains("@")) {
+				throw new ExitException(EXIT_INVALID_INPUT,
+						"Cannot apply version '" + requestedVersion + "' to alias reference '" + a2.scriptRef
+								+ "'. Version can only be applied to the final target. "
+								+ "Use the target alias directly: " + a2.scriptRef + ":" + requestedVersion);
+			}
+
+			a2 = merge(a2, a2.scriptRef, findUnqualifiedAlias, names, requestedVersion);
+
+			// EXISTING: Property merging (all unchanged from original code)
 			String desc = a1.description != null ? a1.description : a2.description;
 			List<String> args = a1.arguments != null && !a1.arguments.isEmpty() ? a1.arguments : a2.arguments;
 			List<String> jopts = a1.runtimeOptions != null && !a1.runtimeOptions.isEmpty() ? a1.runtimeOptions
@@ -263,9 +295,12 @@ public class Alias extends CatalogItem {
 			List<JavaAgent> jags = a1.javaAgents != null && !a1.javaAgents.isEmpty() ? a1.javaAgents : a2.javaAgents;
 			List<String> docs = a1.docs != null && !a1.docs.isEmpty() ? a1.docs : a2.docs;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
+
+			// EXISTING: Create merged alias
 			return new Alias(a2.scriptRef, desc, args, jopts, srcs, ress, deps, repos, cpaths, props, javaVersion,
 					mainClass, moduleName, copts, nimg, nopts, forceType, ints, jfr, debug, cds, inter, ep, ea, esa,
-					mopts, jags, docs, catalog);
+					mopts,
+					jags, docs, catalog);
 		} else {
 			return a1;
 		}

--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -3,10 +3,12 @@ package dev.jbang.catalog;
 import static dev.jbang.ExitException.EXIT_INVALID_INPUT;
 
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.function.Function;
 
 import org.jspecify.annotations.NonNull;
@@ -16,6 +18,8 @@ import com.google.gson.annotations.SerializedName;
 
 import dev.jbang.ExitException;
 import dev.jbang.dependencies.DependencyUtil;
+import dev.jbang.source.ProjectBuilder;
+import dev.jbang.util.PropertiesValueResolver;
 import dev.jbang.util.Util;
 
 public class Alias extends CatalogItem {
@@ -224,7 +228,8 @@ public class Alias extends CatalogItem {
 			throw new RuntimeException("Invalid alias name '" + name + "'");
 		}
 
-		// EXISTING: Look up alias (unchanged)
+		// Look up alias, expanding any ${jbang.app.version:default} in catalog
+		// references
 		Alias a2;
 		if (parts.length == 1) {
 			a2 = findUnqualifiedAlias.apply(name);
@@ -232,7 +237,9 @@ public class Alias extends CatalogItem {
 			if (parts[1].isEmpty()) {
 				throw new RuntimeException("Invalid alias name '" + name + "'");
 			}
-			a2 = fromCatalog(parts[1], parts[0]);
+			// Expand ${jbang.app.version:default} in catalog reference before fetching
+			String catalogRef = expandVersionProperty(parts[1], requestedVersion);
+			a2 = fromCatalog(catalogRef, parts[0]);
 		}
 
 		// EXISTING: Merge if found
@@ -323,6 +330,32 @@ public class Alias extends CatalogItem {
 	static Catalog findNearestCatalogWithAlias(Path dir, String aliasName) {
 		return Catalog.findNearestCatalogWith(dir, true, true,
 				catalog -> catalog.aliases.containsKey(aliasName) ? catalog : null);
+	}
+
+	/**
+	 * Expand {@code ${jbang.app.version:default}} in a string.
+	 * <p>
+	 * If {@code requestedVersion} is non-null, it's used as the value for
+	 * {@code jbang.app.version}. Otherwise, the default value after the colon is
+	 * used.
+	 *
+	 * @param value            the string potentially containing property references
+	 * @param requestedVersion the version to use, or null to use defaults
+	 * @return the string with properties expanded
+	 */
+	private static String expandVersionProperty(String value, String requestedVersion) {
+		if (value == null || !value.contains("${jbang.app.version")) {
+			return value;
+		}
+		Properties props = ProjectBuilder.getContextProperties(Collections.emptyMap());
+		if (requestedVersion != null) {
+			props.setProperty("jbang.app.version", requestedVersion);
+		}
+		String expanded = PropertiesValueResolver.replaceProperties(value, props);
+		if (!expanded.equals(value)) {
+			Util.verboseMsg("Expanded catalog reference: " + value + " → " + expanded);
+		}
+		return expanded;
 	}
 
 	/**

--- a/src/main/java/dev/jbang/catalog/AliasRef.java
+++ b/src/main/java/dev/jbang/catalog/AliasRef.java
@@ -1,0 +1,102 @@
+package dev.jbang.catalog;
+
+/**
+ * Represents a user-provided alias reference that may contain an inline
+ * version.
+ * <p>
+ * This parser exists to separate <em>parsing</em> from <em>resolution</em>:
+ * parsing must be side-effect free (no catalog loading, no network access) so
+ * it can safely run in early CLI probing and unit tests.
+ * 
+ * We do this so we have access to the raw alias reference for error messages
+ * and logging, while also have access to optional version and a version of the
+ * resolved alias.
+ * 
+ * <p>
+ * Supported syntax:
+ * <ul>
+ * <li>{@code alias} - plain alias</li>
+ * <li>{@code alias:version} - alias with an inline requested version</li>
+ * <li>{@code alias@catalogRef} - alias qualified with a catalog reference</li>
+ * <li>{@code alias:version@catalogRef} - alias qualified with catalog reference
+ * and version</li>
+ * </ul>
+ */
+public final class AliasRef {
+	/**
+	 * The original alias reference as provided by the user.
+	 */
+	public final String rawAlias;
+	/**
+	 * The alias reference with any inline {@code :version} removed.
+	 * <p>
+	 * Examples:
+	 * <ul>
+	 * <li>{@code hello:v1.0} -&gt; {@code hello}</li>
+	 * <li>{@code hello:v1.0@org/repo/main} -&gt; {@code hello@org/repo/main}</li>
+	 * <li>{@code hello@org/repo/main} -&gt; {@code hello@org/repo/main}</li>
+	 * </ul>
+	 */
+	public final String alias;
+	/**
+	 * The requested version from inline {@code :version} syntax, or {@code null}
+	 * when no inline version was present.
+	 */
+	public final String requestedVersion;
+
+	private AliasRef(String rawAlias, String alias, String requestedVersion) {
+		this.rawAlias = rawAlias;
+		this.alias = alias;
+		this.requestedVersion = requestedVersion;
+	}
+
+	/**
+	 * Parse a alias reference (alias[:version][@catalog]) into {@link AliasRef}
+	 * without performing any alias or catalog resolution.
+	 * <p>
+	 * 
+	 * @param userAlias raw user input (e.g. {@code tool:1.0@org/repo/main})
+	 * @return a parsed reference where {@link #alias} can be used for alias lookup
+	 *         and {@link #requestedVersion} (if non-null) can be applied by the
+	 *         caller
+	 * @throws IllegalArgumentException if the token is syntactically invalid (e.g.
+	 *                                  empty alias or empty version)
+	 */
+	public static AliasRef parse(String userAlias) {
+		if (userAlias == null) {
+			throw new IllegalArgumentException("Invalid alias syntax: null");
+		}
+		if (userAlias.startsWith(":") || userAlias.startsWith("@")) {
+			throw new IllegalArgumentException("Invalid alias syntax: '" + userAlias + "'");
+		}
+
+		int colonIdx = userAlias.indexOf(':');
+		String alias = userAlias;
+		String version = null;
+
+		int atIdx = userAlias.indexOf('@');
+		if (colonIdx > 0 && (atIdx == -1 || colonIdx < atIdx)) {
+			String beforeColon = userAlias.substring(0, colonIdx);
+			String afterColon = userAlias.substring(colonIdx + 1);
+
+			int versionAtIdx = afterColon.indexOf('@');
+			if (versionAtIdx == 0) {
+				throw new IllegalArgumentException(
+						"Invalid alias syntax: '" + userAlias + "'. Expected format: alias:version@catalog");
+			} else if (versionAtIdx > 0) {
+				version = afterColon.substring(0, versionAtIdx);
+				alias = beforeColon + afterColon.substring(versionAtIdx);
+			} else {
+				version = afterColon;
+				alias = beforeColon;
+			}
+
+			if (alias.isEmpty() || version.isEmpty()) {
+				throw new IllegalArgumentException(
+						"Invalid alias syntax: '" + userAlias + "'. Expected format: alias:version@catalog");
+			}
+		}
+
+		return new AliasRef(userAlias, alias, version);
+	}
+}

--- a/src/main/java/dev/jbang/catalog/AliasVersionPinner.java
+++ b/src/main/java/dev/jbang/catalog/AliasVersionPinner.java
@@ -1,0 +1,261 @@
+package dev.jbang.catalog;
+
+import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import dev.jbang.cli.ExitException;
+import dev.jbang.dependencies.DependencyUtil;
+import dev.jbang.source.ProjectBuilder;
+import dev.jbang.util.PropertiesValueResolver;
+import dev.jbang.util.Util;
+
+/**
+ * This class has the logic to deal with alias:version[@catalog] syntax.
+ * <p>
+ * The logic is to apply the version to the script reference in the following
+ * order:
+ * <ol>
+ * <li>Property replacement</li>
+ * <li>Maven coordinates (GAV) replacement/appending</li>
+ * <li>Versionable URL replacement for known git-hosting URL shapes
+ * (GitHub/GitLab/Bitbucket)</li>
+ * <li>Catalog reference replacement for {@code alias@org/repo/ref} by swapping
+ * the last segment to the requested version</li>
+ * </ol>
+ */
+public final class AliasVersionPinner {
+	private AliasVersionPinner() {
+	}
+
+	/**
+	 * Ordered set of URL patterns that support version substitution.
+	 * <p>
+	 * The map key is a short provider label used for verbose logging when a
+	 * replacement matches (eg. {@code github}, {@code gitlab}, {@code bitbucket}).
+	 * <p>
+	 * Each {@link Pattern} must contain three capturing groups:
+	 * <ol>
+	 * <li>prefix up to (and including) the version segment delimiter</li>
+	 * <li>the version segment to replace (not used other than for matching)</li>
+	 * <li>suffix after the version segment</li>
+	 * </ol>
+	 * so the replacement can reconstruct {@code group(1) + version + group(3)}.
+	 */
+	private static final Map<String, List<Pattern>> VERSIONABLE_URL_PATTERNS = new LinkedHashMap<>();
+	static {
+		VERSIONABLE_URL_PATTERNS.put("github", Arrays.asList(
+				Pattern.compile("(https://github\\.com/[^/]+/[^/]+/blob/)([^/]+)(/.+)"),
+				Pattern.compile("(https://github\\.com/[^/]+/[^/]+/releases/download/)([^/]+)(/.+)"),
+				Pattern.compile("(https://raw\\.githubusercontent\\.com/[^/]+/[^/]+/)([^/]+)(/.+)")));
+		VERSIONABLE_URL_PATTERNS.put("gitlab", Arrays.asList(
+				Pattern.compile("(https://gitlab\\.com/[^/]+/[^/]+/-/blob/)([^/]+)(/.+)"),
+				Pattern.compile("(https://gitlab\\.com/[^/]+/[^/]+/-/raw/)([^/]+)(/.+)")));
+		VERSIONABLE_URL_PATTERNS.put("bitbucket", Arrays.asList(
+				Pattern.compile("(https://bitbucket\\.org/[^/]+/[^/]+/src/)([^/]+)(/.+)"),
+				Pattern.compile("(https://bitbucket\\.org/[^/]+/[^/]+/raw/)([^/]+)(/.+)")));
+	}
+
+	/**
+	 * Apply an inline version to a {@code scriptRef} using a fixed replacement
+	 * cascade.
+	 * <p>
+	 * Cascade order:
+	 * <ol>
+	 * <li><b>Property replacement</b> using {@code jbang.app.version}. If any
+	 * property replacement occurs, automatic replacement is skipped.</li>
+	 * <li><b>Maven coordinates (GAV)</b> replacement/appending.</li>
+	 * <li><b>Versionable URL</b> replacement for known git-hosting URL shapes
+	 * (GitHub/GitLab/Bitbucket).</li>
+	 * <li><b>Catalog reference</b> replacement for {@code alias@org/repo/ref} by
+	 * swapping the last segment to the requested version.</li>
+	 * </ol>
+	 * If none apply, an {@link ExitException} is thrown for least surprise.
+	 *
+	 * @param scriptRef the original script reference from an alias definition
+	 * @param version   the requested version (non-null)
+	 * @return the transformed script reference
+	 */
+	public static String applyVersion(String scriptRef, String version) {
+		Properties props = ProjectBuilder.getContextProperties(Collections.emptyMap());
+		return applyVersion(scriptRef, version, props);
+	}
+
+	public static String applyVersion(String scriptRef, String version, Properties baseProperties) {
+		if (version == null) {
+			return scriptRef;
+		}
+
+		Util.verboseMsg("Version '" + version + "' requested for alias");
+
+		Properties props = new Properties();
+		if (baseProperties != null) {
+			props.putAll(baseProperties);
+		}
+		props.setProperty("jbang.app.version", version);
+
+		String afterProperties = PropertiesValueResolver.replaceProperties(scriptRef, props);
+		if (!afterProperties.equals(scriptRef)) {
+			Util.verboseMsg("Property replacement active in script-ref, skipping automatic version replacement");
+			Util.verboseMsg("Version pinned property replacement: " + scriptRef + " → " + afterProperties);
+			return afterProperties;
+		}
+
+		Util.verboseMsg("Applying automatic version replacement to: " + scriptRef);
+
+		String gavResult = tryMavenGavReplacement(scriptRef, version);
+		if (!gavResult.equals(scriptRef)) {
+			Util.verboseMsg("Version pinned Maven GAV: " + scriptRef + " → " + gavResult);
+			return gavResult;
+		}
+
+		Replacement urlReplacement = tryVersionableUrlReplacement(scriptRef, version);
+		if (urlReplacement != null) {
+			Util.verboseMsg("Matched versionable URL pattern: " + urlReplacement.key);
+			Util.verboseMsg("Version pinned URL: " + scriptRef + " → " + urlReplacement.replaced);
+			return urlReplacement.replaced;
+		}
+
+		String catalogResult = tryCatalogRefReplacement(scriptRef, version);
+		if (!catalogResult.equals(scriptRef)) {
+			Util.verboseMsg("Version pinned catalog reference: " + scriptRef + " → " + catalogResult);
+			return catalogResult;
+		}
+
+		if (Catalog.isValidCatalogReference(scriptRef)) {
+			throw new ExitException(EXIT_INVALID_INPUT,
+					"Cannot apply version '" + version + "' to catalog reference '" + scriptRef
+							+ "'. Registered catalog names don't support version pinning. "
+							+ "Either use a path-based catalog (e.g., alias@org/repo/ref) or have the alias define ${jbang.app.version} in its script-ref.");
+		} else {
+			throw new ExitException(EXIT_INVALID_INPUT,
+					"Cannot apply version '" + version + "' to script-ref '" + scriptRef
+							+ "'. No recognizable version pattern found. "
+							+ "Supported patterns: Maven GAV, GitHub/GitLab/Bitbucket URLs, or use ${jbang.app.version:default} in the alias definition.");
+		}
+	}
+
+	/**
+	 * Attempt to apply a version to Maven coordinates.
+	 * <p>
+	 * Supports:
+	 * <ul>
+	 * <li>Full GAV: {@code group:artifact:version[:classifier][@type]} (replaces
+	 * the version)</li>
+	 * <li>Lenient GAV: {@code group:artifact} (appends {@code :version})</li>
+	 * </ul>
+	 *
+	 * @param ref     input reference
+	 * @param version requested version
+	 * @return transformed reference if a Maven-like pattern matched, otherwise
+	 *         {@code ref}
+	 */
+	private static String tryMavenGavReplacement(String ref, String version) {
+		if (!DependencyUtil.looksLikeAPossibleGav(ref)) {
+			return ref;
+		}
+
+		Matcher m = DependencyUtil.fullGavPattern.matcher(ref);
+		if (m.matches()) {
+			String g = m.group("groupid");
+			String a = m.group("artifactid");
+			String c = m.group("classifier");
+			String t = m.group("type");
+
+			StringBuilder result = new StringBuilder(g).append(":").append(a).append(":").append(version);
+			if (c != null && !c.isEmpty()) {
+				result.append(":").append(c);
+			}
+			if (t != null && !t.isEmpty()) {
+				result.append("@").append(t);
+			}
+			return result.toString();
+		}
+
+		m = DependencyUtil.lenientGavPattern.matcher(ref);
+		if (m.matches() && m.group("version") == null) {
+			return m.group("groupid") + ":" + m.group("artifactid") + ":" + version;
+		}
+
+		return ref;
+	}
+
+	/**
+	 * Small carrier for a successful replacement.
+	 */
+	private static final class Replacement {
+		final String key;
+		final String replaced;
+
+		private Replacement(String key, String replaced) {
+			this.key = key;
+			this.replaced = replaced;
+		}
+	}
+
+	/**
+	 * Attempt to apply a version to a known versionable URL pattern.
+	 * <p>
+	 * Patterns are tried in the insertion order of
+	 * {@link #VERSIONABLE_URL_PATTERNS}.
+	 *
+	 * @param ref     input reference
+	 * @param version requested version
+	 * @return a {@link Replacement} containing the provider key and replaced value,
+	 *         or {@code null}
+	 */
+	private static Replacement tryVersionableUrlReplacement(String ref, String version) {
+		for (Map.Entry<String, List<Pattern>> entry : VERSIONABLE_URL_PATTERNS.entrySet()) {
+			String key = entry.getKey();
+			for (Pattern p : entry.getValue()) {
+				Matcher m = p.matcher(ref);
+				if (m.matches()) {
+					String replaced = m.group(1) + version + m.group(3);
+					return new Replacement(key, replaced);
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Attempt to apply a version to a catalog reference in the form:
+	 * {@code alias@org/repo/ref}.
+	 * <p>
+	 * Only path-based catalog references are versionable; registered catalog names
+	 * (no slash segments) are left untouched and will be rejected by the caller's
+	 * fallback error.
+	 *
+	 * @param ref     input reference
+	 * @param version requested version
+	 * @return transformed reference if a path-based catalog reference matched,
+	 *         otherwise {@code ref}
+	 */
+	private static String tryCatalogRefReplacement(String ref, String version) {
+		if (!Catalog.isValidCatalogReference(ref)) {
+			return ref;
+		}
+
+		String[] parts = ref.split("@", 2);
+		if (parts.length != 2) {
+			return ref;
+		}
+
+		String aliasName = parts[0];
+		String catalogRef = parts[1];
+
+		int lastSlash = catalogRef.lastIndexOf('/');
+		if (lastSlash > 0 && lastSlash < catalogRef.length() - 1) {
+			String catalogBase = catalogRef.substring(0, lastSlash);
+			return aliasName + "@" + catalogBase + "/" + version;
+		}
+		return ref;
+	}
+}

--- a/src/main/java/dev/jbang/catalog/AliasVersionPinner.java
+++ b/src/main/java/dev/jbang/catalog/AliasVersionPinner.java
@@ -1,6 +1,6 @@
 package dev.jbang.catalog;
 
-import static dev.jbang.cli.BaseCommand.EXIT_INVALID_INPUT;
+import static dev.jbang.ExitException.EXIT_INVALID_INPUT;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,7 +11,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import dev.jbang.cli.ExitException;
+import dev.jbang.ExitException;
 import dev.jbang.dependencies.DependencyUtil;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.PropertiesValueResolver;

--- a/src/main/java/dev/jbang/resources/resolvers/AliasResourceResolver.java
+++ b/src/main/java/dev/jbang/resources/resolvers/AliasResourceResolver.java
@@ -6,9 +6,13 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.AliasRef;
+import dev.jbang.catalog.AliasVersionPinner;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.resources.ResourceRef;
 import dev.jbang.resources.ResourceResolver;
+import dev.jbang.source.ProjectBuilder;
+import dev.jbang.util.PropertiesValueResolver;
 
 public class AliasResourceResolver implements ResourceResolver {
 	@Nullable
@@ -34,17 +38,27 @@ public class AliasResourceResolver implements ResourceResolver {
 	public ResourceRef resolve(String resource, boolean trusted) {
 		ResourceResolver resolver = resolverFactory.apply(null);
 		ResourceRef ref = resolver.resolve(resource, trusted);
-		if (ref == null) {
-			Alias alias = (catalog != null) ? Alias.get(catalog, resource) : Alias.get(resource);
+		if (ref == null) { // If the resource is not found in the catalog, we know this must be an alias!
+			AliasRef aliasRef = AliasRef.parse(resource);
+			Alias alias = (catalog != null) ? Alias.get(catalog, aliasRef.alias, aliasRef.requestedVersion)
+					: Alias.get(aliasRef.alias);
 			if (alias != null) {
 				resolver = resolverFactory.apply(alias);
-				ResourceRef aliasRef = resolver.resolve(alias.resolve(), trusted);
-				if (aliasRef == null) {
+				String rawScriptRef = alias.scriptRef;
+				if (aliasRef.requestedVersion != null) {
+					rawScriptRef = AliasVersionPinner.applyVersion(rawScriptRef, aliasRef.requestedVersion,
+							ProjectBuilder.getContextProperties(java.util.Collections.emptyMap()));
+				} else {
+					rawScriptRef = PropertiesValueResolver.replaceProperties(rawScriptRef);
+				}
+				String resolved = alias.resolve(rawScriptRef);
+				ResourceRef resolvedRef = resolver.resolve(resolved, trusted);
+				if (resolvedRef == null) {
 					throw new IllegalArgumentException(
 							"Alias " + resource + " from " + alias.catalog.catalogRef + " failed to resolve "
 									+ alias.scriptRef);
 				}
-				ref = new AliasedResourceRef(aliasRef, alias);
+				ref = new AliasedResourceRef(resolvedRef, alias);
 			}
 		}
 		return ref;

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import dev.jbang.BaseTest;
 import dev.jbang.Settings;
 import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.AliasRef;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.util.Util;
 
@@ -562,6 +563,58 @@ public class TestAlias extends BaseTest {
 			assertThat(ex.getMessage(), containsString("seven"));
 		}
 
+	}
+
+	@Test
+	void testParseVersionedAlias() throws IOException {
+		clearSettingsCaches();
+		// Use existing "one" alias from standard catalog
+		AliasRef ref = AliasRef.parse("one:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+
+		assertThat(alias, notNullValue());
+		assertThat(ref.requestedVersion, equalTo("2.0.0"));
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+	}
+
+	@Test
+	void testParseVersionedAliasFromCatalog() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"test\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+		clearSettingsCaches();
+		Catalog cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+
+		dev.jbang.catalog.AliasRef ref = dev.jbang.catalog.AliasRef.parse("test:2.0.0");
+		Alias alias = Alias.get(cat, ref.alias);
+
+		assertThat(alias, notNullValue());
+		assertThat(ref.requestedVersion, equalTo("2.0.0"));
+	}
+
+	@Test
+	void testGavNotParsedAsVersionedAlias() {
+		Alias alias = Alias.get("io.quarkus:artifact:1.0.0@jar");
+		assertThat(alias, nullValue());
+	}
+
+	@Test
+	void testEmptyVersionThrowsError() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> dev.jbang.catalog.AliasRef.parse("test:@catalog"));
+		assertThat(exception.getMessage(), containsString("Invalid alias syntax"));
+	}
+
+	@Test
+	void testEmptyAliasNameThrowsError() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> dev.jbang.catalog.AliasRef.parse(":1.0@catalog"));
+		assertThat(exception.getMessage(), containsString("Invalid alias"));
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -20,6 +20,7 @@ import dev.jbang.BaseTest;
 import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.AliasRef;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.util.Util;
 
@@ -552,6 +553,58 @@ public class TestAlias extends BaseTest {
 			assertThat(ex.getMessage(), containsString("seven"));
 		}
 
+	}
+
+	@Test
+	void testParseVersionedAlias() throws IOException {
+		clearSettingsCaches();
+		// Use existing "one" alias from standard catalog
+		AliasRef ref = AliasRef.parse("one:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+
+		assertThat(alias, notNullValue());
+		assertThat(ref.requestedVersion, equalTo("2.0.0"));
+		assertThat(alias.scriptRef, equalTo("http://dummy"));
+	}
+
+	@Test
+	void testParseVersionedAliasFromCatalog() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"test\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+		clearSettingsCaches();
+		Catalog cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+
+		dev.jbang.catalog.AliasRef ref = dev.jbang.catalog.AliasRef.parse("test:2.0.0");
+		Alias alias = Alias.get(cat, ref.alias);
+
+		assertThat(alias, notNullValue());
+		assertThat(ref.requestedVersion, equalTo("2.0.0"));
+	}
+
+	@Test
+	void testGavNotParsedAsVersionedAlias() {
+		Alias alias = Alias.get("io.quarkus:artifact:1.0.0@jar");
+		assertThat(alias, nullValue());
+	}
+
+	@Test
+	void testEmptyVersionThrowsError() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> dev.jbang.catalog.AliasRef.parse("test:@catalog"));
+		assertThat(exception.getMessage(), containsString("Invalid alias syntax"));
+	}
+
+	@Test
+	void testEmptyAliasNameThrowsError() {
+		Exception exception = assertThrows(IllegalArgumentException.class,
+				() -> dev.jbang.catalog.AliasRef.parse(":1.0@catalog"));
+		assertThat(exception.getMessage(), containsString("Invalid alias"));
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestAliasVersionReplacement.java
+++ b/src/test/java/dev/jbang/cli/TestAliasVersionReplacement.java
@@ -1,0 +1,424 @@
+package dev.jbang.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+import dev.jbang.catalog.Alias;
+import dev.jbang.catalog.AliasRef;
+import dev.jbang.catalog.AliasVersionPinner;
+import dev.jbang.catalog.Catalog;
+import dev.jbang.util.PropertiesValueResolver;
+
+public class TestAliasVersionReplacement extends BaseTest {
+
+	private static String resolveWithVersion(Alias alias, AliasRef ref) {
+		String raw = alias.scriptRef;
+		if (ref.requestedVersion != null) {
+			raw = AliasVersionPinner.applyVersion(raw, ref.requestedVersion);
+		} else {
+			raw = PropertiesValueResolver.replaceProperties(raw);
+		}
+		return alias.resolve(raw);
+	}
+
+	@BeforeEach
+	void initCatalog() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"gav-with-property\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:${jbang.app.version:1.0.0}\"\n" +
+				"    },\n" +
+				"    \"url-with-property\": {\n" +
+				"      \"script-ref\": \"https://github.com/user/repo/blob/${jbang.app.version:main}/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+	}
+
+	@Test
+	void testPropertyReplacementInGav() throws IOException {
+		AliasRef ref = AliasRef.parse("gav-with-property:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+
+		assertThat(alias, notNullValue());
+
+		String resolved = resolveWithVersion(alias, ref);
+		assertThat(resolved, equalTo("com.example:artifact:2.0.0"));
+	}
+
+	@Test
+	void testPropertyReplacementInUrl() throws IOException {
+		AliasRef ref = AliasRef.parse("url-with-property:v1.5.0");
+		Alias alias = Alias.get(ref.alias);
+
+		assertThat(alias, notNullValue());
+
+		String resolved = resolveWithVersion(alias, ref);
+		assertThat(resolved, equalTo("https://github.com/user/repo/blob/v1.5.0/script.java"));
+	}
+
+	@Test
+	void testPropertyDefaultUsedWhenNoVersionProvided() throws IOException {
+		AliasRef ref = AliasRef.parse("gav-with-property");
+		Alias alias = Alias.get(ref.alias);
+
+		assertThat(alias, notNullValue());
+
+		String resolved = resolveWithVersion(alias, ref);
+		assertThat(resolved, equalTo("com.example:artifact:1.0.0"));
+	}
+
+	@Test
+	void testGavVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("com.example:artifact:2.0.0"));
+	}
+
+	@Test
+	void testGavWithClassifierVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0:classifier\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("com.example:artifact:2.0.0:classifier"));
+	}
+
+	@Test
+	void testGavWithClassifierAndTypeVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0:classifier@jar\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("com.example:artifact:2.0.0:classifier@jar"));
+	}
+
+	@Test
+	void testGavWithoutVersionAppends() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:2.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("com.example:artifact:2.0.0"));
+	}
+
+	@Test
+	void testGitHubBlobVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://github.com/org/repo/blob/main/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:v1.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://github.com/org/repo/blob/v1.0.0/script.java"));
+	}
+
+	@Test
+	void testGitHubRawVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://raw.githubusercontent.com/org/repo/main/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://raw.githubusercontent.com/org/repo/1.0.0/script.java"));
+	}
+
+	@Test
+	void testGitHubReleaseDownloadVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://github.com/jbangdev/jbang/releases/download/v0.137.0/checksums_sha256.txt\"\n"
+				+
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:v0.138.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved,
+				equalTo("https://github.com/jbangdev/jbang/releases/download/v0.138.0/checksums_sha256.txt"));
+	}
+
+	@Test
+	void testGitLabBlobVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://gitlab.com/org/repo/-/blob/develop/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:v1.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://gitlab.com/org/repo/-/blob/v1.0/script.java"));
+	}
+
+	@Test
+	void testGitLabRawVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://gitlab.com/org/repo/-/raw/main/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://gitlab.com/org/repo/-/raw/1.0.0/script.java"));
+	}
+
+	@Test
+	void testBitbucketSrcVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://bitbucket.org/org/repo/src/master/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://bitbucket.org/org/repo/src/1.0/script.java"));
+	}
+
+	@Test
+	void testBitbucketRawVersionReplacement() throws IOException {
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://bitbucket.org/org/repo/raw/master/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(resolved, equalTo("https://bitbucket.org/org/repo/raw/1.0/script.java"));
+	}
+
+	@Test
+	void testDirectCatalogRefWithVersion() throws IOException {
+		AliasRef ref = AliasRef.parse("hello:v1.0@jbangdev/jbang-catalog/main");
+		assertThat(ref.requestedVersion, equalTo("v1.0"));
+		assertThat(ref.alias, equalTo("hello@jbangdev/jbang-catalog/main"));
+	}
+
+	@Test
+	void testPropertyReplacementSkipsAutomaticReplacement() throws IOException {
+		// Property replacement should take precedence over automatic GAV replacement
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:tool-${jbang.app.version:1.0}:2.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:3.0");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		// Should use property replacement only, not replace the :2.0 GAV version
+		assertThat(resolved, equalTo("com.example:tool-3.0:2.0"));
+	}
+
+	@Test
+	void testBackwardCompatibilityNoVersion() throws IOException {
+		// Aliases without version syntax should work exactly as before
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		Alias alias = Alias.get("tool");
+		String resolved = alias.resolve();
+
+		assertThat(resolved, equalTo("com.example:artifact:1.0.0"));
+	}
+
+	@Test
+	void testVersionWithSpecialCharacters() throws IOException {
+		// Version strings can contain various characters
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0.0-alpha+build.123");
+		Alias alias = Alias.get(ref.alias);
+		String resolved = resolveWithVersion(alias, ref);
+
+		assertThat(ref.requestedVersion, equalTo("1.0.0-alpha+build.123"));
+		assertThat(resolved, equalTo("com.example:artifact:1.0.0-alpha+build.123"));
+	}
+
+	@Test
+	void testNoReplacementForPlainUrls() throws IOException {
+		// URLs that don't match git patterns should throw error for least surprise
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"https://example.com/script.java\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		AliasRef ref = AliasRef.parse("tool:1.0.0");
+		Alias alias = Alias.get(ref.alias);
+		assertThat(alias, notNullValue());
+
+		ExitException ex = assertThrows(ExitException.class,
+				() -> resolveWithVersion(alias, ref));
+		assertThat(ex.getMessage(), containsString("Cannot apply version '1.0.0'"));
+		assertThat(ex.getMessage(), containsString("No recognizable version pattern found"));
+	}
+
+	@Test
+	void testAliasChainWithVersionErrors() throws IOException {
+		// Test that version CANNOT be applied to alias chains
+		// Version should only apply to the direct target, not through references
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"base\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    },\n" +
+				"    \"wrapper\": {\n" +
+				"      \"script-ref\": \"base\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		Catalog cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+		AliasRef ref = AliasRef.parse("wrapper:2.0.0");
+		ExitException ex = assertThrows(ExitException.class, () -> Alias.get(cat, ref.alias, ref.requestedVersion));
+		assertThat(ex.getMessage(), containsString("Cannot apply version '2.0.0' to alias reference 'base'"));
+		assertThat(ex.getMessage(), containsString("Use the target alias directly: base:2.0.0"));
+	}
+
+	@Test
+	@Disabled("version pinning currently not supported inside catalogs")
+	void testAliasChainWithVersionRef() throws IOException {
+		// Test that version CANNOT be applied to alias chains
+		// Version should only apply to the direct target, not through references
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"base\": {\n" +
+				"      \"script-ref\": \"com.example:artifact:1.0.0\"\n" +
+				"    },\n" +
+				"    \"wrapper\": {\n" +
+				"      \"script-ref\": \"base:2.0.0\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		Catalog cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+		AliasRef ref = AliasRef.parse("wrapper");
+		Alias alias = Alias.get(cat, ref.alias, ref.requestedVersion);
+
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("com.example:artifact:1.0.0"));
+
+		cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+		ref = AliasRef.parse("wrapper:3.0.0");
+		alias = Alias.get(cat, ref.alias, ref.requestedVersion);
+
+		assertThat(alias, notNullValue());
+		assertThat(alias.scriptRef, equalTo("com.example:artifact:3.0.0"));
+
+	}
+
+}

--- a/src/test/java/dev/jbang/cli/TestAliasVersionReplacement.java
+++ b/src/test/java/dev/jbang/cli/TestAliasVersionReplacement.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
+import dev.jbang.ExitException;
 import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.AliasRef;
 import dev.jbang.catalog.AliasVersionPinner;
@@ -419,6 +420,42 @@ public class TestAliasVersionReplacement extends BaseTest {
 		assertThat(alias, notNullValue());
 		assertThat(alias.scriptRef, equalTo("com.example:artifact:3.0.0"));
 
+	}
+
+	@Test
+	void testCatalogRefVersionPropertyExpansion() throws IOException {
+		// Test that ${jbang.app.version} is expanded in catalog references
+		// before the catalog is looked up.
+		// This verifies the fix for: "Unknown catalog
+		// './apps/${jbang.app.version:1.0.0}/...'"
+
+		String catalog = "{\n" +
+				"  \"aliases\": {\n" +
+				"    \"tool\": {\n" +
+				"      \"script-ref\": \"app@./versions/${jbang.app.version:1.0.0}/jbang-catalog.json\"\n" +
+				"    }\n" +
+				"  }\n" +
+				"}";
+		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), catalog.getBytes());
+
+		Catalog cat = Catalog.get(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON));
+
+		// Without version: error should show EXPANDED path (1.0.0), not raw
+		// ${jbang.app.version}
+		AliasRef ref1 = AliasRef.parse("tool");
+		ExitException ex = assertThrows(ExitException.class,
+				() -> Alias.get(cat, ref1.alias, ref1.requestedVersion));
+		// Key assertion: the error contains the expanded version "1.0.0", not
+		// "${jbang.app.version:1.0.0}"
+		assertThat(ex.getMessage(), containsString("1.0.0"));
+		assertThat(ex.getMessage(), not(containsString("${jbang.app.version")));
+
+		// With version: error should show requested version "2.0.0"
+		AliasRef ref2 = AliasRef.parse("tool:2.0.0");
+		ex = assertThrows(ExitException.class,
+				() -> Alias.get(cat, ref2.alias, ref2.requestedVersion));
+		assertThat(ex.getMessage(), containsString("2.0.0"));
+		assertThat(ex.getMessage(), not(containsString("${jbang.app.version")));
 	}
 
 }


### PR DESCRIPTION
Implements `alias:version@catalog` syntax to pin versions at invocation time without modifying catalog files.
                                         
   Try and fix with the syntax suggested in #1979

  **Examples:**
   ```bash
   jbang picocli:4.7.0                    # GAV version replacement
   jbang tool:v1.0@jbangdev               # Git URL branch replacement
   jbang app:2.0@myorg/repo/main          # Catalog ref replacement
   ```

   ## Implementation

   **Version replacement cascade:**
   1. Property replacement (`${jbang.app.version:default}`) - takes precedence

As in, if alias has property replacement we will NOT do automagic replacement because 
can't know user really want the replacement .

   3. Maven GAV replacement (`group:artifact:version` → `group:artifact:newversion`)
   4. Git URL replacement (GitHub/GitLab/Bitbucket branch/tag substitution)
   5. Catalog reference replacement (`alias@org/repo/ref` → `alias@org/repo/version`)
   6. **Hard error** if version specified but no pattern matches.

Did this with the thinking that if version replacement not possible its better we fail - but of course if jbang.app.version is included we 'll have to just trust the catalog writer.

For example:
   ```json
   {
     "aliases": {
       "quarkus": {
         "script-ref": "io.quarkus:quarkus-cli-${jbang.app.version:3.0.0}:3.7.0"
       }
     }
   }
   ```
   Running `jbang quarkus:3.5.0` resolves to `io.quarkus:quarkus-cli-3.5.0:3.7.0`

   ## Feedback Needed

   1. **Hard error vs warning**: Currently throws `ExitException` when version cannot be applied to unknown URL patterns. Is this the right behavior (least surprise) or should it warn and continue?

   2. **GAV detection heuristic**: Uses colon counting (2+ colons = GAV) and dot detection in first segment (groupId pattern). Edge cases where this might fail?

   3. **Catalog reference version pinning**: For registered catalog names (e.g., `tool:1.0@mycatalog` where `mycatalog` is a named catalog), currently errors since we can't modify the catalog URL. Should this work
   differently?

 
   ## Documentation

   Added complete "Version Pinning" section to `docs/modules/ROOT/pages/alias_catalogs.adoc` with syntax, examples, and all replacement strategies.
   
  