### PR TITLE
fix: restore multi-JDK features lost in aesh migration

### DIFF
--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.SerializedName;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
+import dev.jbang.devkitman.JdkDistroQuery;
 import dev.jbang.devkitman.JdkManager;
 import dev.jbang.devkitman.JdkProvider;
 import dev.jbang.util.CommandBuffer;
@@ -162,6 +163,12 @@ public class Jdk extends BaseCommand {
 		@Option(shortName = 'a', name = "available", hasValue = false, description = "Shows versions available for installation")
 		boolean available;
 
+		@Option(shortName = 'P', name = "providers", hasValue = false, description = "Shows available providers")
+		boolean listProviders;
+
+		@Option(shortName = 'D', name = "distros", hasValue = false, description = "Shows distributions available for installation")
+		boolean listDistros;
+
 		@Option(shortName = 'd', name = "show-details", aliases = {
 				"details" }, hasValue = false, description = "Shows detailed information for each JDK (only when format=text)")
 		boolean details;
@@ -173,24 +180,58 @@ public class Jdk extends BaseCommand {
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk defaultJdk = jdkMan.getDefaultJdk();
-			int defMajorVersion = defaultJdk != null ? defaultJdk.majorVersion() : 0;
+			String defVersion = defaultJdk != null ? defaultJdk.version() : "";
 			PrintStream out = System.out;
-			List<? extends dev.jbang.devkitman.Jdk> jdks;
-			if (available) {
-				jdks = jdkMan.listAvailableJdks();
-			} else {
-				jdks = jdkMan.listInstalledJdks();
+
+			if (listProviders) {
+				List<JdkProvider> providers = new ArrayList<>(jdkMan.providers());
+				providers.sort(Comparator.comparing(JdkProvider::name));
+				if (format == OutputFormat.json) {
+					Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+					parser.toJson(providers, out);
+				} else {
+					out.println("Available JDK Providers:");
+					providers.forEach(p -> out.println("   " + p.name()));
+				}
+				return EXIT_OK;
+			} else if (listDistros) {
+				List<JdkDistroQuery.JdkDistro> distros = jdkMan.listDistros();
+				distros.sort(Comparator.comparing(JdkDistroQuery.JdkDistro::name));
+				if (format == OutputFormat.json) {
+					Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
+					parser.toJson(distros, out);
+				} else {
+					out.println("Available JDK Distributions:");
+					distros.forEach(d -> out.println("   " + d.name()));
+				}
+				return EXIT_OK;
 			}
-			List<JdkOut> jdkOuts = jdks.stream()
-				.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
-						jdk.isInstalled() ? ((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).home() : null,
-						null,
-						details ? jdk.equals(defaultJdk)
-								: jdk.majorVersion() == defMajorVersion,
-						jdk.tags()))
-				.collect(Collectors.toList());
+
+			List<JdkOut> jdkOuts;
+			if (available) {
+				List<dev.jbang.devkitman.Jdk.AvailableJdk> jdks = jdkMan.listAvailableJdks();
+				jdkOuts = jdks.stream()
+					.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
+							null, null,
+							details ? jdk.equals(defaultJdk)
+									: jdk.version().equals(defVersion),
+							jdk.tags()))
+					.collect(Collectors.toList());
+			} else {
+				List<dev.jbang.devkitman.Jdk.InstalledJdk> jdks = jdkMan.listInstalledJdks();
+				jdkOuts = jdks.stream()
+					.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
+							jdk.home(),
+							jdk instanceof dev.jbang.devkitman.Jdk.LinkedJdk
+									? ((dev.jbang.devkitman.Jdk.LinkedJdk) jdk).linked().id()
+									: null,
+							details ? jdk.equals(defaultJdk)
+									: jdk.version().equals(defVersion),
+							jdk.tags()))
+					.collect(Collectors.toList());
+			}
 			if (!details) {
-				// Only keep a list of unique major versions
+				// Only keep a list of unique versions
 				Set<JdkOut> uniqueJdks = new TreeSet<>(Comparator.<JdkOut>comparingInt(j -> j.version).reversed());
 				uniqueJdks.addAll(jdkOuts);
 				jdkOuts = new ArrayList<>(uniqueJdks);
@@ -207,12 +248,17 @@ public class Jdk extends BaseCommand {
 						out.print("   ");
 						out.print(jdk.version);
 						out.print(" (");
-						out.print(jdk.fullVersion);
 						if (details) {
+							out.print(jdk.fullVersion);
 							out.print(", " + jdk.providerName + ", " + jdk.id);
 							if (jdk.javaHomeDir != null) {
 								out.print(", " + jdk.javaHomeDir);
 							}
+							if (!jdk.tags.isEmpty()) {
+								out.print(", " + jdk.tags);
+							}
+						} else {
+							out.print(available ? jdk.id : jdk.fullVersion);
 						}
 						out.print(")");
 						if (!available) {
@@ -243,13 +289,18 @@ public class Jdk extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
+			// This will first select for JDKs from providers that can actually install JDKs
 			dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getInstalledJdk(versionOrId,
-					JdkProvider.Predicates.canUpdate);
+					JdkProvider.Predicates.canInstall);
 			if (jdk == null) {
-				throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
+				// If necessary we select JDKs from providers that can update JDKs
+				jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canUpdate);
+				if (jdk == null) {
+					throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
+				}
 			}
 			jdk.uninstall();
-			Util.infoMsg("Uninstalled JDK:\n  " + versionOrId);
+			Util.infoMsg("Uninstalled JDK:\n  " + jdk.id());
 			return EXIT_OK;
 		}
 	}
