### PR TITLE
build: migrate from Allure 2 to Allure 3

### DIFF
--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -8,7 +8,7 @@
 // group results by OS so the Allure 3 Environments view shows a side-by-side
 // comparison across platforms.
 //
-// Reference: https://allurereport.org/docs/how-it-works-report-configuration/
+// Reference: https://allurereport.org/docs/v3/configure/
 
 export default {
 	name: "JBang Test Report",

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -1,0 +1,26 @@
+// Allure 3 report configuration file.
+//
+// NOTE: When generating reports via `./gradlew allureReport`, the Allure Gradle
+// plugin 4.x generates its own config file and passes it to the Allure 3 CLI
+// via --config. This file is therefore NOT automatically picked up by Gradle.
+// It IS used when running the Allure 3 CLI directly (e.g. `allure generate ...`).
+//
+// The Gradle plugin default already uses the "awesome" plugin with
+// groupBy defaulting to ["parentSuite", "suite", "subSuite"], which groups
+// tests by platform (OS/arch/Java) at the top level — matching our intent.
+//
+// Custom grouping hierarchy:
+//   Level 1: parentSuite label  — OS/arch/Java version (set per-job in CI)
+//   Level 2: tag label          — "unit-test" or "integration-test"
+//
+// Reference: https://allurereport.org/docs/how-it-works-report-configuration/
+export default {
+    name: "JBang Test Report",
+    plugins: {
+        awesome: {
+            options: {
+                groupBy: ["parentSuite", "tag"],
+            },
+        },
+    },
+};

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -1,26 +1,50 @@
-// Allure 3 report configuration file.
+// Allure 3 report configuration.
 //
-// NOTE: When generating reports via `./gradlew allureReport`, the Allure Gradle
-// plugin 4.x generates its own config file and passes it to the Allure 3 CLI
-// via --config. This file is therefore NOT automatically picked up by Gradle.
-// It IS used when running the Allure 3 CLI directly (e.g. `allure generate ...`).
+// The Gradle allureReport task is configured (in build.gradle) to use this file
+// via --config, overriding the plugin's auto-generated allurerc.json.
 //
-// The Gradle plugin default already uses the "awesome" plugin with
-// groupBy defaulting to ["parentSuite", "suite", "subSuite"], which groups
-// tests by platform (OS/arch/Java) at the top level — matching our intent.
-//
-// Custom grouping hierarchy:
-//   Level 1: parentSuite label  — OS/arch/Java version (set per-job in CI)
-//   Level 2: tag label          — "unit-test" or "integration-test"
+// Environments: each CI matrix cell produces a distinct parentSuite label
+// (e.g. "Linux-amd64-21.0.10-unit-test-jvm-17-abc1234"). The matchers below
+// group results by OS so the Allure 3 Environments view shows a side-by-side
+// comparison across platforms.
 //
 // Reference: https://allurereport.org/docs/how-it-works-report-configuration/
+
 export default {
-    name: "JBang Test Report",
-    plugins: {
-        awesome: {
-            options: {
-                groupBy: ["parentSuite", "tag"],
-            },
-        },
-    },
+	name: "JBang Test Report",
+	plugins: {
+		awesome: {
+			options: {
+				singleFile: true,
+				groupBy: ["parentSuite", "suite", "subSuite"],
+			},
+		},
+	},
+	environments: {
+		linux: {
+			name: "Linux",
+			matcher: ({ labels }) =>
+				labels.some(
+					(l) => l.name === "parentSuite" && /^Linux/i.test(l.value),
+				),
+		},
+		macos: {
+			name: "macOS",
+			matcher: ({ labels }) =>
+				labels.some(
+					(l) =>
+						l.name === "parentSuite" &&
+						/^Mac/i.test(l.value),
+				),
+		},
+		windows: {
+			name: "Windows",
+			matcher: ({ labels }) =>
+				labels.some(
+					(l) =>
+						l.name === "parentSuite" &&
+						/^Windows/i.test(l.value),
+				),
+		},
+	},
 };

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,29 @@ allure {
 	}
 }
 
