### PR TITLE
fix: use stream copy instead of transferFrom for service file merging.

### DIFF
--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -6,8 +6,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.*;
 import java.util.*;
 import java.util.function.Function;
@@ -416,9 +414,13 @@ public class Export extends BaseCommand {
 			}
 			if (zipEntry.getName().startsWith("META-INF/services/")) {
 				Util.verboseMsg("Merging service files: " + zipEntry.getName());
-				try (ReadableByteChannel readableByteChannel = Channels.newChannel(zipFile.getInputStream(zipEntry));
-						FileOutputStream fileOutputStream = new FileOutputStream(outFile.toFile(), true)) {
-					fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+				try (InputStream is = zipFile.getInputStream(zipEntry);
+						FileOutputStream fos = new FileOutputStream(outFile.toFile(), true)) {
+					byte[] buf = new byte[8192];
+					int n;
+					while ((n = is.read(buf)) != -1) {
+						fos.write(buf, 0, n);
+					}
 				}
 			} else {
 				Util.verboseMsg("Skipping duplicate file: " + zipEntry.getName());

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -9,12 +9,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.jar.Attributes;
 import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -589,6 +592,56 @@ public class TestExport extends BaseTest {
 		assertThat(result.err, containsString("DUMMY.SF"));
 		assertThat(result.err, containsString("DUMMY.DSA"));
 		assertThat(result.err, containsString("DUMMY.RSA"));
+	}
+
+	@Test
+	void testExportFatjarServiceFileMerging(@TempDir Path temp) throws Exception {
+		// Create two jars with overlapping META-INF/services/ entries
+		String serviceFile = "META-INF/services/com.example.Service";
+
+		Path jar1 = temp.resolve("dep1.jar");
+		try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar1.toFile()))) {
+			jos.putNextEntry(new ZipEntry(serviceFile));
+			jos.write("com.example.Impl1\n".getBytes());
+			jos.closeEntry();
+		}
+
+		Path jar2 = temp.resolve("dep2.jar");
+		try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar2.toFile()))) {
+			jos.putNextEntry(new ZipEntry(serviceFile));
+			jos.write("com.example.Impl2\n".getBytes());
+			jos.closeEntry();
+		}
+
+		// Create a script that depends on both jars
+		String code = "//DEPS " + jar1.toAbsolutePath() + "\n"
+				+ "//DEPS " + jar2.toAbsolutePath() + "\n"
+				+ "public class svctest { public static void main(String... a) {} }\n";
+		Path src = temp.resolve("svctest.java");
+		Util.writeString(src, code);
+
+		CaptureResult<Integer> result = checkedRun("export", "fatjar", src.toString());
+		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+
+		// Verify the merged service file contains both implementations
+		Path fatjar = cwdDir.resolve("svctest-fatjar.jar");
+		assertThat(fatjar.toFile(), anExistingFile());
+
+		try (JarInputStream jis = new JarInputStream(new FileInputStream(fatjar.toFile()))) {
+			java.util.jar.JarEntry entry;
+			String serviceContent = null;
+			while ((entry = jis.getNextJarEntry()) != null) {
+				if (serviceFile.equals(entry.getName())) {
+					byte[] buf = new byte[4096];
+					int n = jis.read(buf);
+					serviceContent = new String(buf, 0, n);
+					break;
+				}
+			}
+			assertThat("Service file should exist in fatjar", serviceContent, is(notNullValue()));
+			assertThat("Service file should contain Impl1", serviceContent, containsString("com.example.Impl1"));
+			assertThat("Service file should contain Impl2", serviceContent, containsString("com.example.Impl2"));
+		}
 	}
 
 }


### PR DESCRIPTION
… (#2481)

FileChannel.transferFrom with position 0 could overwrite existing content instead of appending on some platforms, even when the FileOutputStream was opened with append=true. Replace with plain stream copy which correctly appends to the output file.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
