### PR TITLE
fix: cache clear now deletes dep files from disk, not just JSON

### DIFF
--- a/src/main/java/dev/jbang/Cache.java
+++ b/src/main/java/dev/jbang/Cache.java
@@ -5,6 +5,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import dev.jbang.cli.ExitException;
+import dev.jbang.dependencies.DependencyCache;
 import dev.jbang.devkitman.Jdk;
 import dev.jbang.devkitman.JdkManager;
 import dev.jbang.util.JavaUtil;
@@ -39,6 +40,10 @@ public class Cache {
 						Util.verboseMsg("Deleting file " + Settings.getCacheDependencyFile());
 						Files.deleteIfExists(Settings.getCacheDependencyFile().toAbsolutePath());
 					}
+					// Also delete the actual dependency cache directory containing JARs
+					Util.deletePath(Settings.getCacheDir(cc), true);
+					// Clear in-memory cache
+					DependencyCache.clear();
 				} catch (IOException io) {
 					throw new ExitException(-1,
 							"Could not delete dependency cache " + Settings.getCacheDependencyFile().toString(), io);

--- a/src/main/java/dev/jbang/dependencies/DependencyCache.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyCache.java
@@ -140,6 +140,22 @@ public class DependencyCache {
 
 	public static void clear() {
 		depCache = null;
+		// Also clear the dependency cache JSON file from disk
+		try {
+			Path cacheFile = Settings.getCacheDependencyFile();
+			if (Files.exists(cacheFile)) {
+				Util.verboseMsg("Deleting dependency cache file: " + cacheFile);
+				Files.deleteIfExists(cacheFile);
+			}
+			// Also clear the depcache directory containing actual JARs
+			Path depCacheDir = Settings.getCacheDir(dev.jbang.Cache.CacheClass.deps);
+			if (Files.exists(depCacheDir)) {
+				Util.verboseMsg("Deleting dependency cache dir: " + depCacheDir);
+				Util.deletePath(depCacheDir, true);
+			}
+		} catch (IOException e) {
+			Util.errorMsg("Could not clear dependency cache files", e);
+		}
 	}
 
 }


### PR DESCRIPTION
## Problem
`jbang cache clear` was not actually clearing the dependency cache from disk.

The `DependencyCache.clear()` method only set the in-memory `depCache` to null,
but never deleted the actual cached files on disk. This means running
`jbang cache clear` would leave all downloaded JARs and the dependency_cache.json
file still present on disk.

## Fix
Updated `DependencyCache.clear()` to also:
- Delete the `dependency_cache.json` file from disk
- Delete the `depcache` directory containing actual downloaded JARs

## Related Issue
Fixes #475