### PR TITLE
feat: support native-aware wrapper install/update flows

### DIFF
--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -295,6 +295,52 @@ jobs:
           chmod +x ./test_suite.sh
           ./test_suite.sh
 
+  jreleaser-dry-run:
+    needs: [build-shared, build-test-native-image]
+    if: always() && needs.build-shared.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      JRELEASER_VERSION: 1.19.0
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+      - id: shared-build
+        uses: ./.github/actions/shared-build-setup
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
+          path: build
+      - name: Download native bundles
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-*
+          path: build/distributions
+          merge-multiple: true
+          if-no-files-found: warn
+      - name: version extract
+        id: version
+        run: |
+          RELEASE_VERSION=`cat build/tmp/version.txt`
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $RELEASE_VERSION"
+          ls -la build/distributions
+      - name: Run JReleaser (dry-run)
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
+          JRELEASER_GITHUB_TOKEN: unused-dry-run
+        with:
+          version: ${{ env.JRELEASER_VERSION }}
+          arguments: release --dry-run
+          setup-java: false
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: ${{ steps.shared-build.outputs.github-short-sha }}-jreleaser-release-artifacts
+          path: out/jreleaser/
+
   merge-test-reports:
     if: always() && !inputs.skip_tests
     needs: [unit-test-jvm, integration-test-jvm, build-test-native-image]

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -297,7 +297,7 @@ jobs:
 
   jreleaser-dry-run:
     needs: [build-shared, build-test-native-image]
-    if: always() && needs.build-shared.result == 'success'
+    if: needs.build-shared.result == 'success' && needs.build-test-native-image.result == 'success'
     runs-on: ubuntu-latest
     env:
       JRELEASER_VERSION: 1.19.0
@@ -330,6 +330,11 @@ jobs:
         env:
           JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
           JRELEASER_GITHUB_TOKEN: unused-dry-run
