### PR TITLE
fix: Use nisse-gradle-plugin

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
         with:

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/shared-build-setup
       - name: check formatting and comment on PR if failed
         id: check-formatting
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - name: build-with-no-tests
@@ -61,6 +65,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - name: setup-graalvm
@@ -122,6 +128,8 @@ jobs:
         os: *os_matrix
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e #
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -183,6 +191,8 @@ jobs:
     name: integration-tests
     steps:
       - uses: actions/checkout@71cf2267d89c5cb81562390fa70a37fa40b1305e #
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -233,6 +243,8 @@ jobs:
       _JBANG_: ./build/install/jbang/bin/jbang
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
         with:
@@ -276,6 +288,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -297,6 +311,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - name: Create test results summary

--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,7 @@ nisseConfig {
 		countingVersion = true
 		countingStartPatch = 1
 		appendSnapshot = false
+		countingPattern = '%M.%m.%p(.%c)'
 	}
 	os {
 		active = true
@@ -257,7 +258,7 @@ nisseConfig {
 
 // Version is computed by Nisse JGit counting version (replaces git-versioner plugin).
 // Walks commit history matching [major]/[minor]/[patch] in messages.
-// Configuration is in gradle.properties (must be set before plugin applies).
+// Must use afterEvaluate because the nisse plugin populates project.nisse in its own afterEvaluate.
 afterEvaluate {
 	version = project.nisse['nisse.jgit.countingVersion']
 }
@@ -329,11 +330,13 @@ jar {
 	manifest {
 		attributes(
 			'Main-Class': 'dev.jbang.Main',
-			'Enable-Final-Field-Mutation': 'ALL-UNNAMED',
-			'JBang-Version': project.version
+			'Enable-Final-Field-Mutation': 'ALL-UNNAMED'
 		)
 	}
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	doFirst {
+		manifest.attributes('JBang-Version': project.version)
+	}
 }
 
 // Common compiler settings for all Java compilation tasks
@@ -370,9 +373,11 @@ shadowJar {
 	mergeServiceFiles()
 	manifest {
 		attributes(
-			'Main-Class': 'dev.jbang.Main',
-			'JBang-Version': project.version
+			'Main-Class': 'dev.jbang.Main'
 		)
+	}
+	doFirst {
+		manifest.attributes('JBang-Version': project.version)
 	}
 	archiveFileName = "${archiveBaseName.get()}.${archiveExtension.get()}"
 }
@@ -496,7 +501,7 @@ task createChecksum(type: Checksum) {
 
 task container(type: Copy) {
 	dependsOn(createChecksum)
-	inputs.property('version', project.version)
+	inputs.property('version', provider { project.version })
 	from('src/main/scripts/container/')
 	include('*')
 	into(buildDir.toString() + '/container')
@@ -512,7 +517,7 @@ task container(type: Copy) {
 
 task spec(type: Copy) {
 	dependsOn(createChecksum)
-	inputs.property('version', project.version)
+	inputs.property('version', provider { project.version })
 	from('src/main/scripts/spec/jbang.spec')
 	into(buildDir.toString() + '/spec')
 	doFirst { t ->
@@ -527,7 +532,7 @@ task spec(type: Copy) {
 
 task chocolatey(type: Copy) {
 	dependsOn(createChecksum)
-	inputs.property('version', project.version)
+	inputs.property('version', provider { project.version })
 	from('src/main/scripts/choco')
 	into(buildDir.toString() + '/choco')
 	doFirst { t ->

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 	id "org.sonarqube" version "4.0.0.2929"
 	id 'jacoco'
 	id 'maven-publish'
-	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.8.5-SNAPSHOT'
+	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.9.0'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
 }
@@ -175,6 +175,7 @@ dependencies {
 	implementation "org.jline:jline-console-ui:$jlineVersion"
 	implementation "org.jline:jline-terminal-jni:$jlineVersion"
 
+	// used in JBang as well (aside of nisse plugin in the build)
 	implementation "eu.maveniverse.maven.nisse:core:0.6.2"
 	implementation "eu.maveniverse.maven.nisse.sources:os-source:0.6.2"
 
@@ -243,10 +244,23 @@ spotless {
 	}
 }
 
+nisseConfig {
+	jgit {
+		countingVersion = true
+		countingStartPatch = 1
+		appendSnapshot = false
+	}
+	os {
+		active = true
+	}
+}
+
 // Version is computed by Nisse JGit counting version (replaces git-versioner plugin).
 // Walks commit history matching [major]/[minor]/[patch] in messages.
 // Configuration is in gradle.properties (must be set before plugin applies).
-project.version = nisse['nisse.jgit.countingVersion']
+afterEvaluate {
+	version = project.nisse['nisse.jgit.countingVersion']
+}
 
 task printVersion {
 	group = "versioning"

--- a/build.gradle
+++ b/build.gradle
@@ -260,7 +260,11 @@ nisseConfig {
 // Walks commit history matching [major]/[minor]/[patch] in messages.
 // Must use afterEvaluate because the nisse plugin populates project.nisse in its own afterEvaluate.
 afterEvaluate {
-	version = project.nisse['nisse.jgit.countingVersion']
+	def resolvedVersion = project.nisse['nisse.jgit.countingVersion']?.toString()
+	if (!resolvedVersion || resolvedVersion.matches('0\\.0\\.1-\\d+')) {
+		throw new GradleException("Invalid computed version '${resolvedVersion}'. Ensure semantic version tags exist (e.g., 'v0.120.0') or check fetch-depth/clone strategy.")
+	}
+	version = resolvedVersion
 }
 
 task printVersion {
@@ -556,6 +560,30 @@ task tagVersion {
 	doLast {
 		def tagName = 'v' + project.version
 		println 'Tagging with ' + tagName
+		def existingTag = new ByteArrayOutputStream()
+		exec {
+			commandLine 'git', 'tag', '-l', tagName
+			standardOutput = existingTag
+		}
+		if (existingTag.toString().trim()) {
+			// Tag exists — verify it points to HEAD
+			def tagSha = new ByteArrayOutputStream()
+			exec {
+				commandLine 'git', 'rev-list', '-n', '1', tagName
+				standardOutput = tagSha
+			}
+			def headSha = new ByteArrayOutputStream()
+			exec {
+				commandLine 'git', 'rev-parse', 'HEAD'
+				standardOutput = headSha
+			}
+			if (tagSha.toString().trim() == headSha.toString().trim()) {
+				println "Tag '${tagName}' already exists at HEAD, skipping"
+				return
+			} else {
+				throw new GradleException("Tag '${tagName}' already exists but points to ${tagSha.toString().trim()}, not HEAD (${headSha.toString().trim()})")
+			}
+		}
 		exec {
 			commandLine 'git', 'tag', '-a', tagName, '-m', tagName
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
 	id "org.sonarqube" version "4.0.0.2929"
 	id 'jacoco'
 	id 'maven-publish'
+	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.8.5-SNAPSHOT'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id "java"
 	id "jvm-test-suite"
 	id "com.github.breadmoirai.github-release" version "2.4.1"
-	id "io.toolebox.git-versioner" version "1.6.7"
+
 	id 'org.gradle.crypto.checksum' version '1.4.0'
 	id "com.diffplug.spotless" version "7.2.1"
 	id 'com.github.gmazzo.buildconfig' version "3.1.0"
@@ -243,7 +243,18 @@ spotless {
 	}
 }
 
-versioner.apply()
+// Version is computed by Nisse JGit counting version (replaces git-versioner plugin).
+// Walks commit history matching [major]/[minor]/[patch] in messages.
+// Configuration is in gradle.properties (must be set before plugin applies).
+project.version = nisse['nisse.jgit.countingVersion']
+
+task printVersion {
+	group = "versioning"
+	description = "Print the project version"
+	doLast {
+		println project.version
+	}
+}
 
 task versionTxt() {
 	doLast {
@@ -520,27 +531,17 @@ task copyITests(type: Copy) {
 	into "${buildDir}/itests"
 }
 
-task tag(type: Exec) {
-	doFirst {
-		println 'Tagging with v' + project.version
-		commandLine 'git', 'tag', '-a', 'v' + project.version, '-m', 'v' + project.version
-	}
-}
-
-versioner {
-	startFrom {
-		major = 0
-		minor = 0
-		patch = 1
-	}
-	pattern {
-		pattern = "%M.%m.%p(.%c)"
-	}
-	git {
-		authentication {
-			https {
-				token = project.hasProperty('github_token') ? getProperty('github_token') : "unknown_github_token"
-			}
+task tagVersion {
+	group = "versioning"
+	description = "Tag and push the current version in git"
+	doLast {
+		def tagName = 'v' + project.version
+		println 'Tagging with ' + tagName
+		exec {
+			commandLine 'git', 'tag', '-a', tagName, '-m', tagName
+		}
+		exec {
+			commandLine 'git', 'push', 'origin', tagName
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,0 @@
-# Nisse JGit counting version configuration (replaces git-versioner plugin)
-# These must be system properties so they're available when the Nisse plugin applies.
-systemProp.nisse.source.jgit.countingVersion=true
-systemProp.nisse.source.jgit.countingVersion.startPatch=1
-systemProp.nisse.source.jgit.countingVersion.pattern=%M.%m.%p(.%c)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Nisse JGit counting version configuration (replaces git-versioner plugin)
+# These must be system properties so they're available when the Nisse plugin applies.
+systemProp.nisse.source.jgit.countingVersion=true
+systemProp.nisse.source.jgit.countingVersion.startPatch=1
+systemProp.nisse.source.jgit.countingVersion.pattern=%M.%m.%p(.%c)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
+pluginManagement {
+  repositories {
+      gradlePluginPortal()
+      mavenLocal()
+  }
+
+  resolutionStrategy {
+    eachPlugin {
+        if (requested.id.namespace == 'eu.maveniverse.gradle.plugins') {
+            useModule("eu.maveniverse.gradle.plugins:nisse-gradle-plugin:${requested.version}")
+        }
+    }
+  }
+}
+
 plugins {
 	id "com.gradle.develocity" version "4.3.2"
 	id "org.gradle.toolchains.foojay-resolver-convention" version "0.10.0"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
 repositories {
 	gradlePluginPortal()
-	mavenCentral() // until nisse-gradle-plugin gets approved
-	mavenLocal() // for testing locally built versions of the plugin
+	mavenCentral() // nisse-gradle-plugin is published to Maven Central
 }
 
 resolutionStrategy {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,16 +1,17 @@
 pluginManagement {
-  repositories {
-      gradlePluginPortal()
-      mavenLocal()
-  }
+repositories {
+	gradlePluginPortal()
+	mavenCentral() // until nisse-gradle-plugin gets approved
+	mavenLocal() // for testing locally built versions of the plugin
+}
 
-  resolutionStrategy {
-    eachPlugin {
-        if (requested.id.namespace == 'eu.maveniverse.gradle.plugins') {
-            useModule("eu.maveniverse.gradle.plugins:nisse-gradle-plugin:${requested.version}")
-        }
-    }
-  }
+resolutionStrategy {
+	eachPlugin {
+		if (requested.id.namespace == 'eu.maveniverse.gradle.plugins') {
+			useModule("eu.maveniverse.gradle.plugins:nisse-gradle-plugin:${requested.version}")
+		}
+	}
+}
 }
 
 plugins {

--- a/src/test/java/dev/jbang/TestBuildVersion.java
+++ b/src/test/java/dev/jbang/TestBuildVersion.java
@@ -1,0 +1,39 @@
+package dev.jbang;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.util.BuildConfig;
+
+public class TestBuildVersion {
+
+	@Test
+	void versionIsNotUnspecified() {
+		assertNotNull(BuildConfig.VERSION, "BuildConfig.VERSION should not be null");
+		assertFalse(BuildConfig.VERSION.isEmpty(), "BuildConfig.VERSION should not be empty");
+		assertFalse(BuildConfig.VERSION.equals("unspecified"),
+				"BuildConfig.VERSION should not be 'unspecified'");
+		assertTrue(BuildConfig.VERSION.matches("\\d+\\.\\d+\\.\\d+.*"),
+				"BuildConfig.VERSION should look like a semver version, but was: " + BuildConfig.VERSION);
+	}
+
+	@Test
+	void manifestContainsVersion() throws IOException {
+		java.nio.file.Path manifestPath = java.nio.file.Paths.get("build/tmp/jar/MANIFEST.MF");
+		if (!java.nio.file.Files.exists(manifestPath)) {
+			return;
+		}
+		try (InputStream is = java.nio.file.Files.newInputStream(manifestPath)) {
+			Manifest manifest = new Manifest(is);
+			String jbangVersion = manifest.getMainAttributes().getValue("JBang-Version");
+			assertNotNull(jbangVersion, "JBang-Version should be present in META-INF/MANIFEST.MF");
+			assertFalse(jbangVersion.equals("unspecified"),
+					"JBang-Version in MANIFEST.MF should not be 'unspecified'");
+		}
+	}
+}

--- a/src/test/java/dev/jbang/TestBuildVersion.java
+++ b/src/test/java/dev/jbang/TestBuildVersion.java
@@ -1,6 +1,7 @@
 package dev.jbang;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,15 +26,16 @@ public class TestBuildVersion {
 	@Test
 	void manifestContainsVersion() throws IOException {
 		java.nio.file.Path manifestPath = java.nio.file.Paths.get("build/tmp/jar/MANIFEST.MF");
-		if (!java.nio.file.Files.exists(manifestPath)) {
-			return;
-		}
+		assumeTrue(java.nio.file.Files.exists(manifestPath),
+				"Manifest file not yet generated - run jar task first");
 		try (InputStream is = java.nio.file.Files.newInputStream(manifestPath)) {
 			Manifest manifest = new Manifest(is);
 			String jbangVersion = manifest.getMainAttributes().getValue("JBang-Version");
 			assertNotNull(jbangVersion, "JBang-Version should be present in META-INF/MANIFEST.MF");
 			assertFalse(jbangVersion.equals("unspecified"),
 					"JBang-Version in MANIFEST.MF should not be 'unspecified'");
+			assertEquals(BuildConfig.VERSION, jbangVersion,
+					"JBang-Version in MANIFEST.MF should match BuildConfig.VERSION");
 		}
 	}
 }


### PR DESCRIPTION
Just to experiment.

To make it work, locally:
* `mvn install` main branch of https://github.com/maveniverse/nisse (this PR makes jbang build use local repo for plugins too, so it has to be installed for gradle to find it)
* checkout this branch
* run this https://gist.github.com/cstamas/1350aa7c0864dc0b1e2a3f5b1024b23c

<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows updated to fetch full git history for checkout
  * Switched project versioning to a new JGit-based plugin and updated release tagging behavior
  * Configured plugin resolution to support the new versioning plugin
  * Packaging and build tasks adjusted for lazy version evaluation
  * Manifest generation enhanced with additional metadata and runtime version injection
  * Added a task to print the computed project version

* **Tests**
  * Added tests validating build version and manifest version consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang/pull/2464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->