### PR TITLE
build: add 'just shell' recipe for isolated completion testing

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -33,6 +33,12 @@ itest *args:
 jbang *args:
     PATH="build/install/jbang/bin:$PATH" jbang {{args}}
 
+# open interactive shell with jbang completion (zsh, bash, or fish)
+[no-exit-message]
+shell sh="zsh":
+    {{preitest}}
+    @"{{justfile_directory()}}/misc/dev-shell.sh" "{{sh}}" "{{justfile_directory()}}/build/install/jbang/bin"
+
 jbangdebug *args:
     JBANG_JAVA_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044 PATH="build/install/jbang/bin:$PATH" jbang {{args}}
 

--- a/misc/dev-shell.sh
+++ b/misc/dev-shell.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Launch an isolated shell with the local jbang build on PATH and completions loaded.
+# Usage: dev-shell.sh <zsh|bash|fish> <path-to-jbang-bin>
+set -euo pipefail
+
+SHELL_TYPE="${1:?Usage: dev-shell.sh <zsh|bash|fish> <jbang-bin-dir>}"
+JBANG_BIN="${2:?Usage: dev-shell.sh <zsh|bash|fish> <jbang-bin-dir>}"
+
+dir=$(mktemp -d)
+trap 'rm -rf "$dir"' EXIT
+
+case "$SHELL_TYPE" in
+zsh)
+  "$JBANG_BIN/jbang" completion -s zsh > "$dir/_jbang"
+  cat > "$dir/.zshrc" <<EOF
+autoload -Uz compinit
+fpath=("$dir" \$fpath)
+compinit -d "$dir/.zcompdump"
+export PATH="$JBANG_BIN:\$PATH"
+export PS1="(jbang-dev) %~ %# "
+EOF
+  echo "Entering zsh with jbang completions. Exit with 'exit'."
+  ZDOTDIR="$dir" exec zsh -i
+  ;;
+bash)
+  "$JBANG_BIN/jbang" completion -s bash > "$dir/jbang-completion.bash"
+  cat > "$dir/.bashrc" <<EOF
+source "$dir/jbang-completion.bash"
+export PATH="$JBANG_BIN:\$PATH"
+export PS1="(jbang-dev) \w \$ "
+EOF
+  echo "Entering bash with jbang completions. Exit with 'exit'."
+  exec bash --rcfile "$dir/.bashrc"
+  ;;
+fish)
+  mkdir -p "$dir/fish/completions" "$dir/fish/conf.d"
+  "$JBANG_BIN/jbang" completion -s fish > "$dir/fish/completions/jbang.fish"
+  cat > "$dir/fish/conf.d/jbang.fish" <<EOF
+set -gx PATH "$JBANG_BIN" \$PATH
+function fish_prompt; echo "(jbang-dev) "(prompt_pwd)" > "; end
+EOF
+  echo "Entering fish with jbang completions. Exit with 'exit'."
+  XDG_CONFIG_HOME="$dir" exec fish -i
+  ;;
+*)
+  echo "Unknown shell: $SHELL_TYPE. Use zsh, bash, or fish."
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
## Summary

Adds a `just shell [zsh|bash|fish]` recipe that launches an isolated interactive shell with the local jbang build on PATH and tab completions pre-loaded — for testing completion without modifying user config.

## Usage

```bash
just shell         # zsh (default)
just shell bash    # bash
just shell fish    # fish
```

## How it works

- Auto-builds (`installDist`) if the build directory does not exist
- Creates a temp directory with a minimal shell rc file that:
  - Sources completion from `jbang completion -s <shell>`
  - Prepends the local build to `$PATH`
  - Sets a `(jbang-dev)` prompt
- Launches the shell with isolated config (`ZDOTDIR` for zsh, `--rcfile` for bash, `XDG_CONFIG_HOME` for fish)
- Temp files are cleaned up on exit

No user dotfiles are modified.

## Files

- `.justfile` — new `shell` recipe
- `misc/dev-shell.sh` — shell launcher script
