### PR TITLE
build: update GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/actions/shared-build-setup/action.yml
+++ b/.github/actions/shared-build-setup/action.yml
@@ -23,12 +23,12 @@ runs:
       run: |
         calculatedSha=$(git rev-parse --short ${{ github.sha }})
         echo "github-short-sha=$calculatedSha" >> $GITHUB_OUTPUT
-    - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: temurin
     - name: setup-gradle
-      uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       with:
           cache-overwrite-existing: true
           add-job-summary: ${{ inputs.add-job-summary }}

--- a/.github/actions/shared-test-archiving/action.yml
+++ b/.github/actions/shared-test-archiving/action.yml
@@ -16,21 +16,21 @@ runs:
       run: |
           ./gradlew --no-daemon allureReport --clean
     - name: Upload Allure Test Report
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always() # always run even if the previous step fails
       with:
         name: ${{ inputs.prefix }}allure-report${{ inputs.suffix }}
         path: 'build/reports/allure-report/allureReport/index.html'
         retention-days: 7
     - name: Upload Allure Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always() # always run even if the previous step fails
       with:
         name: ${{ inputs.prefix }}allure-results${{ inputs.suffix }}
         path: 'build/allure-results/**'
         retention-days: 7
     - name: Upload All Reports
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always() # always run even if the previous step fails
       with:
         name: ${{ inputs.prefix }}all-reports${{ inputs.suffix }}

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -32,13 +32,13 @@ jobs:
         with:
           java-version: 11
       - name: Download jbang distribution
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build-jbang
           path: build/install/jbang
      
       - name: Download native image'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang.bin-*
           path: build/native-image

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -59,13 +59,13 @@ jobs:
           password: ${{ secrets.CR_PAT }}
 
       - name: install-java11
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           java-version: 11
           distribution: temurin
           cache: gradle
       - name: setup-gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
       - name: build-gradle
         run: ./gradlew --no-daemon clean build -x test --build-cache --scan -s
       - name: version extract
@@ -84,7 +84,7 @@ jobs:
           setup-java: false
       - name: JReleaser publish output
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-publish
           path: |
@@ -107,14 +107,14 @@ jobs:
           setup-java: false
       - name: JReleaser announce output
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-announce
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
       - name: upload-choco
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-choco
           path: build/choco
@@ -124,7 +124,7 @@ jobs:
     name: publish-choco
     continue-on-error: true
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: build-choco
           path: build/choco

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -51,7 +51,7 @@ jobs:
           echo "The PR number is: ${{ env.pr_number }}"
 
       - name: Download Test Report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: junit-test-results-*
           #path: test-${{ matrix.os }}
@@ -59,7 +59,7 @@ jobs:
           merge-multiple: true
           run-id: ${{ github.event.workflow_run.id }}
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           commit: ${{github.event.workflow_run.head_sha}}
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -44,13 +44,13 @@ jobs:
       - name: build-with-no-tests
         run: ./gradlew --no-daemon clean build installDist publish -x spotlessCheck -x test -x integrationTest --build-cache --scan -s
       - name: Upload jbang.zip
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build-jbang
           path: build/install/jbang
       - name: Upload build results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name:  ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
@@ -70,13 +70,13 @@ jobs:
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
       - name: setup-graalvm
-        uses: graalvm/setup-graalvm@eec48106e0bf45f2976c2ff0c3e22395cced8243 # v1
+        uses: graalvm/setup-graalvm@bef4b0e916c7dd079bf60fb95d49139f67e32c5f # v1
         with:
             java-version: '25'      
             distribution: 'graalvm-community' # like to use mandrel but using community for now
             github-token: ${{ secrets.GITHUB_TOKEN }}
             set-java-home: false # we should not use graalvm for java builds (we need java 11)
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
           path: build
