### PR TITLE
fix: support --option=false syntax for boolean flags (#2504)

### DIFF
--- a/src/it/java/dev/jbang/it/VersionIT.java
+++ b/src/it/java/dev/jbang/it/VersionIT.java
@@ -37,4 +37,34 @@ public class VersionIT extends BaseIT {
 			.errContains("Repository");
 	}
 
+	// Scenario: verbose version via config
+	// * command('jbang config set verbose true')
+	// * command('jbang version')
+	// * match out == '#regex (?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?.*'
+	// * match err contains 'Repository'
+	// * match exit == 0
+	@Test
+	public void shouldVerboseVersionConfig() {
+		assertThat(shell("jbang config set verbose true")).succeeded();
+		assertThat(shell("jbang version")).succeeded()
+			.outMatches(Pattern.compile(
+					"(?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?(-SNAPSHOT)?" + lineSeparator()))
+			.errContains("Repository");
+	}
+
+	// Scenario: verbose config overridden by --no-verbose
+	// * command('jbang config set verbose true')
+	// * command('jbang --no-verbose version')
+	// * match out == '#regex (?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?.*'
+	// * match err !contains 'Repository'
+	// * match exit == 0
+	@Test
+	public void shouldVerboseVersionConfigOverride() {
+		assertThat(shell("jbang config set verbose true")).succeeded();
+		assertThat(shell("jbang --no-verbose version")).succeeded()
+			.outMatches(Pattern.compile(
+					"(?s)\\d+\\.\\d+\\.\\d+(\\.\\d+)?(-SNAPSHOT)?" + lineSeparator()))
+			.errNotContains("Repository");
+	}
+
 }

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -41,27 +41,27 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 	@Option(name = "insecure", hasValue = false, description = "Enable insecure trust of all SSL certificates.")
 	boolean insecure;
 
