### PR TITLE
fix: use release instead of full-release for earlyaccess and disable signing

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -54,7 +54,7 @@ jobs:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: ${{ env.JRELEASER_VERSION }}
-          arguments: full-release
+          arguments: release -Djreleaser.signing.active=NEVER
           setup-java: false
       - name: JReleaser output
         if: always()


### PR DESCRIPTION
Fixes the earlyaccess job failure in main-build.yml.

`full-release` validates all configured secrets upfront (GPG signing, Maven Central, SDKMAN, Bluesky) even for distributors/announcers with `active: RELEASE` that would be skipped for SNAPSHOT versions. This causes the earlyaccess job to fail with:

```
signing.pgp.secretKey must not be blank
deploy.maven.mavenCentral.jbang.password must not be blank
distributions.jbang.sdkman.consumerKey must not be blank
announce.bluesky.password must not be blank
```

Fix: use `release` (skips deploy+announce phases entirely) and `-Djreleaser.signing.active=NEVER` (disables signing). Earlyaccess only needs to create/update a GitHub pre-release with artifacts.

See failed run: https://github.com/jbangdev/jbang/actions/runs/26405694957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified early-access release build workflow to disable signing during the release process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang/pull/2477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->