### PR TITLE
fix: use platform-specific arrow key sequences for Windows compatibility

### DIFF
--- a/src/main/java/dev/jbang/search/ArtifactSearchWidget.java
+++ b/src/main/java/dev/jbang/search/ArtifactSearchWidget.java
@@ -317,7 +317,11 @@ public class ArtifactSearchWidget {
 			}
 		});
 
-		artifactCombobox.handle("next_phase", "\u001b[C", (g) -> {
+		// Use platform-specific arrow key sequences (fixes Windows compatibility #2403, #2348)
+		String keyRight = org.jline.keymap.KeyMap.key(terminal, Capability.key_right);
+		String keyLeft = org.jline.keymap.KeyMap.key(terminal, Capability.key_left);
+
+		artifactCombobox.handle("next_phase", keyRight != null ? keyRight : "\u001b[C", (g) -> {
 			if (g.matches().size() == 0) {
 				return Collections.<Combobox.ComboboxAction>emptyList();
 			}
@@ -332,7 +336,7 @@ public class ArtifactSearchWidget {
 			return actions;
 		});
 
-		artifactCombobox.handle("previous_phase", "\u001b[D", (g) -> {
+		artifactCombobox.handle("previous_phase", keyLeft != null ? keyLeft : "\u001b[D", (g) -> {
 
 			Fuzz.SearchFuzzedResult<Artifact> selected = g.matches().get(g.selectedIndex());
 

--- a/src/main/java/dev/jbang/search/ComboBox.java
+++ b/src/main/java/dev/jbang/search/ComboBox.java
@@ -35,10 +35,17 @@ class Combobox<T> {
 		this.itemRenderer = (t) -> new AttributedString(t.toString());
 		this.qb = new StringBuilder(initialQuery);
 
-		// Define key bindings
+		// Define key bindings using platform-specific sequences from terminal capabilities
 		keys.setNomatch("nomatch"); // Any printable char
-		handle("up", "\033[A", this::selectionUp); // Arrow up
-		handle("down", "\033[B", this::selectionDown); // Arrow down
+
+		// Use KeyMap.key() to get platform-specific escape sequences for arrow keys
+		// This fixes Windows terminal compatibility (issue #2403, #2348)
+		String keyUp = KeyMap.key(terminal, Capability.key_up);
+		String keyDown = KeyMap.key(terminal, Capability.key_down);
+
+		// Fallback to standard ANSI sequences if terminal doesn't provide capabilities
+		handle("up", keyUp != null ? keyUp : "\033[A", this::selectionUp);
+		handle("down", keyDown != null ? keyDown : "\033[B", this::selectionDown);
 		handle("backspace", "\177", this::delete);
 		handle("enter", "\r", this::select);
 		handle("nomatch", "\u0003", this::update); // Ctrl-C


### PR DESCRIPTION
Fixes #2403
Fixes #2348

## Problem

The `jbang deps search` command was broken on Windows terminals (CMD, PowerShell, Git Bash). When pressing arrow keys:
- Down arrow added 'B' characters to the input instead of moving selection
- The list became shorter
- Selection indicator didn't move

## Root Cause

The code used hardcoded ANSI escape sequences for arrow keys:
- Up: `\033[A`
- Down: `\033[B`
- Left: `\033[D`
- Right: `\033[C`

These sequences don't work correctly on Windows terminals because different terminals send different escape sequences.

## Solution

Use JLine3's `KeyMap.key(terminal, Capability)` method to get platform-specific escape sequences:
- `KeyMap.key(terminal, Capability.key_up)` 
- `KeyMap.key(terminal, Capability.key_down)`
- `KeyMap.key(terminal, Capability.key_left)`
- `KeyMap.key(terminal, Capability.key_right)`

This method queries the terminal's capabilities and returns the correct sequence for each platform, with fallback to standard ANSI sequences for terminals that don't provide capability information.

## Changes

- **ComboBox.java**: Use platform-specific sequences for up/down arrow keys (list navigation)
- **ArtifactSearchWidget.java**: Use platform-specific sequences for left/right arrow keys (phase navigation)

## Testing

- ✅ Maintains backward compatibility with fallback mechanism
- ✅ Uses JLine's built-in platform abstraction
- ✅ Should work on Windows CMD, PowerShell, Git Bash, and all Unix terminals
- ⚠️  Needs testing on Windows to confirm (I don't have access to Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)