### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -32,13 +32,13 @@ jobs:
         with:
           java-version: 11
       - name: Download jbang distribution
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build-jbang
           path: build/install/jbang
      
       - name: Download native image'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang.bin-*
           path: build/native-image

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -75,7 +75,7 @@ jobs:
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
       - name: jreleaser publish
         continue-on-error: true
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env:
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:
@@ -98,7 +98,7 @@ jobs:
         run: ./misc/updatespec.sh
       - name: jreleaser announce
         continue-on-error: true
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env:
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -75,7 +75,7 @@ jobs:
           RELEASE_VERSION=`cat build/tmp/version.txt`
           echo "::set-output name=RELEASE_VERSION::$RELEASE_VERSION"
       - name: Run JReleaser
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
         env: 
           JRELEASER_PROJECT_VERSION: ${{steps.version.outputs.RELEASE_VERSION}}
         with:


### PR DESCRIPTION
Pin all action references to full-length commit SHAs for supply chain security.

This is required for enabling the org-level policy:
**Require actions to be pinned to a full-length commit SHA**

Original version tags are preserved as comments for readability.
Consider adding Dependabot for GitHub Actions to keep pins updated:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configurations to use pinned versions of external GitHub Actions for enhanced security and improved build reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang/pull/2469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->