+// Re-generate the Allure report using our allurerc.mjs which configures
+// Allure 3 environments (OS-based side-by-side comparison) and custom
+// grouping. The plugin's allureReport task generates a minimal JSON config
+// that can't express JS-based environment matchers, so we re-run the CLI
+// with our .mjs config, overwriting the report in-place.
+// This task is finalized by allureReport so it runs automatically whenever
+// allureReport is invoked (including from CI).
+task allureReportCustomConfig(type: Exec) {
+	group = 'verification'
+	description = 'Re-generate Allure report with custom allurerc.mjs config'
+	def customConfig = project.file('allurerc.mjs')
+	def allureCli = project.file("$buildDir/allure/commandline/bin/allure")
+	def resultsDir = project.file("$buildDir/allure-results")
+	onlyIf { customConfig.exists() && allureCli.exists() }
+	doFirst {
+		def reportDir = tasks.named('allureReport').get().reportDir.get().asFile.absolutePath
+		commandLine allureCli.absolutePath, 'generate', resultsDir.absolutePath,
+			'--config', customConfig.absolutePath,
+			'--output', reportDir
+	}
+}
+tasks.named('allureReport') { finalizedBy 'allureReportCustomConfig' }
+
 publishing {
 	publications {
 		maven(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,5 @@
 import org.gradle.crypto.checksum.Checksum
 
-buildscript {
-	dependencies {
-		// Force commons-io 2.22.0+ on the buildscript classpath.
-		// Gradle ships commons-io 2.15.1 which lacks the Supplier overload
-		// of IOUtils.skip() required by commons-compress 1.28.0 (used by
-		// the Allure Gradle plugin's Node.js download task).
-		classpath 'commons-io:commons-io:2.22.0'
-	}
-}
-
 plugins {
 	id "distribution"
 	id "com.gradleup.shadow" version "8.3.9"
@@ -28,7 +18,7 @@ plugins {
 	id 'jacoco'
 	id 'maven-publish'
 	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.9.2'
-	id "io.qameta.allure" version "4.0.2"
+	id "io.qameta.allure" version "4.1.0"
 }
 
 def allureVersion = '2.35.2'
@@ -91,46 +81,10 @@ allure {
 	}
 	report {
 		reportDir.set(project.reporting.baseDirectory.dir("allure-report"))
+		configFile.set(layout.projectDirectory.file("allurerc.mjs"))
 		singleFile = true
 	}
 }
-
-// Re-generate the Allure report using our allurerc.mjs which configures
-// Allure 3 environments (OS-based side-by-side comparison) and custom
-// grouping.
-//
-// The Allure Gradle plugin (4.x) generates a minimal allurerc.json that only
-// sets output dir and singleFile — there is no extension point for custom
-// config (see Allure3Config.kt in allure-gradle). Environments require JS
-// matchers which JSON can't express. So we re-run the Allure CLI with our
-// allurerc.mjs, overwriting the report in-place. This task is finalized by
-// allureReport so it runs automatically whenever allureReport is invoked
-// (including from CI).
-task allureReportCustomConfig(type: Exec) {
-	group = 'verification'
-	description = 'Re-generate Allure report with custom allurerc.mjs config'
-	def customConfig = project.file('allurerc.mjs')
-	onlyIf { customConfig.exists() }
-	doFirst {
-		def allureReportTask = tasks.named('allureReport').get()
-		def reportDir = allureReportTask.reportDir.get().asFile.absolutePath
-		// Resolve the CLI executable the same way the plugin does (allure.bat on Windows)
-		def binDir = layout.buildDirectory.dir('allure/commandline/bin').get().asFile
-		def allureExe = org.apache.tools.ant.taskdefs.condition.Os.isFamily(
-			org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)
-			? new File(binDir, 'allure.bat') : new File(binDir, 'allure')
-		if (!allureExe.exists()) {
-			// Fallback for Windows: some distributions use .cmd
-			allureExe = new File(binDir, 'allure.cmd')
-		}
-		// Use the same input directories as allureReport (respects allureMergeDirs)
-		def resultDirs = allureReportTask.resultsDirs.files.collect { it.absolutePath }
-		def cmd = [allureExe.absolutePath, 'generate'] + resultDirs +
-			['--config', customConfig.absolutePath, '--output', reportDir]
-		commandLine cmd
-	}
-}
-tasks.named('allureReport') { finalizedBy 'allureReportCustomConfig' }
 
 publishing {
 	publications {

--- a/build.gradle
+++ b/build.gradle
@@ -97,23 +97,29 @@ allure {
 
 // Re-generate the Allure report using our allurerc.mjs which configures
 // Allure 3 environments (OS-based side-by-side comparison) and custom
-// grouping. The plugin's allureReport task generates a minimal JSON config
-// that can't express JS-based environment matchers, so we re-run the CLI
-// with our .mjs config, overwriting the report in-place.
-// This task is finalized by allureReport so it runs automatically whenever
-// allureReport is invoked (including from CI).
+// grouping.
+//
+// The Allure Gradle plugin (4.x) generates a minimal allurerc.json that only
+// sets output dir and singleFile — there is no extension point for custom
+// config (see Allure3Config.kt in allure-gradle). Environments require JS
+// matchers which JSON can't express. So we re-run the Allure CLI with our
+// allurerc.mjs, overwriting the report in-place. This task is finalized by
+// allureReport so it runs automatically whenever allureReport is invoked
+// (including from CI).
 task allureReportCustomConfig(type: Exec) {
 	group = 'verification'
 	description = 'Re-generate Allure report with custom allurerc.mjs config'
 	def customConfig = project.file('allurerc.mjs')
-	def allureCli = project.file("$buildDir/allure/commandline/bin/allure")
-	def resultsDir = project.file("$buildDir/allure-results")
-	onlyIf { customConfig.exists() && allureCli.exists() }
+	def allureCli = layout.buildDirectory.file('allure/commandline/bin/allure')
+	onlyIf { customConfig.exists() && allureCli.get().asFile.exists() }
 	doFirst {
-		def reportDir = tasks.named('allureReport').get().reportDir.get().asFile.absolutePath
-		commandLine allureCli.absolutePath, 'generate', resultsDir.absolutePath,
-			'--config', customConfig.absolutePath,
-			'--output', reportDir
+		def allureReportTask = tasks.named('allureReport').get()
+		def reportDir = allureReportTask.reportDir.get().asFile.absolutePath
+		// Use the same input directories as allureReport (respects allureMergeDirs)
+		def resultDirs = allureReportTask.resultsDirs.files.collect { it.absolutePath }
+		def cmd = [allureCli.get().asFile.absolutePath, 'generate'] + resultDirs +
+			['--config', customConfig.absolutePath, '--output', reportDir]
+		commandLine cmd
 	}
 }
 tasks.named('allureReport') { finalizedBy 'allureReportCustomConfig' }

--- a/build.gradle
+++ b/build.gradle
@@ -110,14 +110,22 @@ task allureReportCustomConfig(type: Exec) {
 	group = 'verification'
 	description = 'Re-generate Allure report with custom allurerc.mjs config'
 	def customConfig = project.file('allurerc.mjs')
-	def allureCli = layout.buildDirectory.file('allure/commandline/bin/allure')
-	onlyIf { customConfig.exists() && allureCli.get().asFile.exists() }
+	onlyIf { customConfig.exists() }
 	doFirst {
 		def allureReportTask = tasks.named('allureReport').get()
 		def reportDir = allureReportTask.reportDir.get().asFile.absolutePath
+		// Resolve the CLI executable the same way the plugin does (allure.bat on Windows)
+		def binDir = layout.buildDirectory.dir('allure/commandline/bin').get().asFile
+		def allureExe = org.apache.tools.ant.taskdefs.condition.Os.isFamily(
+			org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)
+			? new File(binDir, 'allure.bat') : new File(binDir, 'allure')
+		if (!allureExe.exists()) {
+			// Fallback for Windows: some distributions use .cmd
+			allureExe = new File(binDir, 'allure.cmd')
+		}
 		// Use the same input directories as allureReport (respects allureMergeDirs)
 		def resultDirs = allureReportTask.resultsDirs.files.collect { it.absolutePath }
-		def cmd = [allureCli.get().asFile.absolutePath, 'generate'] + resultDirs +
+		def cmd = [allureExe.absolutePath, 'generate'] + resultDirs +
 			['--config', customConfig.absolutePath, '--output', reportDir]
 		commandLine cmd
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,15 @@
 import org.gradle.crypto.checksum.Checksum
 
+buildscript {
+	dependencies {
+		// Force commons-io 2.22.0+ on the buildscript classpath.
+		// Gradle ships commons-io 2.15.1 which lacks the Supplier overload
+		// of IOUtils.skip() required by commons-compress 1.28.0 (used by
+		// the Allure Gradle plugin's Node.js download task).
+		classpath 'commons-io:commons-io:2.22.0'
+	}
+}
+
 plugins {
 	id "distribution"
 	id "com.gradleup.shadow" version "8.3.9"
@@ -18,12 +28,10 @@ plugins {
 	id 'jacoco'
 	id 'maven-publish'
 	id 'eu.maveniverse.gradle.plugins.nisse-gradle-plugin' version '0.9.2'
-	id 'io.qameta.allure-report' version '2.12.0'
-	id "io.qameta.allure-adapter-base" version "2.12.0"
+	id "io.qameta.allure" version "4.0.2"
 }
 
-def allureVersion = '2.29.1'
-def aspectJVersion = '1.9.25'
+def allureVersion = '2.35.2'
 def assertjVersion = '3.27.7'
 def aeshVersion = '3.16.4'
 def devkitmanVersion = '0.4.9'
@@ -31,13 +39,6 @@ def junitBomVersion = '5.14.1'
 def testcontainersVersion = '2.0.2'
 def tambouiVersion = '0.4.0'
 def wiremockVersion = '3.13.2'
-
-configurations {
-	agent {
-		canBeResolved = true
-		canBeConsumed = true
-	}
-}
 
 javadoc {
 	options.encoding = 'UTF-8'
@@ -79,19 +80,17 @@ def testExecutionToolchain = project.javaToolchains.launcherFor {
 // See https://docs.gradle.org/current/dsl/org.gradle.api.reporting.ReportingExtension.html
 // Extension is provided via Gradle's `reporting-base` plugin
 reporting {
-	baseDir = "$buildDir/reports"
+	baseDirectory = layout.buildDirectory.dir("reports")
 }
 
 allure {
-	version.set("2.33.0")
+	version.set("3.9.0")
+	adapter {
+		allureJavaVersion.set("2.35.2")
+		aspectjWeaver.set(true)
+	}
 	report {
-
-		// There might be several tasks producing the report, so the property
-		// configures a base directory for all the reports
-		// Each task creates its own subfolder there
 		reportDir.set(project.reporting.baseDirectory.dir("allure-report"))
-
-		// Enable single file generation to open without serving.
 		singleFile = true
 	}
 }
@@ -193,8 +192,6 @@ dependencies {
 	testImplementation platform("io.qameta.allure:allure-bom:$allureVersion")
 	testImplementation "io.qameta.allure:allure-junit5"
 	// only for test running
-	agent "org.aspectj:aspectjweaver:$aspectJVersion"
-
 	if (project.hasProperty('allureMergeDirs')) {
 		project.property('allureMergeDirs').toString().split(',').each { dir ->
 			allureRawResultElements(files(dir.trim()))
@@ -439,7 +436,7 @@ test {
 		excludeTags 'benchmark'
 	}
 	javaLauncher = testExecutionToolchain
-	def jvmArgsList = ["-javaagent:${configurations.agent.singleFile}"] // for allure reporting
+	def jvmArgsList = []
 	if (testJavaVersion.asInt() >= 9) {
 		jvmArgsList.addAll([
 			"--add-opens", "java.base/java.lang=ALL-UNNAMED",


### PR DESCRIPTION
TL;DR: pr to see how allure 3 looks like. I really don't want to introduce yet another layer that relies on nodejs but we already use it for docs generation so maybe not too much of a loss?


## Summary

Migrate test reporting from Allure 2 to Allure 3.

### Changes

- **Plugin**: Replace `allure-report` + `allure-adapter-base` v2.12.0 with single `io.qameta.allure` v4.0.2
- **Report generator**: 2.33.0 → 3.9.0 (Allure 3)
- **allure-bom**: 2.29.1 → 2.35.2
- **AspectJ weaver**: Remove manual `-javaagent` config — plugin 4.x auto-manages it
- **Gradle API**: Modernize `reporting.baseDir` → `reporting.baseDirectory`
- **Workaround**: Add `buildscript { classpath 'commons-io:commons-io:2.22.0' }` to fix a classpath conflict (Gradle ships commons-io 2.15.1 which lacks a method required by the plugin's commons-compress 1.28.0)

### What stays the same

- **No test source code changes** — allure-java stays at 2.x, all `@Description`, `@Issue`, and `Allure.step()` usage is unchanged
- **CI workflow unchanged** — report output path (`build/reports/allure-report/allureReport/index.html`), artifact upload patterns, and multi-OS result merging all work the same
- **Single-file HTML report** still generated

### Verified locally

- `./gradlew clean test allureReport` — 629 tests pass (601 passed, 28 skipped)
- `./gradlew --no-daemon allureReport --clean` — works (matches CI usage)
- Single-file report generated at unchanged path
- `allureRawResultElements` merge mechanism intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Allure 3 reporting configuration with single-file report generation.
  * Reports now group results by parent suite, suite, and sub-suite.
  * Added automatic environment classification for Linux, macOS, and Windows test runs.

* **Improvements**
  * Updated Allure reporting integration and refreshed report output configuration.
  * Improved test report organization and environment visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->