+          JRELEASER_GPG_PASSPHRASE: unused-dry-run
+          JRELEASER_GPG_PUBLIC_KEY: unused-dry-run
+          JRELEASER_GPG_SECRET_KEY: unused-dry-run
+          JRELEASER_MAVENCENTRAL_JBANG_USERNAME: unused-dry-run
+          JRELEASER_MAVENCENTRAL_JBANG_PASSWORD: unused-dry-run
         with:
           version: ${{ env.JRELEASER_VERSION }}
           arguments: release --dry-run

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -92,6 +92,19 @@ jobs:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-jbang.bin-${{ matrix.os }}
           path: build/native-image/*
           if-no-files-found: error
+
+      - name: build-native-bundles
+        run: |
+          ./gradlew --no-daemon nativeDistZip nativeDistTar
+
+      - name: upload-native-bundles
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-${{ matrix.os }}
+          path: |
+            build/distributions/*-${{ runner.os == 'macOS' && 'mac' || runner.os == 'Windows' && 'windows' || 'linux' }}-*.zip
+            build/distributions/*-${{ runner.os == 'macOS' && 'mac' || runner.os == 'Windows' && 'windows' || 'linux' }}-*.tar
+          if-no-files-found: error
       
       - name: create install with jbang.bin
         if: ${{ !inputs.skip_tests }}

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -300,7 +300,7 @@ jobs:
     if: needs.build-shared.result == 'success' && needs.build-test-native-image.result == 'success'
     runs-on: ubuntu-latest
     env:
-      JRELEASER_VERSION: 1.19.0
+      JRELEASER_VERSION: 1.24.0
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -69,11 +69,18 @@ jobs:
           cd itests
           ./test_suite.sh
           cd $pastdir
+      - name: Download native bundles
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-*
+          path: build/distributions
+          merge-multiple: true
       - name: version extract
         id: version
         run: |
           RELEASE_VERSION=`cat build/tmp/version.txt`
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+          ls -la build/distributions
       - name: Run JReleaser
         uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env: 

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -70,7 +70,7 @@ jobs:
           ./test_suite.sh
           cd $pastdir
       - name: Download native bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-*
           path: build/distributions

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -75,11 +75,12 @@ jobs:
           pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-*
           path: build/distributions
           merge-multiple: true
+          if-no-files-found: error
       - name: version extract
         id: version
         run: |
           RELEASE_VERSION=`cat build/tmp/version.txt`
-          echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           ls -la build/distributions
       - name: Run JReleaser
         uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2

--- a/build.gradle
+++ b/build.gradle
@@ -332,14 +332,14 @@ latestDistTar {
 tasks.register('nativeDistZip', Zip) {
 	dependsOn('nativeImage')
 	with commonSpec
-	archiveFileName = "${getNativeBundleBaseName()}.zip"
+	archiveFileName.set(provider { "${getNativeBundleBaseName()}.zip" })
 }
 
 tasks.register('nativeDistTar', Tar) {
 	dependsOn('nativeImage')
 	with commonSpec
 	compression = Compression.NONE
-	archiveFileName = "${getNativeBundleBaseName()}.tar"
+	archiveFileName.set(provider { "${getNativeBundleBaseName()}.tar" })
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -704,7 +704,7 @@ String getNativeBundleArch() {
 	} else if (arch == 'aarch64' || arch == 'arm64') {
 		return 'aarch64'
 	} else {
-		return ''
+		return arch.replaceAll('[^a-z0-9_]+', '-')
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -704,7 +704,7 @@ String getNativeBundleArch() {
 	} else if (arch == 'aarch64' || arch == 'arm64') {
 		return 'aarch64'
 	} else {
-		return arch.replaceAll('[^a-z0-9_]+', '-')
+		return ''
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -325,9 +325,21 @@ latestDistZip {
 	archiveFileName = "${project.name}.zip"
 }
 
-
 latestDistTar {
 	archiveFileName = "${project.name}.tar"
+}
+
+tasks.register('nativeDistZip', Zip) {
+	dependsOn('nativeImage')
+	with commonSpec
+	archiveFileName = "${getNativeBundleBaseName()}.zip"
+}
+
+tasks.register('nativeDistTar', Tar) {
+	dependsOn('nativeImage')
+	with commonSpec
+	compression = Compression.NONE
+	archiveFileName = "${getNativeBundleBaseName()}.tar"
 }
 
 jar {
@@ -664,14 +676,40 @@ def generateParentSuite(boolean isIntegrationTest = false, org.gradle.jvm.toolch
 	return parts.join('-')
 }
 
-// Function to get the correct native executable name based on OS
-def getNativeExecutableName() {
+// Functions to derive native bundle metadata based on the current platform
+String getNativeExecutableName() {
 	def osName = System.getProperty('os.name').toLowerCase()
 	if (osName.contains('windows')) {
 		return 'jbang.bin.exe'
 	} else {
 		return 'jbang.bin'
 	}
+}
+
+String getNativeBundleOs() {
+	def osName = System.getProperty('os.name').toLowerCase()
+	if (osName.contains('mac') || osName.contains('darwin')) {
+		return 'mac'
+	} else if (osName.contains('windows')) {
+		return 'windows'
+	} else {
+		return 'linux'
+	}
+}
+
+String getNativeBundleArch() {
+	def arch = System.getProperty('os.arch').toLowerCase()
+	if (arch == 'x86_64' || arch == 'amd64') {
+		return 'x64'
+	} else if (arch == 'aarch64' || arch == 'arm64') {
+		return 'aarch64'
+	} else {
+		return arch.replaceAll('[^a-z0-9_]+', '-')
+	}
+}
+
+String getNativeBundleBaseName() {
+	return "${project.name}-${project.version}-${getNativeBundleOs()}-${getNativeBundleArch()}"
 }
 
 // Configure resource processing for test and integrationTest

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -30,6 +30,41 @@ Once you have jbang installed, it is recommended you run `jbang app setup`. This
 [NOTE]
 ====
 By default `jbang` uses `~/.jbang` for configurations and build cache. This can be changed using the environment variable `JBANG_DIR`.
+
+**Startup Script Environment Variables:**
+
+[cols="2,3,3"]
+|===
+|Variable |Default |Description
+
+|`JBANG_DIR`
+|`~/.jbang`
+|JBang configuration and cache directory
+
+|`JBANG_CACHE_DIR`
+|`$JBANG_DIR/cache`
+|Build cache directory
+
+|`JBANG_USE_NATIVE`
+|`false`
+|If `true`, prefer native binary (`jbang.bin`) over JAR execution
+
+|`JBANG_DOWNLOAD_BASEURL`
+|`https://github.com/jbangdev/jbang/releases`
+|Base URL for downloading JBang releases (used for testing and offline mirrors)
+
+|`JBANG_DOWNLOAD_VERSION`
+|_(unset, uses latest)_
+|Specific JBang version to download during wrapper bootstrap (e.g., `0.138.0`)
+
+|`JBANG_DEFAULT_JAVA_VERSION`
+|`17`
+|Default Java version to install if none is found
+
+|`JBANG_NO_VERSION_CHECK`
+|_(unset)_
+|If set, disables automatic version update checks
+|===
 ====
 
 == Installation Methods

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -92,6 +92,36 @@ files:
     - path: build/tmp/version.txt
     - path: build/distributions/jbang.zip
     - path: build/distributions/jbang.tar
+    - path: build/distributions/jbang-{{projectVersion}}-mac-aarch64.zip
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
+    - path: build/distributions/jbang-{{projectVersion}}-mac-aarch64.tar
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
+    - path: build/distributions/jbang-{{projectVersion}}-linux-x64.zip
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
+    - path: build/distributions/jbang-{{projectVersion}}-linux-x64.tar
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
+    - path: build/distributions/jbang-{{projectVersion}}-windows-x64.zip
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
+    - path: build/distributions/jbang-{{projectVersion}}-windows-x64.tar
+      active: RELEASE
+      transform: NOOP
+      extraProperties:
+        skipArtifact: '{{missing}}'
 
 distributions:
   jbang:

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -25,6 +25,9 @@ public class Settings {
 
 	public static final String ENV_DEFAULT_JAVA_VERSION = "JBANG_DEFAULT_JAVA_VERSION";
 	public static final String ENV_NO_VERSION_CHECK = "JBANG_NO_VERSION_CHECK";
+	public static final String ENV_DOWNLOAD_BASEURL = "JBANG_DOWNLOAD_BASEURL";
+
+	public static final String DEFAULT_RELEASES_URL = "https://www.jbang.dev/releases";
 
 	public static final int DEFAULT_JAVA_VERSION = 17;
 	public static final int DEFAULT_ALPINE_JAVA_VERSION = 16;
@@ -36,6 +39,18 @@ public class Settings {
 
 	final public static String CONFIG_CACHE_EVICT = "cache-evict";
 	final public static String DEFAULT_CACHE_EVICT = "PT12H";
+
+	/**
+	 * Returns the base URL for downloading JBang releases, respecting the
+	 * JBANG_DOWNLOAD_BASEURL environment variable. Trailing slashes are stripped.
+	 */
+	public static String getDownloadBaseUrl() {
+		String baseUrl = System.getenv(ENV_DOWNLOAD_BASEURL);
+		if (baseUrl == null || baseUrl.trim().isEmpty()) {
+			baseUrl = DEFAULT_RELEASES_URL;
+		}
+		return baseUrl.replaceAll("/+$", "");
+	}
 
 	public static Path getJBangLocalMavenRepoOverride() {
 		String jbangRepo = System.getenv().get(JBANG_REPO);

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -49,7 +49,7 @@ public class Settings {
 		if (baseUrl == null || baseUrl.trim().isEmpty()) {
 			baseUrl = DEFAULT_RELEASES_URL;
 		}
-		return baseUrl.replaceAll("/+$", "");
+		return baseUrl.trim().replaceAll("/+$", "");
 	}
 
 	public static Path getJBangLocalMavenRepoOverride() {

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -58,7 +58,7 @@ public class App {
 
 @CommandLine.Command(name = "install", description = "Install a script as a command.")
 class AppInstall extends BaseBuildCommand {
-	private static final String jbangUrl = "https://www.jbang.dev/releases/latest/download/jbang.zip";
+	private static final String DEFAULT_JBANG_RELEASES_URL = "https://www.jbang.dev/releases";
 
 	@CommandLine.Option(names = { "--force" }, description = "Force re-installation")
 	boolean force;
@@ -211,6 +211,72 @@ class AppInstall extends BaseBuildCommand {
 		Files.write(file, lines, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
 	}
 
+	private static String getDownloadBaseUrl() {
+		String baseUrl = System.getenv("JBANG_DOWNLOAD_BASEURL");
+		if (baseUrl == null || baseUrl.trim().isEmpty()) {
+			baseUrl = DEFAULT_JBANG_RELEASES_URL;
+		}
+		return baseUrl.replaceAll("/+$", "");
+	}
+
+	private static boolean isNativeRequested() {
+		String value = System.getenv("JBANG_USE_NATIVE");
+		return value != null && value.equalsIgnoreCase("true");
+	}
+
+	private static boolean isWindowsOs() {
+		return System.getProperty("os.name").toLowerCase().contains("windows");
+	}
+
+	private static String getBundleExtension() {
+		return isWindowsOs() ? "zip" : "tar";
+	}
+
+	// Keep in sync with src/main/scripts/jbang:native_bundle_arch()
+	// and src/main/scripts/jbang.ps1:Get-NativeBundleArch
+	private static String getNativeBundleArch() {
+		String arch = System.getProperty("os.arch").toLowerCase();
+		if ("x86_64".equals(arch) || "amd64".equals(arch)) {
+			return "x64";
+		}
+		if ("aarch64".equals(arch) || "arm64".equals(arch)) {
+			return "aarch64";
+		}
+		return arch.replaceAll("[^a-z0-9_]+", "-");
+	}
+
+	// Keep in sync with src/main/scripts/jbang:native_bundle_url()
+	// and src/main/scripts/jbang.ps1:Get-NativeBundleUrl
+	private static String getNativeBundleOs() {
+		String os = System.getProperty("os.name").toLowerCase();
+		if (os.contains("mac") || os.contains("darwin")) {
+			return "mac";
+		}
+		if (os.contains("windows")) {
+			return "windows";
+		}
+		return "linux";
+	}
+
+	private static String getGenericBundleUrl(String version) {
+		String baseUrl = getDownloadBaseUrl();
+		if (version == null || version.trim().isEmpty()) {
+			return baseUrl + "/latest/download/jbang." + getBundleExtension();
+		} else {
+			return baseUrl + "/download/v" + version + "/jbang." + getBundleExtension();
+		}
+	}
+
+	private static String getNativeBundleUrl(String version) {
+		String baseUrl = getDownloadBaseUrl();
+		String bundleName = "jbang-" + getNativeBundleOs() + "-" + getNativeBundleArch() + "." + getBundleExtension();
+		if (version == null || version.trim().isEmpty()) {
+			return baseUrl + "/latest/download/" + bundleName;
+		} else {
+			return baseUrl + "/download/v" + version + "/" + bundleName;
+		}
+	}
+
 	public static boolean installJBang(boolean force) throws IOException {
 		Path binDir = Settings.getConfigBinDir();
 		boolean managedJBang = Files.exists(binDir.resolve("jbang.jar"));
@@ -223,12 +289,24 @@ class AppInstall extends BaseBuildCommand {
 		if (force || !managedJBang) {
 			if (!Util.isOffline()) {
 				Util.withCacheEvict(() -> {
-					// Download JBang and unzip to ~/.jbang/bin/
+					// Download JBang and unzip/untar to ~/.jbang/bin/
 					Util.infoMsg("Downloading and installing jbang...");
-					Path zipFile = NetUtil.downloadAndCacheFile(jbangUrl);
+					String version = System.getenv("JBANG_DOWNLOAD_VERSION");
+					Path bundleFile;
+					if (isNativeRequested()) {
+						try {
+							bundleFile = NetUtil.downloadAndCacheFile(getNativeBundleUrl(version));
+						} catch (IOException e) {
+							Util.warnMsg("Native JBang bundle not available, falling back to generic bundle.");
+							Util.verboseMsg("Native bundle download failed: " + e.getMessage());
+							bundleFile = NetUtil.downloadAndCacheFile(getGenericBundleUrl(version));
+						}
+					} else {
+						bundleFile = NetUtil.downloadAndCacheFile(getGenericBundleUrl(version));
+					}
 					Path urlsDir = Settings.getCacheDir(Cache.CacheClass.urls);
 					Util.deletePath(urlsDir.resolve("jbang"), true);
-					UnpackUtil.unpack(zipFile, urlsDir);
+					UnpackUtil.unpack(bundleFile, urlsDir);
 					App.deleteCommandFiles("jbang");
 					Path fromDir = urlsDir.resolve("jbang").resolve("bin");
 					copyJBangFiles(fromDir, binDir);
@@ -254,26 +332,33 @@ class AppInstall extends BaseBuildCommand {
 
 	private static void copyJBangFiles(Path from, Path to) throws IOException {
 		to.toFile().mkdirs();
-		Stream.of("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar")
-			.map(Paths::get)
-			.forEach(f -> {
-				try {
-					Path fromp = from.resolve(f);
-					Path top = to.resolve(f);
-					if (f.endsWith("jbang.jar")) {
-						if (!Files.isReadable(fromp)) {
-							fromp = from.resolve(".jbang/jbang.jar");
-						}
-						if (Util.isWindows() && Files.isRegularFile(top)) {
-							top = to.resolve("jbang.jar.new");
-						}
+		for (String name : Arrays.asList("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar", "jbang.bin",
+				"jbang.bin.exe")) {
+			try {
+				Path f = Paths.get(name);
+				Path fromp = from.resolve(f);
+				Path top = to.resolve(f);
+				if ("jbang.jar".equals(name)) {
+					if (!Files.isReadable(fromp)) {
+						fromp = from.resolve(".jbang/jbang.jar");
 					}
-					Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
-							StandardCopyOption.COPY_ATTRIBUTES);
-				} catch (IOException e) {
-					throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);
+					if (Util.isWindows() && Files.isRegularFile(top)) {
+						top = to.resolve("jbang.jar.new");
+					}
+				} else if ("jbang.bin".equals(name) || "jbang.bin.exe".equals(name)) {
+					if (!Files.isReadable(fromp)) {
+						continue;
+					}
+					if (Files.isRegularFile(top)) {
+						top = to.resolve(name + ".new");
+					}
 				}
-			});
+				Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
+						StandardCopyOption.COPY_ATTRIBUTES);
+			} catch (IOException e) {
+				throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + name, e);
+			}
+		}
 	}
 }
 

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -242,7 +242,7 @@ class AppInstall extends BaseBuildCommand {
 		if ("aarch64".equals(arch) || "arm64".equals(arch)) {
 			return "aarch64";
 		}
-		return arch.replaceAll("[^a-z0-9_]+", "-");
+		return null;
 	}
 
 	// Keep in sync with src/main/scripts/jbang:native_bundle_url()
@@ -258,23 +258,22 @@ class AppInstall extends BaseBuildCommand {
 		return "linux";
 	}
 
-	private static String getGenericBundleUrl(String version) {
+	private static String resolveDownloadUrl(String version, String bundleName) {
 		String baseUrl = getDownloadBaseUrl();
-		if (version == null || version.trim().isEmpty()) {
-			return baseUrl + "/latest/download/jbang." + getBundleExtension();
-		} else {
-			return baseUrl + "/download/v" + version + "/jbang." + getBundleExtension();
-		}
-	}
-
-	private static String getNativeBundleUrl(String version) {
-		String baseUrl = getDownloadBaseUrl();
-		String bundleName = "jbang-" + getNativeBundleOs() + "-" + getNativeBundleArch() + "." + getBundleExtension();
 		if (version == null || version.trim().isEmpty()) {
 			return baseUrl + "/latest/download/" + bundleName;
 		} else {
 			return baseUrl + "/download/v" + version + "/" + bundleName;
 		}
+	}
+
+	private static String getGenericBundleUrl(String version) {
+		return resolveDownloadUrl(version, "jbang." + getBundleExtension());
+	}
+
+	private static String getNativeBundleUrl(String version) {
+		String bundleName = "jbang-" + getNativeBundleOs() + "-" + getNativeBundleArch() + "." + getBundleExtension();
+		return resolveDownloadUrl(version, bundleName);
 	}
 
 	public static boolean installJBang(boolean force) throws IOException {
@@ -293,7 +292,7 @@ class AppInstall extends BaseBuildCommand {
 					Util.infoMsg("Downloading and installing jbang...");
 					String version = System.getenv("JBANG_DOWNLOAD_VERSION");
 					Path bundleFile;
-					if (isNativeRequested()) {
+					if (isNativeRequested() && getNativeBundleArch() != null) {
 						try {
 							bundleFile = NetUtil.downloadAndCacheFile(getNativeBundleUrl(version));
 						} catch (IOException e) {
@@ -302,6 +301,10 @@ class AppInstall extends BaseBuildCommand {
 							bundleFile = NetUtil.downloadAndCacheFile(getGenericBundleUrl(version));
 						}
 					} else {
+						if (isNativeRequested()) {
+							Util.warnMsg("Native binaries not available for architecture '"
+									+ System.getProperty("os.arch") + "', using generic bundle.");
+						}
 						bundleFile = NetUtil.downloadAndCacheFile(getGenericBundleUrl(version));
 					}
 					Path urlsDir = Settings.getCacheDir(Cache.CacheClass.urls);
@@ -332,26 +335,42 @@ class AppInstall extends BaseBuildCommand {
 
 	private static void copyJBangFiles(Path from, Path to) throws IOException {
 		to.toFile().mkdirs();
-		for (String name : Arrays.asList("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar", "jbang.bin",
-				"jbang.bin.exe")) {
+		// Scripts can be overwritten in place
+		copyFiles(from, to, false, "jbang", "jbang.cmd", "jbang.ps1");
+		// JAR uses ".new" only on Windows (locked-file issue)
+		copyFiles(from, to, Util.isWindows(), "jbang.jar");
+		// Native binaries always use ".new" promotion to avoid replacing a running
+		// binary
+		copyFiles(from, to, true, "jbang.bin", "jbang.bin.exe");
+	}
+
+	/**
+	 * Copies files from one directory to another. Missing source files are silently
+	 * skipped (except jbang.jar which also checks .jbang/jbang.jar).
+	 * 
+	 * @param from      source directory
+	 * @param to        destination directory
+	 * @param useDotNew if true and the target file already exists, copy to name +
+	 *                  ".new" instead (for safe atomic updates)
+	 * @param names     file names to copy
+	 */
+	private static void copyFiles(Path from, Path to, boolean useDotNew, String... names) throws IOException {
+		for (String name : names) {
 			try {
-				Path f = Paths.get(name);
-				Path fromp = from.resolve(f);
-				Path top = to.resolve(f);
-				if ("jbang.jar".equals(name)) {
-					if (!Files.isReadable(fromp)) {
+				Path fromp = from.resolve(name);
+				if (!Files.isReadable(fromp)) {
+					if ("jbang.jar".equals(name)) {
 						fromp = from.resolve(".jbang/jbang.jar");
-					}
-					if (Util.isWindows() && Files.isRegularFile(top)) {
-						top = to.resolve("jbang.jar.new");
-					}
-				} else if ("jbang.bin".equals(name) || "jbang.bin.exe".equals(name)) {
-					if (!Files.isReadable(fromp)) {
+						if (!Files.isReadable(fromp)) {
+							continue;
+						}
+					} else {
 						continue;
 					}
-					if (Files.isRegularFile(top)) {
-						top = to.resolve(name + ".new");
-					}
+				}
+				Path top = to.resolve(name);
+				if (useDotNew && Files.isRegularFile(top)) {
+					top = to.resolve(name + ".new");
 				}
 				Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
 						StandardCopyOption.COPY_ATTRIBUTES);

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -58,7 +58,6 @@ public class App {
 
 @CommandLine.Command(name = "install", description = "Install a script as a command.")
 class AppInstall extends BaseBuildCommand {
-	private static final String DEFAULT_JBANG_RELEASES_URL = "https://www.jbang.dev/releases";
 
 	@CommandLine.Option(names = { "--force" }, description = "Force re-installation")
 	boolean force;
@@ -212,11 +211,7 @@ class AppInstall extends BaseBuildCommand {
 	}
 
 	private static String getDownloadBaseUrl() {
-		String baseUrl = System.getenv("JBANG_DOWNLOAD_BASEURL");
-		if (baseUrl == null || baseUrl.trim().isEmpty()) {
-			baseUrl = DEFAULT_JBANG_RELEASES_URL;
-		}
-		return baseUrl.replaceAll("/+$", "");
+		return Settings.getDownloadBaseUrl();
 	}
 
 	private static boolean isNativeRequested() {

--- a/src/main/java/dev/jbang/util/VersionChecker.java
+++ b/src/main/java/dev/jbang/util/VersionChecker.java
@@ -18,7 +18,6 @@ import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 
 public class VersionChecker {
-	private static final String DEFAULT_JBANG_RELEASES_URL = "https://www.jbang.dev/releases";
 	private static final String jbangVersionUrl = buildVersionUrl();
 
 	private static final long DELAY_DAYS = 1;
@@ -181,12 +180,7 @@ public class VersionChecker {
 	}
 
 	private static String buildVersionUrl() {
-		String baseUrl = System.getenv("JBANG_DOWNLOAD_BASEURL");
-		if (baseUrl == null || baseUrl.trim().isEmpty()) {
-			baseUrl = DEFAULT_JBANG_RELEASES_URL;
-		}
-		baseUrl = baseUrl.replaceAll("/+$", "");
-		return baseUrl + "/latest/download/version.txt";
+		return Settings.getDownloadBaseUrl() + "/latest/download/version.txt";
 	}
 
 	public static String getVersionUrl() {

--- a/src/main/java/dev/jbang/util/VersionChecker.java
+++ b/src/main/java/dev/jbang/util/VersionChecker.java
@@ -1,6 +1,8 @@
 package dev.jbang.util;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -16,7 +18,8 @@ import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 
 public class VersionChecker {
-	private static final String jbangVersionUrl = "https://www.jbang.dev/releases/latest/download/version.txt";
+	private static final String DEFAULT_JBANG_RELEASES_URL = "https://www.jbang.dev/releases";
+	private static final String jbangVersionUrl = buildVersionUrl();
 
 	private static final long DELAY_DAYS = 1;
 	private static final int CONNECT_TIMEOUT = 3000;
@@ -177,14 +180,34 @@ public class VersionChecker {
 		return versionCheckResult;
 	}
 
+	private static String buildVersionUrl() {
+		String baseUrl = System.getenv("JBANG_DOWNLOAD_BASEURL");
+		if (baseUrl == null || baseUrl.trim().isEmpty()) {
+			baseUrl = DEFAULT_JBANG_RELEASES_URL;
+		}
+		baseUrl = baseUrl.replaceAll("/+$", "");
+		return baseUrl + "/latest/download/version.txt";
+	}
+
+	public static String getVersionUrl() {
+		try {
+			new URL(jbangVersionUrl);
+			return jbangVersionUrl;
+		} catch (MalformedURLException e) {
+			throw new IllegalArgumentException("Invalid JBANG_DOWNLOAD_BASEURL-derived version URL: " + jbangVersionUrl,
+					e);
+		}
+	}
+
 	// Determines and returns the latest JBang version from GitHub
 	private static String retrieveLatestVersion() throws IOException {
-		Path versionFile = NetUtil.downloadFile(jbangVersionUrl, Settings.getCacheDir(), CONNECT_TIMEOUT);
+		Path versionFile = NetUtil.downloadFile(getVersionUrl(), Settings.getCacheDir(), CONNECT_TIMEOUT);
 		List<String> lines = Files.readAllLines(versionFile);
 		if (!lines.isEmpty()) {
 			return lines.get(0);
+		} else {
+			return null;
 		}
-		return null;
 	}
 
 	private static int compareVersions(String v1, String v2) {

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -8,6 +8,9 @@
 
 # The Java version to install when it's not installed on the system yet
 javaVersion=${JBANG_DEFAULT_JAVA_VERSION:-17}
+# Optional base URL override for testing bundle/version downloads locally.
+# Defaults to the public GitHub release location.
+# Example: JBANG_DOWNLOAD_BASEURL=http://localhost:18080 or file:///tmp/releases
 
 # Number of retry attempts for downloads (curl/wget)
 downloadRetry=${JBANG_DOWNLOAD_RETRY:-5}
@@ -38,6 +41,131 @@ download() {
   else
     echo "Error: curl or wget not found, please make sure one of them is installed" 1>&2
     exit 1
+  fi
+}
+
+native_exec_name() {
+  if [[ "$os" == "windows" ]]; then
+    echo "jbang.bin.exe"
+  else
+    echo "jbang.bin"
+  fi
+}
+
+# Keep in sync with src/main/java/dev/jbang/cli/App.java:getNativeBundleArch()
+# and src/main/scripts/jbang.ps1:Get-NativeBundleArch
+native_bundle_arch() {
+  case "$arch" in
+    x86_64|amd64)
+      echo "x64"
+      ;;
+    aarch64|arm64)
+      echo "aarch64"
+      ;;
+    *)
+      echo "$arch"
+      ;;
+  esac
+}
+
+resolve_download_url() {
+  local release_version="$1"
+  local bundle_name="$2"
+
+  # JBANG_DOWNLOAD_URL is a full URL override (takes precedence over JBANG_DOWNLOAD_BASEURL)
+  if [ -n "$JBANG_DOWNLOAD_URL" ]; then
+    echo "$JBANG_DOWNLOAD_URL"
+    return
+  fi
+
+  local base_url="${JBANG_DOWNLOAD_BASEURL:-https://github.com/jbangdev/jbang/releases}"
+
+  base_url="${base_url%/}"
+  if [[ "$base_url" == file://* || "$base_url" == http://* || "$base_url" == https://* ]]; then
+    if [ -z "$release_version" ]; then
+      echo "${base_url}/latest/download/${bundle_name}"
+    else
+      echo "${base_url}/download/v$release_version/${bundle_name}"
+    fi
+  else
+    if [ -z "$release_version" ]; then
+      echo "${base_url}/latest/download/${bundle_name}"
+    else
+      echo "${base_url}/v$release_version/${bundle_name}"
+    fi
+  fi
+}
+
+native_bundle_url() {
+  local release_version="$1"
+  local bundle_name="jbang"
+  local bundle_arch
+
+  bundle_arch=$(native_bundle_arch)
+  bundle_name+="-${os}-${bundle_arch}"
+
+  if [[ "$os" == "windows" ]]; then
+    bundle_name+=".zip"
+  else
+    bundle_name+=".tar"
+  fi
+
+  resolve_download_url "$release_version" "$bundle_name"
+}
+
+fallback_bundle_url() {
+  local release_version="$1"
+  local bundle_name
+
+  if [[ "$os" == "windows" ]]; then
+    bundle_name="jbang.zip"
+  else
+    bundle_name="jbang.tar"
+  fi
+
+  resolve_download_url "$release_version" "$bundle_name"
+}
+
+install_jbang_bundle() {
+  local release_version="$1"
+  local native_requested="$2"
+  local jburl
+  local fallback_url
+  local bundle_file
+  local native_name
+
+  mkdir -p "$TDIR/urls"
+  bundle_file="$TDIR/urls/jbang-bundle"
+  native_name=$(native_exec_name)
+
+  if [[ "$native_requested" == "true" ]]; then
+    jburl=$(native_bundle_url "$release_version")
+    echo "Downloading JBang ${release_version:-latest} native bundle..." 1>&2
+    download "$jburl" "$bundle_file"
+    if [ $retval -ne 0 ]; then
+      echo "WARNING: Native JBang bundle not available from $jburl, falling back to generic bundle" 1>&2
+      fallback_url=$(fallback_bundle_url "$release_version")
+      download "$fallback_url" "$bundle_file"
+      if [ $retval -ne 0 ]; then echo "Error downloading JBang from $fallback_url" 1>&2; exit $retval; fi
+    fi
+  else
+    jburl=$(fallback_bundle_url "$release_version")
+    echo "Downloading JBang ${release_version:-latest}..." 1>&2
+    download "$jburl" "$bundle_file"
+    if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
+  fi
+
+  echo "Installing JBang..." 1>&2
+  rm -rf "$TDIR/urls/jbang"
+  tar xf "$bundle_file" -C "$TDIR/urls"
+  if [ $retval -ne 0 ]; then echo "Error installing JBang" 1>&2; exit $retval; fi
+
+  mkdir -p "$JBDIR/bin"
+  rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
+  cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
+
+  if [[ "$native_requested" == "true" && ! -f "$JBDIR/bin/$native_name" ]]; then
+    echo "WARNING: Downloaded JBang bundle does not include native binary for this platform, falling back to jbang.jar" 1>&2
   fi
 }
 
@@ -257,25 +385,19 @@ if [[ -z "$binaryPath" ]]; then
   fi
 fi
 if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
+  native_name=$(native_exec_name)
+  needs_install="false"
+
   if [[ ! -f "$JBDIR/bin/jbang.jar" || ! -f "$JBDIR/bin/jbang" ]]; then
-    echo "Downloading JBang $JBANG_DOWNLOAD_VERSION..." 1>&2
-    mkdir -p "$TDIR/urls"
-    if [ -n "$JBANG_DOWNLOAD_URL" ]; then
-      jburl="$JBANG_DOWNLOAD_URL";
-    elif [ -z "$JBANG_DOWNLOAD_VERSION" ]; then
-      jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.tar";
-    else
-      jburl="https://github.com/jbangdev/jbang/releases/download/v$JBANG_DOWNLOAD_VERSION/jbang.tar";
-    fi
-    download "$jburl" "$TDIR/urls/jbang.tar"
-    if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
-    echo "Installing JBang..." 1>&2
-    rm -rf "$TDIR/urls/jbang"
-    tar xf "$TDIR/urls/jbang.tar" -C "$TDIR/urls"
-    if [ $retval -ne 0 ]; then echo "Error installing JBang" 1>&2; exit $retval; fi
-    mkdir -p "$JBDIR/bin"
-    rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
-    cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
+    needs_install="true"
+  fi
+
+  if [[ "$JBANG_USE_NATIVE" == "true" && ! -f "$JBDIR/bin/$native_name" ]]; then
+    needs_install="true"
+  fi
+
+  if [[ "$needs_install" == "true" ]]; then
+    install_jbang_bundle "$JBANG_DOWNLOAD_VERSION" "$JBANG_USE_NATIVE"
   fi
   "$JBDIR"/bin/jbang "$@"
   exit $?
@@ -284,6 +406,14 @@ fi
 if [ -f "$jarPath.new" ]; then
   # a new jbang version was found, we replace the old one with it
   mv "$jarPath.new" "$jarPath"
+fi
+
+if [[ "$JBANG_USE_NATIVE" == "true" ]]; then
+  native_name=$(native_exec_name)
+  if [ -f "$abs_jbang_dir/${native_name}.new" ]; then
+    mv "$abs_jbang_dir/${native_name}.new" "$abs_jbang_dir/${native_name}"
+    chmod +x "$abs_jbang_dir/${native_name}" 2>/dev/null || true
+  fi
 fi
 
 # Only setup Java if we're running the JAR version

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -130,7 +130,6 @@ install_jbang_bundle() {
   local release_version="$1"
   local native_requested="$2"
   local jburl
-  local fallback_url
   local bundle_file
   local native_name
 

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -63,7 +63,7 @@ native_bundle_arch() {
       echo "aarch64"
       ;;
     *)
-      echo "$arch"
+      echo ""
       ;;
   esac
 }
@@ -138,17 +138,22 @@ install_jbang_bundle() {
   bundle_file="$TDIR/urls/jbang-bundle"
   native_name=$(native_exec_name)
 
-  if [[ "$native_requested" == "true" ]]; then
+  local bundle_arch
+  bundle_arch=$(native_bundle_arch)
+  if [[ "$native_requested" == "true" && -n "$bundle_arch" ]]; then
     jburl=$(native_bundle_url "$release_version")
     echo "Downloading JBang ${release_version:-latest} native bundle..." 1>&2
     download "$jburl" "$bundle_file"
     if [ $retval -ne 0 ]; then
       echo "WARNING: Native JBang bundle not available from $jburl, falling back to generic bundle" 1>&2
-      fallback_url=$(fallback_bundle_url "$release_version")
-      download "$fallback_url" "$bundle_file"
-      if [ $retval -ne 0 ]; then echo "Error downloading JBang from $fallback_url" 1>&2; exit $retval; fi
+      jburl=$(fallback_bundle_url "$release_version")
+      download "$jburl" "$bundle_file"
+      if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
     fi
   else
+    if [[ "$native_requested" == "true" && -z "$bundle_arch" ]]; then
+      echo "WARNING: Native binaries not available for architecture '$arch', using generic bundle" 1>&2
+    fi
     jburl=$(fallback_bundle_url "$release_version")
     echo "Downloading JBang ${release_version:-latest}..." 1>&2
     download "$jburl" "$bundle_file"
@@ -158,6 +163,7 @@ install_jbang_bundle() {
   echo "Installing JBang..." 1>&2
   rm -rf "$TDIR/urls/jbang"
   tar xf "$bundle_file" -C "$TDIR/urls"
+  retval=$?
   if [ $retval -ne 0 ]; then echo "Error installing JBang" 1>&2; exit $retval; fi
 
   mkdir -p "$JBDIR/bin"

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -173,7 +173,11 @@ install_jbang_bundle() {
 
   echo "Installing JBang..." 1>&2
   rm -rf "$TDIR/urls/jbang"
-  tar xf "$bundle_file" -C "$TDIR/urls"
+  if [[ "$jburl" == *.zip ]]; then
+    unzip -qq -o "$bundle_file" -d "$TDIR/urls"
+  else
+    tar xf "$bundle_file" -C "$TDIR/urls"
+  fi
   retval=$?
   if [ $retval -ne 0 ]; then echo "Error installing JBang" 1>&2; exit $retval; fi
 

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -28,20 +28,32 @@ script_dir() {
 }
 
 download() {
-  if [ -x "$(command -v curl)" ]; then
-    curl -sLf --retry "$downloadRetry" --retry-delay "$downloadRetryDelay" -o "$2" "$1"
-    retval=$?
-  elif [ -x "$(command -v wget)" ]; then
-    if [ "$downloadRetryDelay" -gt 0 ] 2>/dev/null; then
-      wget -q --tries="$downloadRetry" --waitretry="$downloadRetryDelay" -O "$2" "$1"
+  local attempt=0
+  local maxAttempts=$((downloadRetry + 1))
+  while true; do
+    attempt=$((attempt + 1))
+    if [ -x "$(command -v curl)" ]; then
+      curl -sLf -o "$2" "$1"
+      retval=$?
+    elif [ -x "$(command -v wget)" ]; then
+      wget -q -O "$2" "$1"
+      retval=$?
     else
-      wget -q --tries="$downloadRetry" -O "$2" "$1"
+      echo "Error: curl or wget not found, please make sure one of them is installed" 1>&2
+      exit 1
     fi
-    retval=$?
-  else
-    echo "Error: curl or wget not found, please make sure one of them is installed" 1>&2
-    exit 1
-  fi
+    if [ $retval -eq 0 ] || [ $attempt -ge $maxAttempts ]; then
+      break
+    fi
+    if [ "$downloadRetryDelay" -gt 0 ] 2>/dev/null; then
+      sleepSeconds=$downloadRetryDelay
+    else
+      # Exponential backoff: 1, 2, 4, 8, ...
+      sleepSeconds=$((1 << (attempt - 1)))
+    fi
+    echo "Download attempt $attempt/$maxAttempts failed, retrying in $sleepSeconds second(s)..." 1>&2
+    sleep $sleepSeconds
+  done
 }
 
 native_exec_name() {
@@ -141,7 +153,7 @@ install_jbang_bundle() {
   bundle_arch=$(native_bundle_arch)
   if [[ "$native_requested" == "true" && -n "$bundle_arch" ]]; then
     jburl=$(native_bundle_url "$release_version")
-    echo "Downloading JBang ${release_version:-latest} native bundle..." 1>&2
+    echo "Downloading JBang ${release_version:-latest} native bundle from $jburl..." 1>&2
     download "$jburl" "$bundle_file"
     if [ $retval -ne 0 ]; then
       echo "WARNING: Native JBang bundle not available from $jburl, falling back to generic bundle" 1>&2
@@ -154,7 +166,7 @@ install_jbang_bundle() {
       echo "WARNING: Native binaries not available for architecture '$arch', using generic bundle" 1>&2
     fi
     jburl=$(fallback_bundle_url "$release_version")
-    echo "Downloading JBang ${release_version:-latest}..." 1>&2
+    echo "Downloading JBang ${release_version:-latest} from $jburl..." 1>&2
     download "$jburl" "$bundle_file"
     if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
   fi

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -4,6 +4,11 @@ SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 rem The Java version to install when it's not installed on the system yet
 if "%JBANG_DEFAULT_JAVA_VERSION%"=="" (set javaVersion=17) else (set javaVersion=%JBANG_DEFAULT_JAVA_VERSION%)
 
+rem Optional base URL override for testing bundle/version downloads locally.
+rem Defaults to the public GitHub release location.
+rem Example: set JBANG_DOWNLOAD_BASEURL=http://localhost:18080
+if "%JBANG_DOWNLOAD_BASEURL%"=="" (set JBANG_DOWNLOAD_BASEURL=https://github.com/jbangdev/jbang/releases)
+
 if "%JBANG_DIR%"=="" (set JBDIR=%userprofile%\.jbang) else (set JBDIR=%JBANG_DIR%)
 if "%JBANG_CACHE_DIR%"=="" (set TDIR=%JBDIR%\cache) else (set TDIR=%JBANG_CACHE_DIR%)
 if "%JBANG_USE_NATIVE%"=="" (set JBANG_USE_NATIVE=false)
@@ -28,7 +33,10 @@ if "!binaryPath!"=="" (
   )
 )
 if "!binaryPath!"=="" if "!jarPath!"=="" (
-  if not exist "%JBDIR%\bin\jbang.jar" (
+  set needsInstall=false
+  if not exist "%JBDIR%\bin\jbang.jar" set needsInstall=true
+  if "%JBANG_USE_NATIVE%"=="true" if not exist "%JBDIR%\bin\jbang.bin.exe" set needsInstall=true
+  if "!needsInstall!"=="true" (
     powershell -NoProfile -ExecutionPolicy Bypass -NonInteractive -Command "%~dp0jbang.ps1 version" > nul
     if !ERRORLEVEL! NEQ 0 ( exit /b %ERRORLEVEL% )
   )
@@ -43,6 +51,11 @@ if exist "%jarPath%.new" (
   rem a new jbang version was found, we replace the old one with it
   copy /y "%jarPath%.new" "%jarPath%" > nul 2>&1
   del /f /q "%jarPath%.new"
+)
+
+if "%JBANG_USE_NATIVE%"=="true" if exist "%~dp0jbang.bin.exe.new" (
+  copy /y "%~dp0jbang.bin.exe.new" "%~dp0jbang.bin.exe" > nul 2>&1
+  del /f /q "%~dp0jbang.bin.exe.new"
 )
 
 rem Find/get a JDK (only needed for JAR execution)

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -185,7 +185,7 @@ function Install-JBangBundle {
 
     if ($NativeRequested -eq "true") {
         $jburl = Get-NativeBundleUrl $ReleaseVersion
-        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest') native bundle...")
+        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest') native bundle from $jburl...")
         $ok = Invoke-Download "$jburl" $bundlePath
         if (-not $ok) {
           [Console]::Error.WriteLine("WARNING: Native JBang bundle not available from $jburl, falling back to generic bundle")
@@ -194,13 +194,12 @@ function Install-JBangBundle {
         }
     } else {
         $jburl = Get-FallbackBundleUrl $ReleaseVersion
-        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest')...")
+        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest') from $jburl...")
         $ok = Invoke-Download "$jburl" $bundlePath
     }
     if (-not ($ok)) {
       [Console]::Error.WriteLine("Error downloading JBang from $jburl to $bundlePath")
-      [Console]::Error.WriteLine($err)
-      break
+      exit 1
     }
     [Console]::Error.WriteLine("Installing JBang...")
     Remove-Item -LiteralPath "$TDIR\urls\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -64,6 +64,10 @@ if (-not (Test-Path env:JBANG_USE_NATIVE)) { $env:JBANG_USE_NATIVE="false" }
 if (-not (Test-Path env:JBANG_DOWNLOAD_RETRY)) { $downloadRetry=5 } else { $downloadRetry=[int]$env:JBANG_DOWNLOAD_RETRY }
 if (-not (Test-Path env:JBANG_DOWNLOAD_RETRY_DELAY)) { $downloadRetryDelay=0 } else { $downloadRetryDelay=[int]$env:JBANG_DOWNLOAD_RETRY_DELAY }
 
+# Optional base URL override for testing bundle/version downloads locally.
+# Defaults to the public GitHub release location.
+# Example: $env:JBANG_DOWNLOAD_BASEURL='http://localhost:18080'
+
 function Invoke-Download {
     param([string]$url, [string]$outFile)
     $attempt=0
@@ -117,6 +121,109 @@ function Invoke-JBang {
     $env:JAVA_HOME, $env:JBANG_RUNTIME_SHELL, $env:JBANG_STDIN_NOTTY, $env:JBANG_LAUNCH_CMD=$oldJavaHome, $oldShell, $oldNotty, $oldCmd
 }
 
+function Get-NativeExecName {
+    return "jbang.bin.exe"
+}
+
+# Keep in sync with src/main/java/dev/jbang/cli/App.java:getNativeBundleArch()
+# and src/main/scripts/jbang:native_bundle_arch()
+function Get-NativeBundleArch {
+    switch ($arch) {
+        "x86_64" { return "x64" }
+        "amd64" { return "x64" }
+        "aarch64" { return "aarch64" }
+        "arm64" { return "aarch64" }
+        default { return $arch }
+    }
+}
+
+function Resolve-DownloadUrl {
+    param([string]$ReleaseVersion, [string]$BundleName)
+
+    # JBANG_DOWNLOAD_URL is a full URL override (takes precedence over JBANG_DOWNLOAD_BASEURL)
+    if (Test-Path env:JBANG_DOWNLOAD_URL) {
+        return $env:JBANG_DOWNLOAD_URL
+    }
+
+    $baseUrl = $env:JBANG_DOWNLOAD_BASEURL
+    if (-not $baseUrl) {
+        $baseUrl = "https://github.com/jbangdev/jbang/releases"
+    }
+    $baseUrl = $baseUrl.TrimEnd('/')
+
+    if ($baseUrl.StartsWith("file://") -or $baseUrl.StartsWith("http://") -or $baseUrl.StartsWith("https://")) {
+        if (-not $ReleaseVersion) {
+            return "$baseUrl/latest/download/$BundleName"
+        }
+        return "$baseUrl/download/v$ReleaseVersion/$BundleName"
+    }
+
+    if (-not $ReleaseVersion) {
+        return "$baseUrl/latest/download/$BundleName"
+    }
+    return "$baseUrl/v$ReleaseVersion/$BundleName"
+}
+
+function Get-NativeBundleUrl {
+    param([string]$ReleaseVersion)
+
+    $bundleName = "jbang-$os-$(Get-NativeBundleArch).zip"
+    return Resolve-DownloadUrl $ReleaseVersion $bundleName
+}
+
+function Get-FallbackBundleUrl {
+    param([string]$ReleaseVersion)
+
+    return Resolve-DownloadUrl $ReleaseVersion "jbang.zip"
+}
+
+function Install-JBangBundle {
+    param([string]$ReleaseVersion, [string]$NativeRequested)
+
+    $bundlePath = "$TDIR\urls\jbang.zip"
+    New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
+
+    if ($NativeRequested -eq "true") {
+        $jburl = Get-NativeBundleUrl $ReleaseVersion
+        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest') native bundle...")
+        $ok = Invoke-Download "$jburl" $bundlePath
+        if (-not $ok) {
+          [Console]::Error.WriteLine("WARNING: Native JBang bundle not available from $jburl, falling back to generic bundle")
+          $jburl = Get-FallbackBundleUrl $ReleaseVersion
+          $ok = Invoke-Download "$jburl" $bundlePath
+        }
+    } else {
+        $jburl = Get-FallbackBundleUrl $ReleaseVersion
+        [Console]::Error.WriteLine("Downloading JBang $($ReleaseVersion ? $ReleaseVersion : 'latest')...")
+        $ok = Invoke-Download "$jburl" $bundlePath
+    }
+    if (-not ($ok)) {
+      [Console]::Error.WriteLine("Error downloading JBang from $jburl to $bundlePath")
+      [Console]::Error.WriteLine($err)
+      break
+    }
+    [Console]::Error.WriteLine("Installing JBang...")
+    Remove-Item -LiteralPath "$TDIR\urls\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
+    try { Expand-Archive -Path $bundlePath -DestinationPath "$TDIR\urls"; $ok=$? } catch {
+      $ok=$false
+      $err=$_
+    }
+    if (-not ($ok)) {
+      [Console]::Error.WriteLine("Error unzipping JBang from $bundlePath to $TDIR\urls")
+      [Console]::Error.WriteLine($err)
+      break
+    }
+    New-Item -ItemType Directory -Force -Path "$JBDIR\bin" >$null 2>&1
+    Remove-Item -LiteralPath "$JBDIR\bin\jbang" -Force -ErrorAction Ignore >$null 2>&1
+    Remove-Item -Path "$JBDIR\bin\jbang.*" -Force -ErrorAction Ignore >$null 2>&1
+    Copy-Item -Path "$TDIR\urls\jbang\bin\*" -Destination "$JBDIR\bin" -Force >$null 2>&1
+
+    $nativeName = Get-NativeExecName
+    if ($NativeRequested -eq "true" -and -not (Test-Path "$JBDIR\bin\$nativeName")) {
+      [Console]::Error.WriteLine("WARNING: Downloaded JBang bundle does not include native binary for this platform, falling back to jbang.jar")
+    }
+}
+
 # resolve jbang.bin binary or jar path from script location
 $binaryPath=""
 $jarPath=""
@@ -137,36 +244,12 @@ if (-not $binaryPath) {
   }
 }
 if (-not $binaryPath -and -not $jarPath) {
-  if (-not (Test-Path "$JBDIR\bin\jbang.jar") -or -not (Test-Path "$JBDIR\bin\jbang.ps1")) {
-    New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
-    if (Test-Path env:JBANG_DOWNLOAD_URL) {
-        $jburl=$env:JBANG_DOWNLOAD_URL
-    } elseif (-not (Test-Path env:JBANG_DOWNLOAD_VERSION)) {
-        $jburl="https://github.com/jbangdev/jbang/releases/latest/download/jbang.zip"
-    } else {
-        $jburl="https://github.com/jbangdev/jbang/releases/download/v$env:JBANG_DOWNLOAD_VERSION/jbang.zip";
-    }
-    [Console]::Error.WriteLine("Downloading JBang $env:JBANG_DOWNLOAD_VERSION...")
-    $ok = Invoke-Download "$jburl" "$TDIR\urls\jbang.zip"
-    if (-not ($ok)) {
-      [Console]::Error.WriteLine("Error downloading JBang from $jburl to $TDIR\urls\jbang.zip")
-      exit 1
-    }
-    [Console]::Error.WriteLine("Installing JBang...")
-    Remove-Item -LiteralPath "$TDIR\urls\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
-    try { Expand-Archive -Path "$TDIR\urls\jbang.zip" -DestinationPath "$TDIR\urls"; $ok=$? } catch {
-      $ok=$false
-      $err=$_
-    }
-    if (-not ($ok)) {
-      [Console]::Error.WriteLine("Error unzipping JBang from $TDIR\urls\jbang.zip to $TDIR\urls")
-      [Console]::Error.WriteLine($err)
-      break
-    }
-    New-Item -ItemType Directory -Force -Path "$JBDIR\bin" >$null 2>&1
-    Remove-Item -LiteralPath "$JBDIR\bin\jbang" -Force -ErrorAction Ignore >$null 2>&1
-    Remove-Item -Path "$JBDIR\bin\jbang.*" -Force -ErrorAction Ignore >$null 2>&1
-    Copy-Item -Path "$TDIR\urls\jbang\bin\*" -Destination "$JBDIR\bin" -Force >$null 2>&1
+  $needsInstall = -not (Test-Path "$JBDIR\bin\jbang.jar") -or -not (Test-Path "$JBDIR\bin\jbang.ps1")
+  if ($env:JBANG_USE_NATIVE -eq "true" -and -not (Test-Path "$JBDIR\bin\$(Get-NativeExecName)")) {
+    $needsInstall = $true
+  }
+  if ($needsInstall) {
+    Install-JBangBundle $env:JBANG_DOWNLOAD_VERSION $env:JBANG_USE_NATIVE
   }
   . "$JBDIR\bin\jbang.ps1" @args
   break
@@ -174,6 +257,9 @@ if (-not $binaryPath -and -not $jarPath) {
 if (Test-Path "$jarPath.new") {
   # a new jbang version was found, we replace the old one with it
   Move-Item -Path "$jarPath.new" -Destination "$jarPath" -Force
+}
+if ($env:JBANG_USE_NATIVE -eq "true" -and (Test-Path "$PSScriptRoot\jbang.bin.exe.new")) {
+  Move-Item -Path "$PSScriptRoot\jbang.bin.exe.new" -Destination "$PSScriptRoot\jbang.bin.exe" -Force
 }
 
 # Find/get a JDK (only needed for JAR execution)


### PR DESCRIPTION
## Overview

Adds native binary support to JBang wrapper scripts and install/update mechanisms, enabling faster startup and better performance when GraalVM native images are available.

Closes #2458

> **Note:** This PR should be rebased on top of #2472 and #2473 before merging.
> - #2472 — bash retry loop with user feedback
> - #2473 — CI/release native bundle infrastructure and jreleaser 1.24.0

## Core Features

- **Native binary detection**: Wrapper scripts (bash, PowerShell, CMD) detect and use native binaries when `JBANG_USE_NATIVE=true`
- **Intelligent fallback**: Falls back to JAR execution if native binary unavailable
- **Platform-specific bundles**: Downloads native platform-specific bundles (e.g. `jbang-linux-x64.tar`)
- **Automatic fallback**: Falls back to generic bundle if native bundle not published yet
- **Safe updates**: Uses `.new` file promotion mechanism for atomic updates

## Version Handling

- Both native and generic bundles respect `JBANG_DOWNLOAD_VERSION`
- Supports versioned downloads (e.g., `/download/v0.138.0/jbang-linux-x64.tar`)
- Defaults to `/latest/download/` when version not specified
- Consistent behavior between native and generic bundle downloads

## Configuration

New environment variables control wrapper behavior:

| Variable | Default | Description |
|----------|---------|-------------|
| `JBANG_USE_NATIVE` | `false` | If `true`, prefer native binary over JAR |
| `JBANG_DOWNLOAD_BASEURL` | `https://github.com/jbangdev/jbang/releases` | Override base URL (for testing/mirrors) |
| `JBANG_DOWNLOAD_VERSION` | _(unset, uses latest)_ | Specific version to download during bootstrap |

## Script Changes

- `jbang` (bash): Native bundle download/install functions, `JBANG_USE_NATIVE` support, `.new` file promotion for native binaries
- `jbang.ps1`: Same native-aware logic ported to PowerShell
- `jbang.cmd`: Native binary detection and `.new` promotion for Windows CMD

## Java Changes

- `Settings.java`: Shared `getDownloadBaseUrl()` respecting `JBANG_DOWNLOAD_BASEURL`
- `App.java`: Native-aware `installJBang()` with platform detection and fallback
- `VersionChecker.java`: Uses shared download base URL, fixed unreachable code

## Code Quality Improvements

- Fixed unreachable code in `VersionChecker.retrieveLatestVersion()`
- Replaced `Stream.forEach` with for-loop (Java best practice for side effects)
- Used `Arrays.asList` for Java 8 compatibility
- Added cross-reference comments to keep Java/bash/PS1 implementations in sync
- Null-safe string comparisons throughout

## Documentation

- Added comprehensive environment variable table to `installation.adoc`

## Related PRs

| PR | Description | Status |
|----|-------------|--------|
| #2472 | `fix:` bash retry loop with user feedback | Prerequisite |
| #2473 | `build:` CI native bundles + jreleaser 1.24.0 | Prerequisite |
| #2467 | `feat:` native-aware wrapper (this PR) | Depends on above |