@@ -87,7 +87,7 @@ jobs:
         run: |
             chmod -v +x build/native-image/jbang.bin*
       - name: upload-native-image
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-jbang.bin-${{ matrix.os }}
           path: build/native-image/*
@@ -110,7 +110,7 @@ jobs:
           prefix: ${{ steps.shared-build.outputs.github-short-sha }}-test-native-image-
           suffix: -${{matrix.os}}
       - name: Archive build results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-test-native-image-build-${{ matrix.os }}
@@ -132,7 +132,7 @@ jobs:
           fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
           path: build
@@ -146,14 +146,14 @@ jobs:
           prefix: ${{ steps.shared-build.outputs.github-short-sha }}-unit-test-jvm-
           suffix: -${{matrix.os}}-${{ matrix.java-version }}
       - name: Archive build results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-unit-test-jvm-build-${{ matrix.os }}-${{ matrix.java-version }}
           path: build
       - name: Write out Unit Test report annotation for forked repo
         if: failure()
-        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
           annotate_only: true # forked repo cannot write to checks so just do annotations
@@ -195,7 +195,7 @@ jobs:
           fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
           path: build
@@ -211,7 +211,7 @@ jobs:
           prefix: ${{ steps.shared-build.outputs.github-short-sha }}-integration-test-jvm-
           suffix: -${{matrix.os}}-${{ matrix.java-version }}
       - name: Archive build results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-integration-test-jvm-build-${{ matrix.os }}-${{ matrix.java-version }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Write out Unit Test report annotation for forked repo
         if: failure()
-        uses: mikepenz/action-junit-report@3585e9575db828022551b4231f165eb59a0e74e3 # v5
+        uses: mikepenz/action-junit-report@3a81627bfac62268172037048872e8ebd4207e6d # v6
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
           annotate_only: true # forked repo cannot write to checks so just do annotations
@@ -249,7 +249,7 @@ jobs:
         uses: ./.github/actions/shared-build-setup
         with:
           add-job-summary: 'never'
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
           path: build
@@ -292,7 +292,7 @@ jobs:
           fetch-depth: 0
       - id: shared-build
         uses: ./.github/actions/shared-build-setup
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: ${{ steps.shared-build.outputs.github-short-sha }}-*-allure-results-*
           path: build/allure-results

--- a/.github/workflows/step-ci-build.yml
+++ b/.github/workflows/step-ci-build.yml
@@ -159,6 +159,7 @@ jobs:
           annotate_only: true # forked repo cannot write to checks so just do annotations
       - name: Add artifact.ci links
         if: failure()
+        shell: bash
         run: |
           BASE="https://www.artifact.ci/artifact/view/${{ github.repository }}/run/${{ github.run_id }}.${{ github.run_attempt}}"
           echo "View [Allure Report](${BASE}/allure-report-${{ matrix.os }}) [direct link (available after first view)](${BASE}/allure-report-${{ matrix.os }}/build/reports/allure-report/allureReport/index.html) for ${{ matrix.os }} build" >> $GITHUB_STEP_SUMMARY
@@ -225,6 +226,7 @@ jobs:
           annotate_only: true # forked repo cannot write to checks so just do annotations
       - name: Add artifact.ci links
         if: failure()
+        shell: bash
         run: |
           BASE="https://www.artifact.ci/artifact/view/${{ github.repository }}/run/${{ github.run_id }}.${{ github.run_attempt}}"
           echo "View [Allure Report](${BASE}/allure-report-${{ matrix.os }}) [direct link (available after first view)](${BASE}/allure-report-${{ matrix.os }}/build/reports/allure-report/allureReport/index.html) for ${{ matrix.os }} build" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -84,7 +84,7 @@ jobs:
           setup-java: false
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: jreleaser-release
           path: |


### PR DESCRIPTION
## Summary

Update GitHub Actions dependencies to versions that use Node.js 24, avoiding the deprecation warnings:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Changes

| Action | Old | New | Node |
|--------|-----|-----|------|
| `actions/setup-java` | v4 | v5 | 24 |
| `gradle/actions/setup-gradle` | v4 | v6 | 24 |
| `actions/download-artifact` | v4 | v8 | 24 |
| `actions/upload-artifact` | v4 | v7 | 24 |
| `graalvm/setup-graalvm` | v1.4 | v1.5.3 | 24 |
| `mikepenz/action-junit-report` | v5 | v6 | 24 |

Only `mxschmitt/action-tmate` remains on Node.js 20 (no Node 24 release yet, debug-only usage).

Also fixes `shell: bash` on artifact.ci link steps that fail on Windows with PowerShell default shell.

## Files changed

- `.github/actions/shared-build-setup/action.yml`
- `.github/actions/shared-test-archiving/action.yml`
- `.github/workflows/main-build.yml`
- `.github/workflows/publish-packages.yml`
- `.github/workflows/report.yml`
- `.github/workflows/step-ci-build.yml`
- `.github/workflows/tag-and-release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD GitHub Actions to newer versions across build, test, and release pipelines for improved stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang/pull/2474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->