### PR TITLE
build: upgrade to aesh 3.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,11 +156,11 @@ dependencies {
 	implementation 'org.jspecify:jspecify:1.0.0'
 	implementation 'org.apache.commons:commons-text:1.15.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'
-	implementation('org.aesh:aesh:3.11') {
+	implementation('org.aesh:aesh:3.12.1') {
 		exclude group: 'org.aesh', module: 'readline'
 	}
 	implementation 'org.aesh:readline-api:3.11'
-	annotationProcessor 'org.aesh:aesh-processor:3.11'
+	annotationProcessor 'org.aesh:aesh-processor:3.12.1'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
 	implementation 'com.google.code.gson:gson:2.13.2'

--- a/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
+++ b/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
@@ -33,18 +33,6 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			return null;
 		}
 
-		// Skip config defaults for inherited options on child commands.
-		// The root command (JBang) will get the config default and handle
-		// it in afterParse(). Without this guard, a child command's config
-		// default (e.g. verbose=true) would override a CLI flag like
-		// --no-verbose that was already processed by the parent.
-		if (option.isInherited()
-				&& option.parent() != null
-				&& option.parent().getCommand() != null
-				&& !(option.parent().getCommand() instanceof JBang)) {
-			return null;
-		}
-
 		String optName = option.name().replace("-", "");
 		String fullPath = null;
 


### PR DESCRIPTION
Fixes:
- jdk command aliases not working (#2512)
- NO_COLOR environment variable support
- Completion descriptions for all options and group subcommands
- Sorted completion candidates
- Fish completion file fallback via __fish_complete_path
- --manifest=Key=Value backwards-compatible syntax

Cleanup:
- Remove inherited options guard from JBangDefaultValueProvider, now handled natively by aesh (aesh#488)


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
