### PR TITLE
fix: updating to latest devkitman

### DIFF
--- a/src/it/java/dev/jbang/it/BaseIT.java
+++ b/src/it/java/dev/jbang/it/BaseIT.java
@@ -109,7 +109,7 @@ public class BaseIT {
 			// We want to make sure the "multihome" is added for when we run in GH CI
 			JdkManager jdkMan = JavaUtil.defaultJdkManagerBuilder().provider("multihome").build();
 			// if env not avail it is null and will use default jdk
-			// to use same jdk as what tets run with to make it more
+			// to use same jdk as what tests run with to make it more
 			// deterministic.
 
 			System.err.println("Requested Java version: " + javaMajorVersion);

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -244,9 +244,12 @@ public class Jdk extends BaseCommand {
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getInstalledJdk(versionOrId,
-					JdkProvider.Predicates.canUpdate);
+					JdkProvider.Predicates.canInstall);
 			if (jdk == null) {
-				throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
+				jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canUpdate);
+				if (jdk == null) {
+					throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
+				}
 			}
 			jdk.uninstall();
 			Util.infoMsg("Uninstalled JDK:\n  " + versionOrId);

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
+import dev.jbang.devkitman.JdkDistroQuery;
 import dev.jbang.devkitman.JdkManager;
 import dev.jbang.devkitman.JdkProvider;
 import dev.jbang.util.CommandBuffer;
@@ -162,6 +163,12 @@ public class Jdk extends BaseCommand {
 		@Option(shortName = 'a', name = "available", hasValue = false, description = "Shows versions available for installation")
 		boolean available;
 
+		@Option(shortName = 'P', name = "providers", hasValue = false, description = "Shows available providers")
+		boolean listProviders;
+
+		@Option(shortName = 'D', name = "distros", hasValue = false, description = "Shows distributions available for installation")
+		boolean listDistros;
+
 		@Option(shortName = 'd', name = "show-details", aliases = {
 				"details" }, hasValue = false, description = "Shows detailed information for each JDK (only when format=text)")
 		boolean details;
@@ -173,24 +180,58 @@ public class Jdk extends BaseCommand {
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk defaultJdk = jdkMan.getDefaultJdk();
-			int defMajorVersion = defaultJdk != null ? defaultJdk.majorVersion() : 0;
+			String defVersion = defaultJdk != null ? defaultJdk.version() : "";
 			PrintStream out = System.out;
-			List<? extends dev.jbang.devkitman.Jdk> jdks;
-			if (available) {
-				jdks = jdkMan.listAvailableJdks();
-			} else {
-				jdks = jdkMan.listInstalledJdks();
+
+			if (listProviders) {
+				List<JdkProvider> providers = new ArrayList<>(jdkMan.providers());
+				providers.sort(Comparator.comparing(JdkProvider::name));
+				if (format == OutputFormat.json) {
+					Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+					parser.toJson(providers, out);
+				} else {
+					out.println("Available JDK Providers:");
+					providers.forEach(p -> out.println("   " + p.name()));
+				}
+				return EXIT_OK;
+			} else if (listDistros) {
+				List<JdkDistroQuery.JdkDistro> distros = jdkMan.listDistros();
+				distros.sort(Comparator.comparing(JdkDistroQuery.JdkDistro::name));
+				if (format == OutputFormat.json) {
+					Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+					parser.toJson(distros, out);
+				} else {
+					out.println("Available JDK Distributions:");
+					distros.forEach(d -> out.println("   " + d.name()));
+				}
+				return EXIT_OK;
 			}
-			List<JdkOut> jdkOuts = jdks.stream()
-				.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
-						jdk.isInstalled() ? ((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).home() : null,
-						null,
-						details ? jdk.equals(defaultJdk)
-								: jdk.majorVersion() == defMajorVersion,
-						jdk.tags()))
-				.collect(Collectors.toList());
+
+			List<JdkOut> jdkOuts;
+			if (available) {
+				List<dev.jbang.devkitman.Jdk.AvailableJdk> jdks = jdkMan.listAvailableJdks();
+				jdkOuts = jdks.stream()
+					.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
+							null, null,
+							details ? jdk.equals(defaultJdk)
+									: jdk.version().equals(defVersion),
+							jdk.tags()))
+					.collect(Collectors.toList());
+			} else {
+				List<dev.jbang.devkitman.Jdk.InstalledJdk> jdks = jdkMan.listInstalledJdks();
+				jdkOuts = jdks.stream()
+					.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
+							jdk.home(),
+							jdk instanceof dev.jbang.devkitman.Jdk.LinkedJdk
+									? ((dev.jbang.devkitman.Jdk.LinkedJdk) jdk).linked().id()
+									: null,
+							details ? jdk.equals(defaultJdk)
+									: jdk.version().equals(defVersion),
+							jdk.tags()))
+					.collect(Collectors.toList());
+			}
 			if (!details) {
-				// Only keep a list of unique major versions
+				// Only keep a list of unique versions
 				Set<JdkOut> uniqueJdks = new TreeSet<>(Comparator.<JdkOut>comparingInt(j -> j.version).reversed());
 				uniqueJdks.addAll(jdkOuts);
 				jdkOuts = new ArrayList<>(uniqueJdks);
@@ -207,12 +248,20 @@ public class Jdk extends BaseCommand {
 						out.print("   ");
 						out.print(jdk.version);
 						out.print(" (");
-						out.print(jdk.fullVersion);
 						if (details) {
+							out.print(jdk.fullVersion);
 							out.print(", " + jdk.providerName + ", " + jdk.id);
 							if (jdk.javaHomeDir != null) {
 								out.print(", " + jdk.javaHomeDir);
 							}
+							if (jdk.linkedId != null) {
+								out.print(", link to " + jdk.linkedId);
+							}
+							if (!jdk.tags.isEmpty()) {
+								out.print(", " + jdk.tags);
+							}
+						} else {
+							out.print(available ? jdk.id : jdk.fullVersion);
 						}
 						out.print(")");
 						if (!available) {
@@ -243,17 +292,24 @@ public class Jdk extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
+			// This will first select for JDKs from providers that can actually install JDKs
 			dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getInstalledJdk(versionOrId,
 					JdkProvider.Predicates.canInstall);
 			if (jdk == null) {
+				// If necessary we select JDKs from providers that can update JDKs
 				jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canUpdate);
 				if (jdk == null) {
 					throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
 				}
 			}
 			jdk.uninstall();
-			Util.infoMsg("Uninstalled JDK:\n  " + versionOrId);
-			return EXIT_OK;
+			if (!jdk.isInstalled()) {
+				Util.infoMsg("Uninstalled JDK:\n  " + jdk.id());
+				return EXIT_OK;
+			} else {
+				Util.warnMsg("Unable to uninstall JDK:\n  " + jdk.id());
+				return EXIT_GENERIC_ERROR;
+			}
 		}
 	}
 
