### PR TITLE
fix: JDK26: Put modules required by JavaFX modules on the module-path

### DIFF
--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -5,13 +5,17 @@ import static dev.jbang.Settings.CP_SEPARATOR;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
@@ -93,18 +97,52 @@ public class ModularClassPath {
 
 				resolvePathsResult.getPathElements().forEach((key, value) -> pathElements.put(key.getPath(), value));
 
-				pathElements.forEach((k, v) -> {
-					if (v != null && v.name() != null && v.name().startsWith(JAVAFX_PREFIX)) {
-						// only JavaFX jars are required in the module-path
-						modulePaths.add(k);
-					} else {
-						// classpathElements.add(k);
+				// Index the resolved modules by name so we can follow `requires` edges.
+				Map<String, String> moduleNameToPath = new HashMap<>();
+				Map<String, JavaModuleDescriptor> moduleNameToDescriptor = new HashMap<>();
+				pathElements.forEach((path, descriptor) -> {
+					if (descriptor != null && descriptor.name() != null) {
+						moduleNameToPath.put(descriptor.name(), path);
+						moduleNameToDescriptor.put(descriptor.name(), descriptor);
 					}
 				});
 
+				// Start from the JavaFX modules and transitively collect everything they
+				// require. This way modules like `jdk.jsobject` (required by `javafx.web`)
+				// also end up on the module-path instead of the class-path, where the boot
+				// layer would not find them. See https://github.com/jbangdev/jbang/issues/559
+				Set<String> requiredModules = new HashSet<>();
+				Deque<String> toVisit = new ArrayDeque<>();
+				moduleNameToDescriptor.keySet()
+					.stream()
+					.filter(name -> name.startsWith(JAVAFX_PREFIX))
+					.forEach(toVisit::add);
+				while (!toVisit.isEmpty()) {
+					String name = toVisit.poll();
+					if (!requiredModules.add(name)) {
+						continue;
+					}
+					JavaModuleDescriptor descriptor = moduleNameToDescriptor.get(name);
+					if (descriptor != null) {
+						descriptor.requires()
+							.stream()
+							.map(JavaModuleDescriptor.JavaRequires::name)
+							.filter(moduleNameToDescriptor::containsKey)
+							.forEach(toVisit::add);
+					}
+				}
+
+				// Put the JavaFX modules and their required modules on the module-path.
+				requiredModules.stream()
+					.map(moduleNameToPath::get)
+					.filter(Objects::nonNull)
+					.forEach(modulePaths::add);
+
 				if (!modulePaths.isEmpty()) {
 					commandArguments.add("--module-path");
-					String modulePath = String.join(File.pathSeparator, modulePaths);
+					String modulePath = modulePaths.stream()
+						.distinct()
+						.collect(Collectors.joining(File.pathSeparator));
 					commandArguments.add(modulePath);
 				}
 

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -5,17 +5,13 @@ import static dev.jbang.Settings.CP_SEPARATOR;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
@@ -29,6 +25,9 @@ import dev.jbang.util.Util;
 
 public class ModularClassPath {
 	static final String JAVAFX_PREFIX = "javafx";
+	// Required by `javafx.web`; removed from the JDK in 26 and now shipped as
+	// `org.openjfx:jdk-jsobject`.
+	static final String JDK_JSOBJECT_MODULE = "jdk.jsobject";
 
 	private final List<ArtifactInfo> artifacts;
 
@@ -97,52 +96,25 @@ public class ModularClassPath {
 
 				resolvePathsResult.getPathElements().forEach((key, value) -> pathElements.put(key.getPath(), value));
 
-				// Index the resolved modules by name so we can follow `requires` edges.
-				Map<String, String> moduleNameToPath = new HashMap<>();
-				Map<String, JavaModuleDescriptor> moduleNameToDescriptor = new HashMap<>();
-				pathElements.forEach((path, descriptor) -> {
-					if (descriptor != null && descriptor.name() != null) {
-						moduleNameToPath.put(descriptor.name(), path);
-						moduleNameToDescriptor.put(descriptor.name(), descriptor);
+				pathElements.forEach((k, v) -> {
+					if (v != null && v.name() != null
+							&& (v.name().startsWith(JAVAFX_PREFIX) || v.name().equals(JDK_JSOBJECT_MODULE))) {
+						// JavaFX jars belong on the module-path. So does `jdk.jsobject`, which is
+						// required by `javafx.web`: until JDK 25 it was part of the JDK, but JDK 26
+						// removed it and openjfx now ships it as the separate
+						// `org.openjfx:jdk-jsobject`
+						// artifact. Left on the class-path the boot layer cannot find it and fails with
+						// `Module jdk.jsobject not found, required by javafx.web`.
+						// See https://github.com/jbangdev/jbang/issues/559
+						modulePaths.add(k);
+					} else {
+						// classpathElements.add(k);
 					}
 				});
 
-				// Start from the JavaFX modules and transitively collect everything they
-				// require. This way modules like `jdk.jsobject` (required by `javafx.web`)
-				// also end up on the module-path instead of the class-path, where the boot
-				// layer would not find them. See https://github.com/jbangdev/jbang/issues/559
-				Set<String> requiredModules = new HashSet<>();
-				Deque<String> toVisit = new ArrayDeque<>();
-				moduleNameToDescriptor.keySet()
-					.stream()
-					.filter(name -> name.startsWith(JAVAFX_PREFIX))
-					.forEach(toVisit::add);
-				while (!toVisit.isEmpty()) {
-					String name = toVisit.poll();
-					if (!requiredModules.add(name)) {
-						continue;
-					}
-					JavaModuleDescriptor descriptor = moduleNameToDescriptor.get(name);
-					if (descriptor != null) {
-						descriptor.requires()
-							.stream()
-							.map(JavaModuleDescriptor.JavaRequires::name)
-							.filter(moduleNameToDescriptor::containsKey)
-							.forEach(toVisit::add);
-					}
-				}
-
-				// Put the JavaFX modules and their required modules on the module-path.
-				requiredModules.stream()
-					.map(moduleNameToPath::get)
-					.filter(Objects::nonNull)
-					.forEach(modulePaths::add);
-
 				if (!modulePaths.isEmpty()) {
 					commandArguments.add("--module-path");
-					String modulePath = modulePaths.stream()
-						.distinct()
-						.collect(Collectors.joining(File.pathSeparator));
+					String modulePath = String.join(File.pathSeparator, modulePaths);
 					commandArguments.add(modulePath);
 				}
 


### PR DESCRIPTION
This adresses https://github.com/jbangdev/jbang/issues/559#issuecomment-4610215903

IMHO required by [JDK-8359760](https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8359760). See 

Code 100% authored and tested w/ JabRef by Claude Code. Guided by me.

---

## Problem

JBang only promotes jars whose module name starts with `javafx` to the
`--module-path`; everything else stays on the class-path. That breaks when a
JavaFX module `requires` a non-`javafx` module shipped as a separate artifact:
`javafx.web` requires `jdk.jsobject` (org.openjfx:jdk-jsobject), which then
stays on the class-path and the boot layer fails:

      java.lang.module.FindException: Module jdk.jsobject not found, required by javafx.web

## Fix

After detecting the JavaFX modules, follow their `requires` edges transitively
and put every required module that is part of the resolved artifacts on the
module-path as well. `--add-modules` is unchanged (the JavaFX roots pull in
`jdk.jsobject` transitively once it is on the module-path).

## Verification

- `./gradlew spotlessApply build` green; `TestRun.testJavaFX*` (4) green.
- installDist run of an unmodified JabRef `jabkit` JBang launcher on JDK 26: