### PR TITLE
fix: prevent duplicate PATH entries when running setup multiple times on WindowsFix/duplicate path entries on windows setup

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -427,11 +427,12 @@ class AppSetup extends BaseCommand {
 						"[EnvironmentVariableTarget]::User)";
 			}
 			if (force || needsSetup()) {
-				// Create the command to change the user's PATH
-				String newPath = binDir + ";";
-				env += " ; [Environment]::SetEnvironmentVariable('Path', '" + newPath + "' + " +
-						"[Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::User), " +
-						"[EnvironmentVariableTarget]::User)";
+				// Only add to PATH if not already present in permanent user PATH
+				env += " ; $userPath = [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::User)";
+				env += " ; if ($userPath -notlike '*" + binDir + "*') {";
+				env += " [Environment]::SetEnvironmentVariable('Path', '" + binDir
+						+ ";' + $userPath, [EnvironmentVariableTarget]::User)";
+				env += " }";
 			}
 			if (!env.isEmpty()) {
 				if (Util.getShell() == Util.Shell.powershell) {


### PR DESCRIPTION
## Problem
Fixes #940

Running `jbang app setup` multiple times on Windows creates duplicate 
PATH entries in the user's permanent PATH (registry).

`needsSetup()` only checks the current session's PATH, so in a new 
shell it always thinks setup is needed and prepends the path again 
without checking if it already exists in the permanent user PATH.

## Fix
Before adding to the permanent user PATH, check if the binDir is 
already present using PowerShell's `-notlike` operator. Only add 
if not already present.