@@ -291,7 +342,7 @@ public class Jdk extends BaseCommand {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk jdk = null;
 			if (versionOrId != null && JavaUtil.isRequestedVersion(versionOrId)) {
-				jdk = jdkMan.getJdk(versionOrId, JdkProvider.Predicates.canUpdate);
+				jdk = jdkMan.getJdk(versionOrId, JdkProvider.Predicates.canInstall);
 			}
 			if (jdk == null || !jdk.isInstalled()) {
 				jdk = jdkMan.getOrInstallJdk(versionOrId);

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -324,6 +324,23 @@ public class TestJdk extends BaseTest {
 	}
 
 	@Test
+	void testJdkInstallWithLinkingAndIntegerId() {
+		assertThrows(IllegalArgumentException.class,
+				() -> checkedRun("install", "--force", "11", "/non-existent-path"),
+				"When providing an existing JDK path, the versionOrId parameter must be a non-integer id");
+	}
+
+	@Test
+	void testJdkInstallWithLinkingToExistingJBangJdkPath() {
+		final Path jdkPath = Settings.getCacheDir(Cache.CacheClass.jdks).resolve("11");
+		initMockJdkDir(jdkPath, "11.0.14");
+
+		assertThrows(IllegalArgumentException.class,
+				() -> checkedRun("install", "my11", jdkPath.toString()),
+				"The provided path cannot point to a JBang managed JDK");
+	}
+
+	@Test
 	void testJdkInstallWithLinkingToExistingJdkPathWithDifferentVersion(@TempDir File javaDir) {
 		initMockJdkDir(javaDir.toPath(), "11.0.14");
 
@@ -361,6 +378,30 @@ public class TestJdk extends BaseTest {
 				containsString("JDK my11-linked has been linked to: " + jdkOk));
 		assertTrue(Util.isLink(jdkPath.resolve("my11-linked")));
 		assertTrue(Files.isSameFile(jdkOk, (jdkPath.resolve("my11-linked").toRealPath())));
+	}
+
+	@Test
+	void testJdkInstallSameVersion() throws Exception {
+		Arrays.asList(11).forEach(TestJdk::createMockJdk);
+
+		CaptureResult<Integer> result = checkedRun("install", "11");
+
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.normalizedErr(), containsString("JDK is already installed"));
+		assertThat(result.normalizedErr(), containsString("Use --force to install anyway"));
+	}
+
+	@Test
+	void testJdkInstallSameVersionForced() throws Exception {
+		Arrays.asList(11).forEach(TestJdk::createMockJdk);
+		Path jdkPath = Settings.getCacheDir(Cache.CacheClass.jdks);
+
+		CaptureResult<Integer> result = checkedRun("install", "--force", "11");
+
+		assertThat(result.result, equalTo(SUCCESS_EXIT));
+		assertThat(result.normalizedErr(), containsString("Installing Mock JDK 11.1"));
+		assertTrue(Files.isDirectory(jdkPath.resolve("11.1")));
+		assertTrue(Util.isLink(jdkPath.resolve("11")));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

PR #2271 (*feat: install multiple JDKs with same major version*) was merged on May 14, but several of its features were lost when PR #2453 (aesh migration) was squash-merged on June 3. The aesh migration rewrote `Jdk.java` from picocli to aesh annotations but didn't preserve all the behavioral changes from #2271.

## What was lost and is now restored

### `Jdk.java` — 7 fixes

| Feature | What happened |
|---|---|
| `jdk list --providers/-P` | Entire option + handler deleted |
| `jdk list --distros/-D` | Entire option + handler deleted, `JdkDistroQuery` import dropped |
| Full version comparison (`defVersion` string) | Reverted to `defMajorVersion` int — breaks default marker with multiple JDKs of same major version |
| Separate available/installed mapping | Collapsed to single path; `linkedId` always null, no `LinkedJdk` detection |
| Tag display in list output | Dropped from text output |
| `jdk uninstall` two-pass (`canInstall` → `canUpdate`) | Replaced with single `canUpdate`; info message uses raw input instead of `jdk.id()` |
| `jdk java-env` uses `canInstall` | Reverted to `canUpdate` |

### `TestJdk.java` — 4 restored tests

| Test | What it covers |
|---|---|
| `testJdkInstallWithLinkingAndIntegerId` | Integer ID rejection when linking |
| `testJdkInstallWithLinkingToExistingJBangJdkPath` | JBang-managed path rejection |
| `testJdkInstallSameVersion` | "Already installed" message |
| `testJdkInstallSameVersionForced` | `--force` creates versioned dir + symlink (core multi-JDK feature) |

## Verification

All 30 TestJdk tests pass (including the 4 restored ones), plus TestRun (124) and TestProject (9) — zero failures.