### PR TITLE
fix: use USERPROFILE on Windows for non-ASCII username support

### DIFF
--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -56,7 +56,12 @@ public class Settings {
 		if (jd != null) {
 			dir = Paths.get(jd);
 		} else {
-			dir = Paths.get(System.getProperty("user.home")).resolve(".jbang");
+			// On Windows, USERPROFILE is more reliable than user.home for non-ASCII
+			// usernames
+			String home = Util.isWindows()
+					? System.getenv().getOrDefault("USERPROFILE", System.getProperty("user.home"))
+					: System.getProperty("user.home");
+			dir = Paths.get(home).resolve(".jbang");
 		}
 
 		if (init)

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -56,12 +56,7 @@ public class Settings {
 		if (jd != null) {
 			dir = Paths.get(jd);
 		} else {
-			// On Windows, USERPROFILE is more reliable than user.home for non-ASCII
-			// usernames
-			String home = Util.isWindows()
-					? System.getenv().getOrDefault("USERPROFILE", System.getProperty("user.home"))
-					: System.getProperty("user.home");
-			dir = Paths.get(home).resolve(".jbang");
+			dir = Util.getUserHomeDir().resolve(".jbang");
 		}
 
 		if (init)
@@ -101,7 +96,7 @@ public class Settings {
 		if (jlr != null) {
 			dir = Paths.get(jlr);
 		} else {
-			dir = Paths.get(System.getProperty("user.home"));
+			dir = Util.getUserHomeDir();
 		}
 		return dir;
 	}

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -3,6 +3,7 @@ package dev.jbang.cli;
 import static dev.jbang.util.JavaUtil.defaultJdkManager;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -480,7 +481,18 @@ class AppSetup extends BaseCommand {
 			}
 		}
 		if (!cmd.isEmpty()) {
-			System.out.println(cmd);
+			if (Util.isWindows() && Util.getShell() == Util.Shell.powershell) {
+				try {
+					Path tmpFile = Files.createTempFile("jbang-setup-", ".ps1");
+					tmpFile.toFile().deleteOnExit();
+					Files.write(tmpFile, cmd.getBytes(StandardCharsets.UTF_8));
+					System.out.println(tmpFile.toAbsolutePath().toString());
+				} catch (IOException e) {
+					System.out.println(cmd);
+				}
+			} else {
+				System.out.println(cmd);
+			}
 			return EXIT_EXECUTE;
 		} else {
 			return EXIT_OK;

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -3,7 +3,6 @@ package dev.jbang.cli;
 import static dev.jbang.util.JavaUtil.defaultJdkManager;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -481,18 +480,7 @@ class AppSetup extends BaseCommand {
 			}
 		}
 		if (!cmd.isEmpty()) {
-			if (Util.isWindows() && Util.getShell() == Util.Shell.powershell) {
-				try {
-					Path tmpFile = Files.createTempFile("jbang-setup-", ".ps1");
-					tmpFile.toFile().deleteOnExit();
-					Files.write(tmpFile, cmd.getBytes(StandardCharsets.UTF_8));
-					System.out.println(tmpFile.toAbsolutePath().toString());
-				} catch (IOException e) {
-					System.out.println(cmd);
-				}
-			} else {
-				System.out.println(cmd);
-			}
+			System.out.println(cmd);
 			return EXIT_EXECUTE;
 		} else {
 			return EXIT_OK;
@@ -550,7 +538,7 @@ class AppSetup extends BaseCommand {
 	}
 
 	private static Path getHome() {
-		return Paths.get(System.getProperty("user.home"));
+		return Util.getUserHomeDir();
 	}
 
 	private static String toHomePath(Path path) {

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -614,6 +614,21 @@ public class Util {
 		return OsUtils.isWindows();
 	}
 
+	/**
+	 * Returns the user's home directory. On Windows, prefers the USERPROFILE
+	 * environment variable over Java's user.home property because user.home can
+	 * return a corrupted path when the username contains non-ASCII characters.
+	 */
+	public static Path getUserHomeDir() {
+		if (isWindows()) {
+			String up = System.getenv("USERPROFILE");
+			if (up != null && !up.isEmpty()) {
+				return Paths.get(up);
+			}
+		}
+		return Paths.get(System.getProperty("user.home"));
+	}
+
 	public static Shell getShell() {
 		try {
 			return Shell.valueOf(System.getenv(JBANG_RUNTIME_SHELL));


### PR DESCRIPTION
## Problem
On Windows, users with non-ASCII characters in their username (common
in many countries including India, China, Eastern Europe) experience
broken PATH setup and jbang failing completely.

Root cause: Java's `System.getProperty("user.home")` can return a
corrupted path on Windows when the username contains non-ASCII characters.

## Fix
On Windows, prefer `USERPROFILE` environment variable over `user.home`
as it always returns the correct path regardless of username characters.

## Related Issue
Fixes #1110