### PR TITLE
build: upgrade to aesh 3.11 and readline-api 3.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,11 +156,11 @@ dependencies {
 	implementation 'org.jspecify:jspecify:1.0.0'
 	implementation 'org.apache.commons:commons-text:1.15.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'
-	implementation('org.aesh:aesh:3.10') {
+	implementation('org.aesh:aesh:3.11') {
 		exclude group: 'org.aesh', module: 'readline'
 	}
-	implementation 'org.aesh:readline-api:3.8'
-	annotationProcessor 'org.aesh:aesh-processor:3.10'
+	implementation 'org.aesh:readline-api:3.11'
+	annotationProcessor 'org.aesh:aesh-processor:3.11'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
 	implementation 'com.google.code.gson:gson:2.13.2'


### PR DESCRIPTION
Fixes fish shell completion not falling back to file completion when no candidates are returned (aesh#487). The generated fish completion script no longer uses the -f flag that suppressed default file completion.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
