### PR TITLE
fix: close DirectoryStream in ExternalCommandsProvider.listFiles (#2482)

### DIFF
--- a/src/main/java/dev/jbang/cli/ExternalCommandsProvider.java
+++ b/src/main/java/dev/jbang/cli/ExternalCommandsProvider.java
@@ -102,8 +102,8 @@ public class ExternalCommandsProvider implements HelpSectionProvider {
 	}
 
 	private static Stream<Path> listFiles(Path dir) {
-		try {
-			return Files.list(dir);
+		try (Stream<Path> files = Files.list(dir)) {
+			return files.collect(Collectors.toList()).stream();
 		} catch (IOException e) {
 			return Stream.empty();
 		}


### PR DESCRIPTION
Files.list() returns a Stream backed by a DirectoryStream that must be closed. The previous code returned the raw stream which leaked the underlying file handle when used inside flatMap. Collect into a list inside a try-with-resources to ensure the DirectoryStream is closed.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource handling and cleanup procedures for file operations. These enhancements ensure that file access operations properly release system resources after completion, preventing potential resource leaks and maintaining consistent application performance and stability during extended use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->