### PR TITLE
fix: handle missing template files gracefully

### DIFF
--- a/src/main/java/dev/jbang/source/RefTarget.java
+++ b/src/main/java/dev/jbang/source/RefTarget.java
@@ -86,7 +86,11 @@ public class RefTarget {
 	}
 
 	public static RefTarget create(String ref, Path dest, ResourceResolver siblingResolver) {
-		return new RefTarget(siblingResolver.resolve(ref), dest);
+		ResourceRef resolved = siblingResolver.resolve(ref);
+		if (resolved == null) {
+			resolved = ResourceRef.forUnresolvable(ref, "not resolvable from " + siblingResolver.description());
+		}
+		return new RefTarget(resolved, dest);
 	}
 
 	public static RefTarget create(ResourceRef ref, Path dest) {

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -354,4 +354,25 @@ public class TestInit extends BaseTest {
 
 	}
 
+	@Test
+	void testInitWithMissingTemplateFile() throws IOException {
+		Path cwd = Util.getCwd();
+		Path out = cwd.resolve("result.java");
+
+		// Create template with reference to non-existent file
+		int addResult = JBang.getCommandLine()
+			.execute("template", "add", "-f", cwd.toString(), "--name=bad-template",
+					"{basename}/{basename}App.java=tpl/NonExistentFile.java");
+		assertThat(addResult, is(0));
+
+		// Attempting to init with this template should fail gracefully with clear error
+		int result = JBang.getCommandLine()
+			.execute("init", "--template=bad-template", "test");
+
+		// Should fail with non-zero exit code
+		assertThat(result, not(0));
+		// Output file should not be created
+		assertThat(out.toFile().exists(), is(false));
+	}
+
 }


### PR DESCRIPTION
Fixes #2396 

## Problem
When a template references a file that doesn't exist, jbang crashes with NullPointerException:
```
[jbang] [ERROR] Cannot invoke "dev.jbang.resources.ResourceRef.getOriginalResource()"
because the return value of "dev.jbang.source.RefTarget.getSource()" is null
```

## Root Cause
In `RefTarget.create()`, when `ResourceResolver.resolve(ref)` returns `null` (which happens when a file doesn't exist), the null value was passed directly to the RefTarget constructor, which expects a non-null ResourceRef.

## Solution
Follows the established pattern from other parts of the codebase (`DocRef`, `ProjectBuilder`, `Source`) by creating an `UnresolvableResourceRef` when `resolve()` returns null.

This provides a clear error message instead of NPE:
```
Failed to get contents from resource 'templates/jbang/HelloToolkitApp.java': 
not resolvable from [resolver description]
```

## Changes
- Modified `RefTarget.create()` to check for null and use `ResourceRef.forUnresolvable()`
- Added test case `testInitWithMissingTemplateFile()` to verify graceful failure

## Testing
- Added unit test that creates a template with missing file reference
- Verifies command fails with non-zero exit code (not NPE)
- Verifies no output files are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)