### PR TITLE
build: Build with Java 25 toolchain

### DIFF
--- a/.github/actions/shared-build-setup/action.yml
+++ b/.github/actions/shared-build-setup/action.yml
@@ -9,7 +9,7 @@ inputs:
   java-version:
     description: The Java version to use
     required: false
-    default: '11'
+    default: '25'
 outputs:
   github-short-sha:
     description: The short github.sha

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -118,26 +118,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        java-version: [11]
         os: *os_matrix
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e #
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
-        with:
-            java-version: 11
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
           path: build
       - name: test
         run: |
-          ./gradlew --no-daemon test
+          ./gradlew --no-daemon test -PtestJavaVersion=${{ matrix.java-version }}
       - name: Arcive test results
         uses: ./.github/actions/shared-test-archiving
         if: always()
         with:
           prefix: ${{ steps.shared-build.outputs.github-short-sha }}-unit-test-jvm-
-          suffix: -${{matrix.os}}
+          suffix: -${{matrix.os}}-${{ matrix.java-version }}
       - name: Archive build results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ repositories {
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(11)
+		languageVersion = JavaLanguageVersion.of(25)
 		vendor = JvmVendorSpec.ADOPTIUM
 	}
 	withJavadocJar()

--- a/build.gradle
+++ b/build.gradle
@@ -324,6 +324,8 @@ compileTestJava {
 	options.compilerArgs.addAll(['--release', '11']) // wiremock requires java 11
 }
 
+
+
 compileJava9Java {
 	sourceCompatibility = 9
 	targetCompatibility = 9
@@ -439,6 +441,13 @@ testing {
 
 tasks.named('integrationTest') {
 	dependsOn("installDist") // todo: move to after buildDist
+}
+
+tasks.named('compileIntegrationTestJava') {
+	options.encoding = 'UTF-8'
+	options.compilerArgs << "-Xlint:deprecation"
+	options.compilerArgs << '-parameters' // for allure reporting
+	options.compilerArgs.addAll(['--release', '11']) // wiremock requires java 11
 }
 
 task karateExecute(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -310,28 +310,24 @@ jar {
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 
-compileJava {
+// Common compiler settings for all Java compilation tasks
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
 	options.compilerArgs << "-Xlint:deprecation"
 	options.compilerArgs << '-parameters' // for allure reporting
+}
+
+compileJava {
 	options.compilerArgs.addAll(['--release', '8'])
 }
 
 compileTestJava {
-	options.encoding = 'UTF-8'
-	options.compilerArgs << "-Xlint:deprecation"
-	options.compilerArgs << '-parameters' // for allure reporting
 	options.compilerArgs.addAll(['--release', '11']) // wiremock requires java 11
 }
-
-
 
 compileJava9Java {
 	sourceCompatibility = 9
 	targetCompatibility = 9
-	options.encoding = 'UTF-8'
-	options.compilerArgs << "-Xlint:deprecation"
-	options.compilerArgs << '-parameters' // for allure reporting
 	options.compilerArgs.addAll(['--release', '9'])
 }
 
@@ -444,9 +440,6 @@ tasks.named('integrationTest') {
 }
 
 tasks.named('compileIntegrationTestJava') {
-	options.encoding = 'UTF-8'
-	options.compilerArgs << "-Xlint:deprecation"
-	options.compilerArgs << '-parameters' // for allure reporting
 	options.compilerArgs.addAll(['--release', '11']) // wiremock requires java 11
 }
 


### PR DESCRIPTION
This is with intent of having faster builds an potentially use markdown in javadoc; but also to allow use of newer gradle plugins to handle git versioning that does not break with git worktrees.

## Summary

Update the build toolchain from Java 11 to Java 25 while keeping the same bytecode targets (`--release 8` for main code, `--release 9` for multi-release, `--release 11` for tests).

## Changes

- **`build.gradle`** — Toolchain `languageVersion` 11 → 25
- **`.github/actions/shared-build-setup/action.yml`** — Default `java-version` 11 → 25 (avoids Gradle auto-provisioning overhead)
- **`.github/workflows/step-ci-build.yml`** — Unit test job now uses `matrix.java-version` (currently `[11]`) with `-PtestJavaVersion`, matching the integration test pattern

## Notes

- `--release 8` still works on JDK 25 but emits a deprecation warning ("source value 8 is obsolete and will be removed in a future release")
- Test execution versions are unchanged: unit tests run on JDK 11, integration tests on 8/11/17/21/25
- The unit test matrix can easily be expanded to more Java versions in the future