@@ -294,7 +350,7 @@ public class Jdk extends BaseCommand {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk jdk = null;
 			if (versionOrId != null && JavaUtil.isRequestedVersion(versionOrId)) {
-				jdk = jdkMan.getJdk(versionOrId, JdkProvider.Predicates.canUpdate);
+				jdk = jdkMan.getJdk(versionOrId, JdkProvider.Predicates.canInstall);
 			}
 			if (jdk == null || !jdk.isInstalled()) {
 				jdk = jdkMan.getOrInstallJdk(versionOrId);

--- a/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
+++ b/src/main/java/dev/jbang/cli/JdkProvidersMixin.java
@@ -12,10 +12,10 @@ import dev.jbang.util.JavaUtil;
 
 public class JdkProvidersMixin {
 
-	@OptionList(name = "jdk-providers", valueSeparator = ',', visibility = OptionVisibility.HIDDEN, description = "Use the given providers to check for installed JDKs")
+	@OptionList(name = "jdk-providers", valueSeparator = ',', description = "Use the given providers to manage JDKs")
 	List<String> jdkProviders;
 
-	@OptionList(name = "jdk-distros", valueSeparator = ',', visibility = OptionVisibility.HIDDEN, description = "Use the given distributions to install new JDKs")
+	@OptionList(name = "jdk-distros", valueSeparator = ',', description = "Use the given distributions to install new JDKs")
 	List<String> jdkDistros;
 
 	@Option(name = "jdk-installer", visibility = OptionVisibility.HIDDEN, description = "Use the given installer to install new JDKs")

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -133,7 +133,7 @@ public class TestJdk extends BaseTest {
 		result = checkedRun(withProviders("jdk", "default"));
 
 		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("* -> 12-jbang"));
+		assertThat(result.normalizedOut(), containsString("* -> 12.0.7-jbang"));
 	}
 
 	@Test
@@ -148,7 +148,7 @@ public class TestJdk extends BaseTest {
 		result = checkedRun(withProviders("jdk", "default"));
 
 		assertThat(result.result, equalTo(SUCCESS_EXIT));
-		assertThat(result.normalizedOut(), containsString("* -> 17-jbang"));
+		assertThat(result.normalizedOut(), containsString("* -> 17.0.7-jbang"));
 	}
 
 	@Test
@@ -368,7 +368,14 @@ public class TestJdk extends BaseTest {
 		int jdkVersion = 14;
 		createMockJdk(jdkVersion);
 
-		CaptureResult<Integer> result = checkedRun(withProviders(
+		CaptureResult<Integer> result = checkedRun(withProviders("jdk", "list", "--show-details"));
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(countLines(result.normalizedOut()), equalTo(4));
+		assertThat(result.normalizedOut(), containsString("default"));
+		assertThat(result.normalizedOut(), containsString("14-default"));
+		assertThat(result.normalizedOut(), containsString("14.0.7-jbang"));
+
+		result = checkedRun(withProviders(
 				"jdk", "uninstall", Integer.toString(jdkVersion)));
 
 		assertThat(result.result, equalTo(SUCCESS_EXIT));
@@ -376,6 +383,10 @@ public class TestJdk extends BaseTest {
 				containsString("Uninstalled JDK:"));
 		assertThat(result.normalizedErr(),
 				containsString("[jbang] Uninstalled JDK:\n  " + jdkVersion));
+
+		result = checkedRun(withProviders("jdk", "list", "--show-details"));
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.normalizedOut(), containsString("No JDKs installed"));
 	}
 
 	@Test
@@ -412,11 +423,17 @@ public class TestJdk extends BaseTest {
 	}
 
 	private static void createMockJdk(int jdkVersion, BiConsumer<Path, String> init) {
-		Path jdkPath = Settings.getCacheDir(Cache.CacheClass.jdks).resolve(String.valueOf(jdkVersion));
-		init.accept(jdkPath, jdkVersion + ".0.7");
-		Path link = Settings.getDefaultJdkDir();
-		if (!Files.exists(link)) {
-			Util.createLink(link, jdkPath);
+		String fullVersion = jdkVersion + ".0.7";
+		Path jdksPath = Settings.getCacheDir(Cache.CacheClass.jdks);
+		Path jdkPath = jdksPath.resolve(fullVersion + "-jbang");
+		init.accept(jdkPath, fullVersion);
+		Path deflink = Settings.getDefaultJdkDir();
+		if (!Files.exists(deflink)) {
+			Util.createLink(deflink, jdkPath);
+		}
+		Path defvlink = jdksPath.resolve(String.valueOf(jdkVersion));
+		if (!Files.exists(defvlink)) {
+			Util.createLink(defvlink, jdkPath);
 		}
 	}
 
@@ -443,5 +460,12 @@ public class TestJdk extends BaseTest {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	private int countLines(String text) {
+		return text.lines()
+			.filter(line -> !line.trim().isEmpty())
+			.mapToInt(line -> 1)
+			.sum();
 	}
 }

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -324,6 +324,23 @@ public class TestJdk extends BaseTest {
 	}
 
 	@Test
+	void testJdkInstallWithLinkingAndIntegerId() {
+		assertThrows(IllegalArgumentException.class,
+				() -> checkedRun("install", "--force", "11", "/non-existent-path"),
+				"When providing an existing JDK path, the versionOrId parameter must be a non-integer id");
+	}
+
+	@Test
+	void testJdkInstallWithLinkingToExistingJBangJdkPath() {
+		final Path jdkPath = Settings.getCacheDir(Cache.CacheClass.jdks).resolve("11");
+		initMockJdkDir(jdkPath, "11.0.14");
+
+		assertThrows(IllegalArgumentException.class,
+				() -> checkedRun("install", "my11", jdkPath.toString()),
+				"The provided path cannot point to a JBang managed JDK");
+	}
+
+	@Test
 	void testJdkInstallWithLinkingToExistingJdkPathWithDifferentVersion(@TempDir File javaDir) {
 		initMockJdkDir(javaDir.toPath(), "11.0.14");
 
@@ -361,6 +378,30 @@ public class TestJdk extends BaseTest {
 				containsString("JDK my11-linked has been linked to: " + jdkOk));
 		assertTrue(Util.isLink(jdkPath.resolve("my11-linked")));
 		assertTrue(Files.isSameFile(jdkOk, (jdkPath.resolve("my11-linked").toRealPath())));
+	}
+
+	@Test
+	void testJdkInstallSameVersion() throws Exception {
+		Arrays.asList(11).forEach(TestJdk::createMockJdk);
+
+		CaptureResult<Integer> result = checkedRun("install", "11");
+
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.normalizedErr(), containsString("JDK is already installed"));
+		assertThat(result.normalizedErr(), containsString("Use --force to install anyway"));
+	}
+
+	@Test
+	void testJdkInstallSameVersionForced() throws Exception {
+		Arrays.asList(11).forEach(TestJdk::createMockJdk);
+		Path jdkPath = Settings.getCacheDir(Cache.CacheClass.jdks);
+
+		CaptureResult<Integer> result = checkedRun("install", "--force", "11");
+
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.normalizedErr(), containsString("Installing Mock JDK 11.1"));
+		assertTrue(Files.isDirectory(jdkPath.resolve("11.1")));
+		assertTrue(Util.isLink(jdkPath.resolve("11")));
 	}
 
 	@Test


### PR DESCRIPTION
This fixes the problem with uninstalls of Jdks sometimes leaving dangling links which confuse older JBangs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling dependency to a newer stable version.

* **New Features**
  * The JDK list command now displays linked JDK information when a link is configured, providing clearer context about your available JDKs.

* **Bug Fixes**
  * The JDK uninstall command now only displays the success message when the uninstallation is confirmed to be complete.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang/pull/2484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->