-	@Option(name = "verbose", hasValue = false, inherited = true, exclusiveWith = {
+	@Option(name = "verbose", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"quiet" }, description = "jbang will be verbose on what it does.")
-	boolean verbose;
+	Boolean verbose;
 
-	@Option(name = "quiet", hasValue = false, inherited = true, exclusiveWith = {
+	@Option(name = "quiet", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"verbose" }, description = "jbang will be quiet, only print when error occurs.")
-	boolean quiet;
+	Boolean quiet;
 
-	@Option(shortName = 'o', name = "offline", hasValue = false, inherited = true, exclusiveWith = {
+	@Option(shortName = 'o', name = "offline", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"fresh" }, description = "Work offline. Fail-fast if dependencies are missing.")
-	boolean offline;
+	Boolean offline;
 
-	@Option(name = "fresh", hasValue = false, inherited = true, exclusiveWith = {
+	@Option(name = "fresh", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"offline" }, description = "Make sure we use fresh (i.e. non-cached) resources.")
-	boolean fresh;
+	Boolean fresh;
 
-	@Option(name = "preview", hasValue = false, inherited = true, description = "Enable jbang preview features", visibility = org.aesh.command.option.OptionVisibility.HIDDEN)
-	boolean preview;
+	@Option(name = "preview", hasValue = false, negatable = true, inherited = true, description = "Enable jbang preview features", visibility = org.aesh.command.option.OptionVisibility.HIDDEN)
+	Boolean preview;
 
-	@Option(shortName = 'x', name = "stacktrace", hasValue = false, inherited = true, description = "Print exceptions stacktraces to stderr (even when quiet).")
-	boolean printExceptions;
+	@Option(shortName = 'x', name = "stacktrace", hasValue = false, negatable = true, inherited = true, description = "Print exceptions stacktraces to stderr (even when quiet).")
+	Boolean printExceptions;
 
 	protected CommandInvocation commandInvocation;
 
@@ -162,23 +162,23 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 
 	@Override
 	public void afterParse() {
-		if (verbose) {
-			Util.setVerbose(true);
+		if (verbose != null) {
+			Util.setVerbose(verbose);
 		}
-		if (quiet) {
-			Util.setQuiet(true);
+		if (quiet != null) {
+			Util.setQuiet(quiet);
 		}
-		if (offline) {
-			Util.setOffline(true);
+		if (offline != null) {
+			Util.setOffline(offline);
 		}
-		if (fresh) {
-			Util.setFresh(true);
+		if (fresh != null) {
+			Util.setFresh(fresh);
 		}
-		if (preview) {
-			Util.setPreview(true);
+		if (preview != null) {
+			Util.setPreview(preview);
 		}
-		if (printExceptions) {
-			Util.setPrintExceptions(true);
+		if (printExceptions != null) {
+			Util.setPrintExceptions(printExceptions);
 		}
 
 		if (configPath != null) {

--- a/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
+++ b/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
@@ -33,6 +33,18 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			return null;
 		}
 
+		// Skip config defaults for inherited options on child commands.
+		// The root command (JBang) will get the config default and handle
+		// it in afterParse(). Without this guard, a child command's config
+		// default (e.g. verbose=true) would override a CLI flag like
+		// --no-verbose that was already processed by the parent.
+		if (option.isInherited()
+				&& option.parent() != null
+				&& option.parent().getCommand() != null
+				&& !(option.parent().getCommand() instanceof JBang)) {
+			return null;
+		}
+
 		String optName = option.name().replace("-", "");
 		String fullPath = null;
 

--- a/src/test/java/dev/jbang/cli/TestAeshParsing.java
+++ b/src/test/java/dev/jbang/cli/TestAeshParsing.java
@@ -216,10 +216,41 @@ class TestAeshParsing extends BaseTest {
 	void testHelpShowsVisibleOptions() throws Exception {
 		CaptureResult<Integer> result = captureOutput(() -> JBang.execute("run", "--help"));
 		String output = result.normalizedOut() + result.normalizedErr();
-		assertThat(output, containsString("--verbose"));
-		assertThat(output, containsString("--quiet"));
-		assertThat(output, containsString("--offline"));
-		assertThat(output, containsString("--fresh"));
+		assertThat(output, containsString("verbose"));
+		assertThat(output, containsString("quiet"));
+		assertThat(output, containsString("offline"));
+		assertThat(output, containsString("fresh"));
+	}
+
+	// --- Boolean options with explicit =true/=false values (#2504) ---
+
+	@Test
+	void testNoVerboseDisablesVerbose() {
+		Util.setVerbose(true);
+		JBang.parseCommand("run", "--no-verbose", "test.java");
+		assertThat(Util.isVerbose(), is(false));
+	}
+
+	@Test
+	void testNoOfflineDisablesOffline() {
+		Util.setOffline(true);
+		JBang.parseCommand("run", "--no-offline", "test.java");
+		assertThat(Util.isOffline(), is(false));
+	}
+
+	@Test
+	void testNoFreshDisablesFresh() {
+		Util.setFresh(true);
+		JBang.parseCommand("run", "--no-fresh", "test.java");
+		assertThat(Util.isFresh(), is(false));
+	}
+
+	@Test
+	void testUnspecifiedVerboseDefaultsToFalse() {
+		// When --verbose is not specified, verbose should be false
+		// (beforeParse resets all flags)
+		JBang.parseCommand("run", "test.java");
+		assertThat(Util.isVerbose(), is(false));
 	}
 
 	// --- Subcommand list consistency ---


### PR DESCRIPTION
Use Boolean wrappers instead of boolean primitives for inherited global flags (verbose, quiet, offline, fresh, preview, stacktrace). This allows afterParse() to distinguish between 'not specified' (null) and 'explicitly set to false' (Boolean.FALSE), so that --offline=false correctly overrides a config-file default of true.

Previously the primitive boolean fields defaulted to false, making it impossible to tell if the user explicitly passed --offline=false or simply didn't specify the flag at all.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
