### PR TITLE
docs: add description to --manifest option (#2485)

### DIFF
--- a/docs/genadoc.java
+++ b/docs/genadoc.java
@@ -1,10 +1,10 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-// aesh classes are provided via --cp from the jbang shadow jar
+//DEPS org.aesh:aesh:3.12.1
 ///COMPILE_OPTIONS -proc:none
 //JAVA 17+
 
 import org.aesh.command.Command;
-import org.aesh.util.doc.DocFormat;
+import org.aesh.command.DocFormat;
 import org.aesh.util.doc.DocumentationGenerator;
 
 import java.io.*;

--- a/docs/modules/cli/pages/jbang-alias-add.adoc
+++ b/docs/modules/cli/pages/jbang-alias-add.adoc
@@ -8,12 +8,8 @@ jbang alias add -- Add alias for script reference.
 
 [source]
 ----
-jbang alias add [-hnigox] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [-f=<file>] [--description=<description>] [--name=<name>] [--force] [--enable-preview] [--docs=<docs>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>] [<params>]
+jbang alias add [-hnig] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [-f=<file>] [--description=<description>] [--name=<name>] [--force] [--enable-preview] [--docs=<docs>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>] [<params>]
 ----
-
-== DESCRIPTION
-
-Add alias for script reference.
 
 == OPTIONS
 
@@ -48,6 +44,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -135,19 +132,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-alias-list.adoc
+++ b/docs/modules/cli/pages/jbang-alias-list.adoc
@@ -8,12 +8,8 @@ jbang alias list -- Lists locally defined aliases or from the given catalog.
 
 [source]
 ----
-jbang alias list [-hgox] [-f=<file>] [--show-origin] [--format=<format>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<catalogName>]
+jbang alias list [-hg] [-f=<file>] [--show-origin] [--format=<format>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<catalogName>]
 ----
-
-== DESCRIPTION
-
-Lists locally defined aliases or from the given catalog.
 
 == OPTIONS
 
@@ -38,19 +34,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-alias-remove.adoc
+++ b/docs/modules/cli/pages/jbang-alias-remove.adoc
@@ -8,12 +8,8 @@ jbang alias remove -- Remove existing alias.
 
 [source]
 ----
-jbang alias remove [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <name>
+jbang alias remove [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <name>
 ----
-
-== DESCRIPTION
-
-Remove existing alias.
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-alias.adoc
+++ b/docs/modules/cli/pages/jbang-alias.adoc
@@ -8,12 +8,8 @@ jbang alias -- Manage aliases for scripts.
 
 [source]
 ----
-jbang alias [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang alias [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage aliases for scripts.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-app-install.adoc
+++ b/docs/modules/cli/pages/jbang-app-install.adoc
@@ -8,12 +8,8 @@ jbang app install -- Install a script as a command.
 
 [source]
 ----
-jbang app install [-hinox] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [--force] [--no-build] [--name=<name>] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>] [<params>]
+jbang app install [-hin] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [--force] [--no-build] [--name=<name>] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>] [<params>]
 ----
-
-== DESCRIPTION
-
-Install a script as a command.
 
 == OPTIONS
 
@@ -86,6 +82,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -129,19 +126,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-app-list.adoc
+++ b/docs/modules/cli/pages/jbang-app-list.adoc
@@ -8,12 +8,8 @@ jbang app list -- Lists installed commands.
 
 [source]
 ----
-jbang app list [-hox] [--format=<format>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang app list [-h] [--format=<format>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Lists installed commands.
 
 == OPTIONS
 
@@ -29,18 +25,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-app-setup.adoc
+++ b/docs/modules/cli/pages/jbang-app-setup.adoc
@@ -8,12 +8,8 @@ jbang app setup -- Make jbang commands available for the user.
 
 [source]
 ----
-jbang app setup [-hox] [--[no-]java] [--force] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang app setup [-h] [--[no-]java] [--force] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Make jbang commands available for the user.
 
 == OPTIONS
 
@@ -32,18 +28,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-app-uninstall.adoc
+++ b/docs/modules/cli/pages/jbang-app-uninstall.adoc
@@ -8,12 +8,8 @@ jbang app uninstall -- Removes a previously installed command.
 
 [source]
 ----
-jbang app uninstall [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <name>
+jbang app uninstall [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <name>
 ----
-
-== DESCRIPTION
-
-Removes a previously installed command.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-app.adoc
+++ b/docs/modules/cli/pages/jbang-app.adoc
@@ -8,12 +8,8 @@ jbang app -- Manage scripts installed on the user's PATH as commands.
 
 [source]
 ----
-jbang app [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang app [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage scripts installed on the user's PATH as commands.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-build.adoc
+++ b/docs/modules/cli/pages/jbang-build.adoc
@@ -8,12 +8,8 @@ jbang build -- Compiles and stores script in the cache.
 
 [source]
 ----
-jbang build [-hnox] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang build [-hn] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Compiles and stores script in the cache.
 
 == OPTIONS
 
@@ -48,6 +44,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -91,19 +88,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-cache-clear.adoc
+++ b/docs/modules/cli/pages/jbang-cache-clear.adoc
@@ -8,12 +8,8 @@ jbang cache clear -- Clear the various caches used by jbang. By default this wil
 
 [source]
 ----
-jbang cache clear [-hox] [--[no-]url] [--[no-]jar] [--[no-]deps] [--[no-]jdk] [--[no-]kotlinc] [--[no-]groovyc] [--[no-]project] [--[no-]script] [--[no-]stdin] [--all] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang cache clear [-h] [--[no-]url] [--[no-]jar] [--[no-]deps] [--[no-]jdk] [--[no-]kotlinc] [--[no-]groovyc] [--[no-]project] [--[no-]script] [--[no-]stdin] [--all] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Clear the various caches used by jbang. By default this will clear the JAR, script, stdin and URL caches.
 
 == OPTIONS
 
@@ -56,18 +52,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-cache.adoc
+++ b/docs/modules/cli/pages/jbang-cache.adoc
@@ -8,12 +8,8 @@ jbang cache -- Manage compiled scripts in the local cache.
 
 [source]
 ----
-jbang cache [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang cache [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage compiled scripts in the local cache.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-catalog-add.adoc
+++ b/docs/modules/cli/pages/jbang-catalog-add.adoc
@@ -8,12 +8,8 @@ jbang catalog add -- Add a catalog.
 
 [source]
 ----
-jbang catalog add [-hgox] [-d=<description>] [--name=<name>] [--force] [--import] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <fileOrURL>
+jbang catalog add [-hg] [-d=<description>] [--name=<name>] [--force] [--import] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <fileOrURL>
 ----
-
-== DESCRIPTION
-
-Add a catalog.
 
 == OPTIONS
 
@@ -44,19 +40,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-catalog-list.adoc
+++ b/docs/modules/cli/pages/jbang-catalog-list.adoc
@@ -8,12 +8,8 @@ jbang catalog list -- Show currently defined catalogs.
 
 [source]
 ----
-jbang catalog list [-hgox] [--show-origin] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<name>]
+jbang catalog list [-hg] [--show-origin] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<name>]
 ----
-
-== DESCRIPTION
-
-Show currently defined catalogs.
 
 == OPTIONS
 
@@ -38,19 +34,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-catalog-remove.adoc
+++ b/docs/modules/cli/pages/jbang-catalog-remove.adoc
@@ -8,12 +8,8 @@ jbang catalog remove -- Remove existing catalog.
 
 [source]
 ----
-jbang catalog remove [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <name>
+jbang catalog remove [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <name>
 ----
-
-== DESCRIPTION
-
-Remove existing catalog.
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-catalog-update.adoc
+++ b/docs/modules/cli/pages/jbang-catalog-update.adoc
@@ -8,12 +8,8 @@ jbang catalog update -- Retrieve the latest contents of the catalogs.
 
 [source]
 ----
-jbang catalog update [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang catalog update [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Retrieve the latest contents of the catalogs.
 
 == OPTIONS
 
@@ -32,18 +28,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-catalog.adoc
+++ b/docs/modules/cli/pages/jbang-catalog.adoc
@@ -8,12 +8,8 @@ jbang catalog -- Manage Catalogs of aliases.
 
 [source]
 ----
-jbang catalog [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang catalog [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage Catalogs of aliases.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-completion.adoc
+++ b/docs/modules/cli/pages/jbang-completion.adoc
@@ -8,12 +8,8 @@ jbang completion -- Generate bash/zsh or fish completion script for jbang.
 
 [source]
 ----
-jbang completion [-hox] [-s=<shell>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang completion [-h] [-s=<shell>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Generate bash/zsh or fish completion script for jbang.
 
 == OPTIONS
 
@@ -29,18 +25,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-config-get.adoc
+++ b/docs/modules/cli/pages/jbang-config-get.adoc
@@ -8,12 +8,8 @@ jbang config get -- Get a configuration value
 
 [source]
 ----
-jbang config get [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <key>
+jbang config get [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <key>
 ----
-
-== DESCRIPTION
-
-Get a configuration value
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-config-list.adoc
+++ b/docs/modules/cli/pages/jbang-config-list.adoc
@@ -8,12 +8,8 @@ jbang config list -- List active configuration values
 
 [source]
 ----
-jbang config list [-hgox] [--show-origin] [--show-available] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang config list [-hg] [--show-origin] [--show-available] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-List active configuration values
 
 == OPTIONS
 
@@ -41,18 +37,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-config-set.adoc
+++ b/docs/modules/cli/pages/jbang-config-set.adoc
@@ -8,12 +8,8 @@ jbang config set -- Set a configuration value
 
 [source]
 ----
-jbang config set [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <key> [<value>]
+jbang config set [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <key> [<value>]
 ----
-
-== DESCRIPTION
-
-Set a configuration value
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-config-unset.adoc
+++ b/docs/modules/cli/pages/jbang-config-unset.adoc
@@ -8,12 +8,8 @@ jbang config unset -- Remove a configuration value
 
 [source]
 ----
-jbang config unset [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <key>
+jbang config unset [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <key>
 ----
-
-== DESCRIPTION
-
-Remove a configuration value
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-config.adoc
+++ b/docs/modules/cli/pages/jbang-config.adoc
@@ -8,12 +8,8 @@ jbang config -- Read and write configuration options.
 
 [source]
 ----
-jbang config [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang config [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Read and write configuration options.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-deps-add.adoc
+++ b/docs/modules/cli/pages/jbang-deps-add.adoc
@@ -8,12 +8,8 @@ jbang deps add -- Add dependencies to a jbang file.
 
 [source]
 ----
-jbang deps add [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<deps target>]
+jbang deps add [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<deps target>]
 ----
-
-== DESCRIPTION
-
-Add dependencies to a jbang file.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-deps-search.adoc
+++ b/docs/modules/cli/pages/jbang-deps-search.adoc
@@ -8,12 +8,8 @@ jbang deps search -- Search for artifacts in local and central Maven repositorie
 
 [source]
 ----
-jbang deps search [-hox] [--max=<max>] [-q=<query>] [--target=<target>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<args>]
+jbang deps search [-h] [--max=<max>] [-q=<query>] [--target=<target>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<args>]
 ----
-
-== DESCRIPTION
-
-Search for artifacts in local and central Maven repositories.
 
 == OPTIONS
 
@@ -37,19 +33,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-deps.adoc
+++ b/docs/modules/cli/pages/jbang-deps.adoc
@@ -8,12 +8,8 @@ jbang deps -- Manage dependencies in jbang files.
 
 [source]
 ----
-jbang deps [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang deps [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage dependencies in jbang files.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-edit.adoc
+++ b/docs/modules/cli/pages/jbang-edit.adoc
@@ -8,12 +8,8 @@ jbang edit -- Setup a temporary project to edit script in an IDE.
 
 [source]
 ----
-jbang edit [-hbox] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--live] [--open] [--no-open] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>] [<additionalFiles>]
+jbang edit [-hb] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--live] [--open] [--no-open] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>] [<additionalFiles>]
 ----
-
-== DESCRIPTION
-
-Setup a temporary project to edit script in an IDE.
 
 == OPTIONS
 
@@ -74,19 +70,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-fatjar.adoc
+++ b/docs/modules/cli/pages/jbang-export-fatjar.adoc
@@ -8,12 +8,8 @@ jbang export fatjar -- Exports an executable jar with all necessary dependencies
 
 [source]
 ----
-jbang export fatjar [-hnox] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export fatjar [-hn] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports an executable jar with all necessary dependencies included inside
 
 == OPTIONS
 
@@ -54,6 +50,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -97,19 +94,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-gradle.adoc
+++ b/docs/modules/cli/pages/jbang-export-gradle.adoc
@@ -8,12 +8,8 @@ jbang export gradle -- Exports a Gradle project
 
 [source]
 ----
-jbang export gradle [-hnox] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export gradle [-hn] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports a Gradle project
 
 == OPTIONS
 
@@ -63,6 +59,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -106,19 +103,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-jlink.adoc
+++ b/docs/modules/cli/pages/jbang-export-jlink.adoc
@@ -8,12 +8,8 @@ jbang export jlink -- Exports a minimized JDK distribution
 
 [source]
 ----
-jbang export jlink [-hnox] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>] [<jlinkParams>]
+jbang export jlink [-hn] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>] [<jlinkParams>]
 ----
-
-== DESCRIPTION
-
-Exports a minimized JDK distribution
 
 == OPTIONS
 
@@ -54,6 +50,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -97,19 +94,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-local.adoc
+++ b/docs/modules/cli/pages/jbang-export-local.adoc
@@ -8,12 +8,8 @@ jbang export local -- Exports jar with classpath referring to local machine depe
 
 [source]
 ----
-jbang export local [-hnox] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export local [-hn] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports jar with classpath referring to local machine dependent locations
 
 == OPTIONS
 
@@ -54,6 +50,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -97,19 +94,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-maven.adoc
+++ b/docs/modules/cli/pages/jbang-export-maven.adoc
@@ -8,12 +8,8 @@ jbang export maven -- Exports a Maven project
 
 [source]
 ----
-jbang export maven [-hnox] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export maven [-hn] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports a Maven project
 
 == OPTIONS
 
@@ -63,6 +59,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -106,19 +103,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-mavenrepo.adoc
+++ b/docs/modules/cli/pages/jbang-export-mavenrepo.adoc
@@ -8,12 +8,8 @@ jbang export mavenrepo -- Exports directory that can be used to publish as a mav
 
 [source]
 ----
-jbang export mavenrepo [-hnox] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export mavenrepo [-hn] [-g=<group>] [-a=<artifact>] [-v=<version>] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports directory that can be used to publish as a maven repository
 
 == OPTIONS
 
@@ -63,6 +59,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -106,19 +103,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-native.adoc
+++ b/docs/modules/cli/pages/jbang-export-native.adoc
@@ -8,12 +8,8 @@ jbang export native -- Exports native executable
 
 [source]
 ----
-jbang export native [-hnox] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export native [-hn] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports native executable
 
 == OPTIONS
 
@@ -54,6 +50,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -97,19 +94,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export-portable.adoc
+++ b/docs/modules/cli/pages/jbang-export-portable.adoc
@@ -8,12 +8,8 @@ jbang export portable -- Exports jar together with dependencies in way that make
 
 [source]
 ----
-jbang export portable [-hnox] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang export portable [-hn] [-O=<output>] [--force] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Exports jar together with dependencies in way that makes it portable
 
 == OPTIONS
 
@@ -54,6 +50,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -97,19 +94,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-export.adoc
+++ b/docs/modules/cli/pages/jbang-export.adoc
@@ -8,12 +8,8 @@ jbang export -- Export the result of a build or the set of the sources to a proj
 
 [source]
 ----
-jbang export [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang export [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Export the result of a build or the set of the sources to a project.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-info-classpath.adoc
+++ b/docs/modules/cli/pages/jbang-info-classpath.adoc
@@ -8,12 +8,8 @@ jbang info classpath -- Prints class-path used for this application using operat
 
 [source]
 ----
-jbang info classpath [-hox] [--deps-only] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang info classpath [-h] [--deps-only] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Prints class-path used for this application using operating system specific path separation.
 
 == OPTIONS
 
@@ -71,19 +67,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-info-docs.adoc
+++ b/docs/modules/cli/pages/jbang-info-docs.adoc
@@ -8,12 +8,8 @@ jbang info docs -- Open the documentation file in the default browser.
 
 [source]
 ----
-jbang info docs [-hox] [--[no-]open] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang info docs [-h] [--[no-]open] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Open the documentation file in the default browser.
 
 == OPTIONS
 
@@ -71,19 +67,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-info-jar.adoc
+++ b/docs/modules/cli/pages/jbang-info-jar.adoc
@@ -8,12 +8,8 @@ jbang info jar -- Prints the path to this application's JAR file.
 
 [source]
 ----
-jbang info jar [-hox] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang info jar [-h] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Prints the path to this application's JAR file.
 
 == OPTIONS
 
@@ -68,19 +64,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-info-tools.adoc
+++ b/docs/modules/cli/pages/jbang-info-tools.adoc
@@ -8,12 +8,8 @@ jbang info tools -- Prints a json description usable for tools/IDE's to get clas
 
 [source]
 ----
-jbang info tools [-hox] [--select=<select>] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>]
+jbang info tools [-h] [--select=<select>] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [--build-dir=<build-dir>] [--module] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>]
 ----
-
-== DESCRIPTION
-
-Prints a json description usable for tools/IDE's to get classpath and more info for a jbang script/application.
 
 == OPTIONS
 
@@ -71,19 +67,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-info.adoc
+++ b/docs/modules/cli/pages/jbang-info.adoc
@@ -8,12 +8,8 @@ jbang info -- Provides info about the script for tools (and humans who are tools
 
 [source]
 ----
-jbang info [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang info [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Provides info about the script for tools (and humans who are tools).
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-init.adoc
+++ b/docs/modules/cli/pages/jbang-init.adoc
@@ -8,12 +8,8 @@ jbang init -- Initialize a script.
 
 [source]
 ----
-jbang init [-hox] [-j=<java>] [--ai-provider=<ai-provider>] [--ai-api-key=<ai-api-key>] [--ai-endpoint=<ai-endpoint>] [--ai-model=<ai-model>] [-t=<template>] [--force] [--edit] [-D<key>=<value>] [--deps=<deps>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <scriptOrFile> [<params>]
+jbang init [-h] [-j=<java>] [--ai-provider=<ai-provider>] [--ai-api-key=<ai-api-key>] [--ai-endpoint=<ai-endpoint>] [--ai-model=<ai-model>] [-t=<template>] [--force] [--edit] [-D<key>=<value>] [--deps=<deps>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <scriptOrFile> [<params>]
 ----
-
-== DESCRIPTION
-
-Initialize a script.
 
 == OPTIONS
 
@@ -56,19 +52,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-default.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-default.adoc
@@ -8,12 +8,8 @@ jbang jdk default -- Sets the default JDK to be used by JBang.
 
 [source]
 ----
-jbang jdk default [-hvdox] [--format=<format>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<versionOrId>]
+jbang jdk default [-hvd] [--format=<format>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<versionOrId>]
 ----
-
-== DESCRIPTION
-
-Sets the default JDK to be used by JBang.
 
 == OPTIONS
 
@@ -37,19 +33,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-exec.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-exec.adoc
@@ -8,12 +8,8 @@ jbang jdk exec -- Executes the given command using the default (or specified) JD
 
 [source]
 ----
-jbang jdk exec [-hox] [-j=<java>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <command>
+jbang jdk exec [-h] [-j=<java>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <command>
 ----
-
-== DESCRIPTION
-
-Executes the given command using the default (or specified) JDK.
 
 == OPTIONS
 
@@ -29,19 +25,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-home.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-home.adoc
@@ -8,12 +8,8 @@ jbang jdk home -- Prints the folder where the given JDK is installed.
 
 [source]
 ----
-jbang jdk home [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<versionOrId>]
+jbang jdk home [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<versionOrId>]
 ----
-
-== DESCRIPTION
-
-Prints the folder where the given JDK is installed.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-install.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-install.adoc
@@ -8,12 +8,8 @@ jbang jdk install -- Installs a JDK.
 
 [source]
 ----
-jbang jdk install [-hfox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <versionOrId> [<existingJdkPath>]
+jbang jdk install [-hf] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <versionOrId> [<existingJdkPath>]
 ----
-
-== DESCRIPTION
-
-Installs a JDK.
 
 == OPTIONS
 
@@ -29,19 +25,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-java-env.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-java-env.adoc
@@ -8,12 +8,8 @@ jbang jdk java env -- Prints out the environment variables needed to use the giv
 
 [source]
 ----
-jbang jdk java env [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<versionOrId>]
+jbang jdk java env [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<versionOrId>]
 ----
-
-== DESCRIPTION
-
-Prints out the environment variables needed to use the given JDK.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk-list.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-list.adoc
@@ -8,12 +8,8 @@ jbang jdk list -- Lists installed JDKs.
 
 [source]
 ----
-jbang jdk list [-hadox] [--format=<format>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang jdk list [-had] [--format=<format>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Lists installed JDKs.
 
 == OPTIONS
 
@@ -37,18 +33,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-jdk-uninstall.adoc
+++ b/docs/modules/cli/pages/jbang-jdk-uninstall.adoc
@@ -8,12 +8,8 @@ jbang jdk uninstall -- Uninstalls an existing JDK.
 
 [source]
 ----
-jbang jdk uninstall [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <versionOrId>
+jbang jdk uninstall [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <versionOrId>
 ----
-
-== DESCRIPTION
-
-Uninstalls an existing JDK.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-jdk.adoc
+++ b/docs/modules/cli/pages/jbang-jdk.adoc
@@ -8,12 +8,8 @@ jbang jdk -- Manage Java Development Kits installed by jbang.
 
 [source]
 ----
-jbang jdk [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang jdk [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage Java Development Kits installed by jbang.
 
 == OPTIONS
 
@@ -26,28 +22,33 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS
 
 * xref:jbang:cli:jbang-jdk-install.adoc[*install*] - Installs a JDK.
+* xref:jbang:cli:jbang-jdk-install.adoc[*install*] - Installs a JDK.
 * xref:jbang:cli:jbang-jdk-list.adoc[*list*] - Lists installed JDKs.
+* xref:jbang:cli:jbang-jdk-list.adoc[*list*] - Lists installed JDKs.
+* xref:jbang:cli:jbang-jdk-uninstall.adoc[*uninstall*] - Uninstalls an existing JDK.
 * xref:jbang:cli:jbang-jdk-uninstall.adoc[*uninstall*] - Uninstalls an existing JDK.
 * xref:jbang:cli:jbang-jdk-home.adoc[*home*] - Prints the folder where the given JDK is installed.
 * xref:jbang:cli:jbang-jdk-java-env.adoc[*java-env*] - Prints out the environment variables needed to use the given JDK.
+* xref:jbang:cli:jbang-jdk-java-env.adoc[*java-env*] - Prints out the environment variables needed to use the given JDK.
+* xref:jbang:cli:jbang-jdk-exec.adoc[*exec*] - Executes the given command using the default (or specified) JDK.
 * xref:jbang:cli:jbang-jdk-exec.adoc[*exec*] - Executes the given command using the default (or specified) JDK.
 * xref:jbang:cli:jbang-jdk-default.adoc[*default*] - Sets the default JDK to be used by JBang.
 

--- a/docs/modules/cli/pages/jbang-run.adoc
+++ b/docs/modules/cli/pages/jbang-run.adoc
@@ -8,12 +8,8 @@ jbang run -- Builds and runs provided script. (default command)
 
 [source]
 ----
-jbang run [-hinox] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [-c] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<scriptOrFile>] [<userParams>]
+jbang run [-hin] [-R=<runtime-option>] [--jfr] [-d=<debug>] [--enableassertions] [--enablesystemassertions] [--javaagent=<javaagent>] [--[no-]cds] [-c] [-s=<sources>] [--files=<files>] [-T=<source-type>] [--jsh] [--catalog=<catalog>] [-j=<java>] [-m=<main>] [--module] [-C=<compile-option>] [--manifest<key>=<value>] [--[no-]integrations] [-D<key>=<value>] [--deps=<deps>] [--repos=<repos>] [--cp=<cp>] [--ignore-transitive-repositories] [-N=<native-option>] [--build-dir=<build-dir>] [--enable-preview] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<scriptOrFile>] [<userParams>]
 ----
-
-== DESCRIPTION
-
-Builds and runs provided script. (default command)
 
 == OPTIONS
 
@@ -80,6 +76,7 @@ Treat resource as a module. Optionally with the given module name
 Options to pass to the compiler
 
 *--manifest*=<key>=<value>::
+Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)
 
 *--[no-]integrations*::
 Enable or disable integration execution (default: true)
@@ -123,19 +120,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-template-add.adoc
+++ b/docs/modules/cli/pages/jbang-template-add.adoc
@@ -8,12 +8,8 @@ jbang template add -- Add template for script reference.
 
 [source]
 ----
-jbang template add [-hgox] [-d=<description>] [--name=<name>] [--force] [-P=<property>] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <files>
+jbang template add [-hg] [-d=<description>] [--name=<name>] [--force] [-P=<property>] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <files>
 ----
-
-== DESCRIPTION
-
-Add template for script reference.
 
 == OPTIONS
 
@@ -44,19 +40,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-template-list.adoc
+++ b/docs/modules/cli/pages/jbang-template-list.adoc
@@ -8,12 +8,8 @@ jbang template list -- Lists locally defined templates or from the given catalog
 
 [source]
 ----
-jbang template list [-hgox] [--show-origin] [--show-files] [--show-properties] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [<name>]
+jbang template list [-hg] [--show-origin] [--show-files] [--show-properties] [--format=<format>] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [<name>]
 ----
-
-== DESCRIPTION
-
-Lists locally defined templates or from the given catalog.
 
 == OPTIONS
 
@@ -44,19 +40,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-template-remove.adoc
+++ b/docs/modules/cli/pages/jbang-template-remove.adoc
@@ -8,12 +8,8 @@ jbang template remove -- Remove existing template.
 
 [source]
 ----
-jbang template remove [-hgox] [-f=<file>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <name>
+jbang template remove [-hg] [-f=<file>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <name>
 ----
-
-== DESCRIPTION
-
-Remove existing template.
 
 == OPTIONS
 
@@ -32,19 +28,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-template.adoc
+++ b/docs/modules/cli/pages/jbang-template.adoc
@@ -8,12 +8,8 @@ jbang template -- Manage templates for scripts.
 
 [source]
 ----
-jbang template [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang template [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage templates for scripts.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-trust-add.adoc
+++ b/docs/modules/cli/pages/jbang-trust-add.adoc
@@ -8,12 +8,8 @@ jbang trust add -- Add trust domains.
 
 [source]
 ----
-jbang trust add [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <rules>
+jbang trust add [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <rules>
 ----
-
-== DESCRIPTION
-
-Add trust domains.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-trust-list.adoc
+++ b/docs/modules/cli/pages/jbang-trust-list.adoc
@@ -8,12 +8,8 @@ jbang trust list -- Show defined trust domains.
 
 [source]
 ----
-jbang trust list [-hox] [--format=<format>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang trust list [-h] [--format=<format>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Show defined trust domains.
 
 == OPTIONS
 
@@ -29,18 +25,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-trust-remove.adoc
+++ b/docs/modules/cli/pages/jbang-trust-remove.adoc
@@ -8,12 +8,8 @@ jbang trust remove -- Remove trust domains.
 
 [source]
 ----
-jbang trust remove [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] <rules>
+jbang trust remove [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] <rules>
 ----
-
-== DESCRIPTION
-
-Remove trust domains.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == ARGUMENTS

--- a/docs/modules/cli/pages/jbang-trust.adoc
+++ b/docs/modules/cli/pages/jbang-trust.adoc
@@ -8,12 +8,8 @@ jbang trust -- Manage which domains you trust to run scripts from.
 
 [source]
 ----
-jbang trust [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang trust [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage which domains you trust to run scripts from.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang-version.adoc
+++ b/docs/modules/cli/pages/jbang-version.adoc
@@ -8,12 +8,8 @@ jbang version -- Display version info.
 
 [source]
 ----
-jbang version [-hox] [--check] [--update] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang version [-h] [--check] [--update] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Display version info.
 
 == OPTIONS
 
@@ -32,18 +28,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-wrapper-install.adoc
+++ b/docs/modules/cli/pages/jbang-wrapper-install.adoc
@@ -8,12 +8,8 @@ jbang wrapper install -- Install/Setup jbang as a wrapper script in a folder
 
 [source]
 ----
-jbang wrapper install [-hfox] [-d=<dir>] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh]
+jbang wrapper install [-hf] [-d=<dir>] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace]
 ----
-
-== DESCRIPTION
-
-Install/Setup jbang as a wrapper script in a folder
 
 == OPTIONS
 
@@ -32,18 +28,18 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 

--- a/docs/modules/cli/pages/jbang-wrapper.adoc
+++ b/docs/modules/cli/pages/jbang-wrapper.adoc
@@ -8,12 +8,8 @@ jbang wrapper -- Manage jbang wrapper for a folder.
 
 [source]
 ----
-jbang wrapper [-hox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang wrapper [-h] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-Manage jbang wrapper for a folder.
 
 == OPTIONS
 
@@ -26,19 +22,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/docs/modules/cli/pages/jbang.adoc
+++ b/docs/modules/cli/pages/jbang.adoc
@@ -8,12 +8,8 @@ jbang -- jbang is a tool for building and running .java/.jsh scripts and jar pac
 
 [source]
 ----
-jbang [-hVox] [--config=<config>] [--insecure] [--verbose] [--quiet] [--fresh] [COMMAND]
+jbang [-hV] [--config=<config>] [--insecure] [--[no-]verbose] [--[no-]quiet] [--[no-]offline] [--[no-]fresh] [--[no-]stacktrace] [COMMAND]
 ----
-
-== DESCRIPTION
-
-jbang is a tool for building and running .java/.jsh scripts and jar packages.
 
 
   jbang init hello.java [args...]
@@ -43,19 +39,19 @@ Path to config file to be used instead of the default
 *--insecure*::
 Enable insecure trust of all SSL certificates.
 
-*--verbose*::
+*--[no-]verbose*::
 jbang will be verbose on what it does.
 
-*--quiet*::
+*--[no-]quiet*::
 jbang will be quiet, only print when error occurs.
 
-*-o*, *--offline*::
+*-o*, *--[no-]offline*::
 Work offline. Fail-fast if dependencies are missing.
 
-*--fresh*::
+*--[no-]fresh*::
 Make sure we use fresh (i.e. non-cached) resources.
 
-*-x*, *--stacktrace*::
+*-x*, *--[no-]stacktrace*::
 Print exceptions stacktraces to stderr (even when quiet).
 
 == COMMANDS

--- a/src/main/java/dev/jbang/cli/BuildMixin.java
+++ b/src/main/java/dev/jbang/cli/BuildMixin.java
@@ -26,7 +26,7 @@ public class BuildMixin {
 	@OptionList(shortName = 'C', name = "compile-option", description = "Options to pass to the compiler")
 	public List<String> compileOptions;
 
-	@OptionGroup(name = "manifest")
+	@OptionGroup(name = "manifest", description = "Add entry to the JAR manifest (e.g. --manifest=Main-Class=com.example.Main)")
 	public Map<String, String> manifestOptions;
 
 	@Option(name = "integrations", hasValue = false, negatable = true, description = "Enable or disable integration execution (default: true)")


### PR DESCRIPTION
The @OptionGroup for manifest had no description attribute, causing blank description lines in the generated CLI docs for all commands that include build options (export fatjar/maven/native, run, build, etc.).

Add description explaining the --manifestKey=Value syntax and regenerate all CLI reference pages.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
