### PR TITLE
test: add ArchUnit rule to prevent primitive types on @Option fields + fix object versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,7 @@ dependencies {
 	testImplementation "com.github.stefanbirkner:system-rules:1.17.2"
 	testImplementation "org.assertj:assertj-core:${assertjVersion}"
 	testImplementation "org.hamcrest:hamcrest-library:2.2"
+	testImplementation "com.tngtech.archunit:archunit-junit5:1.4.0"
 	testImplementation "org.wiremock:wiremock:${wiremockVersion}"
 	testImplementation platform("io.qameta.allure:allure-bom:$allureVersion")
 	testImplementation "io.qameta.allure:allure-junit5"

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -65,7 +65,7 @@ public class Alias extends BaseCommand {
 		String name;
 
 		@Option(name = "force", hasValue = false, description = "Force overwriting of existing alias")
-		boolean force;
+		Boolean force;
 
 		@Option(name = "enable-preview", hasValue = false, description = "Activate Java preview features")
 		Boolean enablePreviewRequested;
@@ -113,7 +113,7 @@ public class Alias extends BaseCommand {
 					runMixin.enableSystemAssertions,
 					buildMixin.manifestOptions, createJavaAgents(), docs, null);
 			Path catFile = catalogOptions.getCatalogOrDefault();
-			if (force || !CatalogUtil.hasAlias(catFile, name)) {
+			if (Boolean.TRUE.equals(force) || !CatalogUtil.hasAlias(catFile, name)) {
 				CatalogUtil.addAlias(catFile, name, alias);
 			} else {
 				Util.infoMsg("A script with name '" + name + "' already exists, use '--force' to add anyway.");
@@ -166,7 +166,7 @@ public class Alias extends BaseCommand {
 		CatalogFileOptionsMixin catalogOptions;
 
 		@Option(name = "show-origin", hasValue = false, description = "Show the origin of the alias")
-		boolean showOrigin;
+		Boolean showOrigin;
 
 		@Argument(paramLabel = "catalogName", index = "0", arity = "0..1", description = "The name of a catalog")
 		String catalogName;
@@ -188,7 +188,7 @@ public class Alias extends BaseCommand {
 			} else {
 				catalog = Catalog.getMerged(true, false);
 			}
-			if (showOrigin) {
+			if (Boolean.TRUE.equals(showOrigin)) {
 				printAliasesWithOrigin(out, catalogName, catalog, format);
 			} else {
 				printAliases(out, catalogName, catalog, format);

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -68,10 +68,10 @@ public class App extends BaseCommand {
 		RunMixin runMixin;
 
 		@Option(name = "force", hasValue = false, description = "Force re-installation")
-		boolean force;
+		Boolean force;
 
 		@Option(name = "no-build", hasValue = false, description = "Don't pre-build the code before installation")
-		boolean noBuild;
+		Boolean noBuild;
 
 		@Option(name = "name", description = "A name for the command")
 		String name;
@@ -98,7 +98,7 @@ public class App extends BaseCommand {
 						throw new ExitException(EXIT_INVALID_INPUT,
 								"It's not possible to install jbang with a different name");
 					}
-					installed = installJBang(force);
+					installed = installJBang(Boolean.TRUE.equals(force));
 				} else {
 					if ("jbang".equals(name)) {
 						throw new ExitException(EXIT_INVALID_INPUT, "jbang is a reserved name.");
@@ -134,7 +134,7 @@ public class App extends BaseCommand {
 
 		public boolean install() throws IOException {
 			Path binDir = Settings.getConfigBinDir();
-			if (!force && name != null && existScripts(binDir, name)) {
+			if (!Boolean.TRUE.equals(force) && name != null && existScripts(binDir, name)) {
 				Util.infoMsg("A script with name '" + name + "' already exists, use '--force' to install anyway.");
 				return false;
 			}
@@ -143,7 +143,7 @@ public class App extends BaseCommand {
 			Project prj = pb.build(scriptRef);
 			if (name == null) {
 				name = CatalogUtil.nameFromRef(scriptRef);
-				if (!force && existScripts(binDir, name)) {
+				if (!Boolean.TRUE.equals(force) && existScripts(binDir, name)) {
 					Util.infoMsg("A script with name '" + name + "' already exists, use '--force' to install anyway.");
 					return false;
 				}
@@ -152,7 +152,7 @@ public class App extends BaseCommand {
 					&& !prj.getResourceRef().isURL()) {
 				scriptRef = prj.getResourceRef().getFile().toAbsolutePath().toString();
 			}
-			if (!noBuild) {
+			if (!Boolean.TRUE.equals(noBuild)) {
 				prj.codeBuilder().build();
 			}
 			installScripts(name, scriptRef, collectRunOptions(), userParams);
@@ -369,7 +369,7 @@ public class App extends BaseCommand {
 		Boolean java;
 
 		@Option(name = "force", hasValue = false, description = "Force setup to be performed even when existing configuration has been detected")
-		boolean force;
+		Boolean force;
 
 		@Override
 		public Integer doCall() throws IOException {
@@ -379,7 +379,7 @@ public class App extends BaseCommand {
 			} else {
 				withJava = java;
 			}
-			return setup(withJava, force, true);
+			return setup(withJava, Boolean.TRUE.equals(force), true);
 		}
 
 		public static boolean needsSetup() {

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -39,7 +39,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 	String configPath;
 
 	@Option(name = "insecure", hasValue = false, description = "Enable insecure trust of all SSL certificates.")
-	boolean insecure;
+	Boolean insecure;
 
 	@Option(name = "verbose", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"quiet" }, description = "jbang will be verbose on what it does.")
@@ -190,7 +190,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 			}
 		}
 
-		if (insecure) {
+		if (Boolean.TRUE.equals(insecure)) {
 			enableInsecure();
 		}
 	}

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -49,14 +49,14 @@ public class Cache extends BaseCommand {
 		Boolean stdin;
 
 		@Option(name = "all", hasValue = false, description = "clear all caches")
-		boolean all;
+		Boolean all;
 
 		@Override
 		public Integer doCall() {
 			EnumSet<dev.jbang.Cache.CacheClass> classes = EnumSet.noneOf(dev.jbang.Cache.CacheClass.class);
 
 			// if all we add everything
-			if (all) {
+			if (Boolean.TRUE.equals(all)) {
 				classes.addAll(Arrays.asList(dev.jbang.Cache.CacheClass.values()));
 			} else if (url == null
 					&& jar == null

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -49,7 +49,7 @@ public class Catalog extends BaseCommand {
 		String name;
 
 		@Option(name = "force", hasValue = false, description = "Force overwriting of existing catalog")
-		boolean force;
+		Boolean force;
 
 		@Option(name = "import", description = "Import catalog items into the catalog's scope")
 		Boolean importItems;
@@ -68,7 +68,7 @@ public class Catalog extends BaseCommand {
 			}
 			CatalogRef ref = CatalogRef.get(urlOrFile);
 			Path catFile = catalogOptions.getCatalogOrDefault();
-			if (force || !CatalogUtil.hasCatalogRef(catFile, name)) {
+			if (Boolean.TRUE.equals(force) || !CatalogUtil.hasCatalogRef(catFile, name)) {
 				CatalogUtil.addCatalogRef(catFile, name, ref.catalogRef, ref.description, importItems);
 			} else {
 				Util.infoMsg("A catalog with name '" + name + "' already exists, use '--force' to add anyway.");
@@ -109,7 +109,7 @@ public class Catalog extends BaseCommand {
 	public static class CatalogList extends BaseCatalogCommand {
 
 		@Option(name = "show-origin", hasValue = false, description = "Show the origin of the catalog")
-		boolean showOrigin;
+		Boolean showOrigin;
 
 		@Argument(paramLabel = "name", description = "The name of a catalog")
 		String name;
@@ -130,7 +130,7 @@ public class Catalog extends BaseCommand {
 				} else {
 					catalog = dev.jbang.catalog.Catalog.getMerged(true, false);
 				}
-				if (showOrigin) {
+				if (Boolean.TRUE.equals(showOrigin)) {
 					printCatalogsWithOrigin(out, name, catalog, format);
 				} else {
 					printCatalogs(out, name, catalog, format);

--- a/src/main/java/dev/jbang/cli/CatalogFileOptionsMixin.java
+++ b/src/main/java/dev/jbang/cli/CatalogFileOptionsMixin.java
@@ -11,7 +11,7 @@ import dev.jbang.catalog.Catalog;
 public class CatalogFileOptionsMixin {
 
 	@Option(shortName = 'g', name = "global", hasValue = false, description = "Use the global (user) catalog file")
-	boolean global;
+	Boolean global;
 
 	@Option(shortName = 'f', name = "file", description = "Path to the catalog file to use")
 	Path catalogFile;
@@ -23,7 +23,7 @@ public class CatalogFileOptionsMixin {
 
 	public Path getCatalog(boolean strict) {
 		Path cat;
-		if (global) {
+		if (Boolean.TRUE.equals(global)) {
 			cat = Settings.getUserCatalogFile();
 		} else {
 			Path catPath = catalogFile;

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -43,7 +43,7 @@ public class Config extends BaseCommand {
 	static abstract class BaseConfigCommand extends BaseCommand {
 
 		@Option(shortName = 'g', name = "global", hasValue = false, description = "Use the global (user) config file")
-		boolean global;
+		Boolean global;
 
 		@Option(shortName = 'f', name = "file", description = "Path to the config file to use")
 		Path configFile;
@@ -59,7 +59,7 @@ public class Config extends BaseCommand {
 
 		protected Path getConfigFile(boolean strict) {
 			Path cfg;
-			if (global) {
+			if (Boolean.TRUE.equals(global)) {
 				cfg = Settings.getUserConfigFile();
 			} else {
 				Path cfgPath = configFile;
@@ -169,10 +169,10 @@ public class Config extends BaseCommand {
 	@CommandDefinition(name = "list", description = "List active configuration values", generateHelp = true)
 	public static class ConfigList extends BaseConfigCommand {
 		@Option(name = "show-origin", hasValue = false, description = "Show the origin of the configuration")
-		boolean showOrigin;
+		Boolean showOrigin;
 
 		@Option(name = "show-available", hasValue = false, description = "Show the available key names")
-		boolean showAvailable;
+		Boolean showAvailable;
 
 		@Option(name = "format", description = "Specify output format ('text' or 'json')")
 		OutputFormat format;
@@ -180,11 +180,11 @@ public class Config extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			PrintStream out = System.out;
-			if (showAvailable && showOrigin) {
+			if (Boolean.TRUE.equals(showAvailable) && Boolean.TRUE.equals(showOrigin)) {
 				throw new ExitException(EXIT_INVALID_INPUT,
 						"Options '--show-available' and '--show-origin' cannot be used together");
 			}
-			if (showAvailable) {
+			if (Boolean.TRUE.equals(showAvailable)) {
 				Set<AvailableOption> opts = new HashSet<>(Arrays.asList(Config.extraOptions));
 				gatherKeys(JBang.class, opts);
 				if (format == OutputFormat.json) {
@@ -199,7 +199,7 @@ public class Config extends BaseCommand {
 				}
 			} else {
 				Configuration cfg = getConfig(null, true);
-				if (showOrigin) {
+				if (Boolean.TRUE.equals(showOrigin)) {
 					printConfigWithOrigin(out, cfg, format);
 				} else {
 					printConfig(out, cfg, format);

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -26,7 +26,7 @@ public class DependencyInfoMixin {
 
 	@Option(name = "ignore-transitive-repositories", aliases = {
 			"itr" }, hasValue = false, description = "Ignore remote repositories found in transitive dependencies")
-	boolean ignoreTransitiveRepositories;
+	Boolean ignoreTransitiveRepositories;
 
 	public Map<String, String> getProperties() {
 		return properties != null && properties.isEmpty() ? null : properties;
@@ -45,7 +45,7 @@ public class DependencyInfoMixin {
 	}
 
 	public void applyIgnoreTransitiveRepositories() {
-		if (ignoreTransitiveRepositories) {
+		if (Boolean.TRUE.equals(ignoreTransitiveRepositories)) {
 			Util.setIgnoreTransitiveRepositories(true);
 		}
 	}

--- a/src/main/java/dev/jbang/cli/Deps.java
+++ b/src/main/java/dev/jbang/cli/Deps.java
@@ -35,7 +35,7 @@ public class Deps extends BaseCommand {
 	public static class DepsSearch extends BaseCommand {
 
 		@Option(name = "max", description = "Maximum number of results to return.", defaultValue = "100")
-		int max;
+		Integer max;
 
 		@Option(shortName = 'q', name = "query", description = "Artifact pattern to search for.")
 		String query;

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -69,16 +69,16 @@ public class Edit extends BaseCommand {
 	}
 
 	@Option(name = "live", hasValue = false, description = "Open directory in IDE's that support JBang or generate temporary project with option to regenerate project on dependency changes.")
-	public boolean live;
+	public Boolean live;
 
 	@Option(name = "open", fallbackValue = "", description = "Opens editor/IDE on the temporary project.")
 	public String editor;
 
 	@Option(name = "no-open", hasValue = false, description = "Explicitly prevent JBang from opening an editor/IDE")
-	public boolean noOpen;
+	public Boolean noOpen;
 
 	@Option(shortName = 'b', name = "sandbox", hasValue = false, description = "Edit in sandbox mode. Useful when the editor/IDE used has no JBang support")
-	boolean sandbox;
+	Boolean sandbox;
 
 	/**
 	 * Returns a parent path if one of the targetFileNames exist in such parent.
@@ -160,7 +160,7 @@ public class Edit extends BaseCommand {
 			additionalFiles = new ArrayList<>();
 		}
 
-		if (!sandbox) {
+		if (!Boolean.TRUE.equals(sandbox)) {
 			File location;
 			if (scriptMixin.scriptOrFile != null) {
 				location = new File(scriptMixin.scriptOrFile);
@@ -179,7 +179,7 @@ public class Edit extends BaseCommand {
 				additionalFiles.add(0, pathToString(location.toPath()));
 			}
 
-			if (!noOpen) {
+			if (!Boolean.TRUE.equals(noOpen)) {
 				openEditor(pathToString(path), additionalFiles);
 			}
 			System.out.println(path);
@@ -197,11 +197,11 @@ public class Edit extends BaseCommand {
 			Path project = createProjectForLinkedEdit(prj, Collections.emptyList(), false);
 			String projectPathString = pathToString(project.toAbsolutePath());
 
-			if (!noOpen) {
+			if (!Boolean.TRUE.equals(noOpen)) {
 				openEditor(projectPathString, additionalFiles);
 			}
 
-			if (!live) {
+			if (!Boolean.TRUE.equals(live)) {
 				out.println(projectPathString);
 			} else {
 				Path orginalFile = prj.getResourceRef().getFile();

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -53,7 +53,7 @@ public class Export extends BaseCommand {
 		java.nio.file.Path outputFile;
 
 		@Option(name = "force", hasValue = false, description = "Force export, i.e. overwrite exported file if already exists")
-		boolean force;
+		Boolean force;
 
 		// Create a Manifest with a Class-Path option
 		protected Manifest createManifest(String newPath) {
@@ -118,7 +118,7 @@ public class Export extends BaseCommand {
 			Path source = ctx.getJarFile();
 			Path outputPath = getJarOutputPath();
 			if (outputPath.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
@@ -155,7 +155,7 @@ public class Export extends BaseCommand {
 			Path source = ctx.getJarFile();
 			Path outputPath = getJarOutputPath();
 			if (outputPath.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
@@ -174,7 +174,7 @@ public class Export extends BaseCommand {
 				Util.mkdirs(libDir);
 				StringBuilder newPath = new StringBuilder();
 				for (ArtifactInfo dep : deps) {
-					if (force) {
+					if (Boolean.TRUE.equals(force)) {
 						Files.copy(dep.getFile(), libDir.resolve(dep.getFile().getFileName()),
 								StandardCopyOption.REPLACE_EXISTING);
 					} else {
@@ -218,7 +218,7 @@ public class Export extends BaseCommand {
 					Util.errorMsg("Cannot export as maven repository as " + outPath + " is not a directory.");
 					return EXIT_INVALID_INPUT;
 				}
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.mkdirs(outPath);
 				} else {
 					Util.errorMsg("Cannot export as " + outPath + " does not exist. Use --force to create.");
@@ -262,7 +262,7 @@ public class Export extends BaseCommand {
 			artifactFile.getParent().toFile().mkdirs();
 
 			if (artifactFile.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					artifactFile.toFile().delete();
 				} else {
 					Util.errorMsg("Cannot export as " + artifactFile + " already exists. Use --force to overwrite.");
@@ -309,7 +309,7 @@ public class Export extends BaseCommand {
 			Path source = ctx.getNativeImageFile();
 			Path outputPath = getNativeOutputPath();
 			if (outputPath.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
@@ -349,7 +349,7 @@ public class Export extends BaseCommand {
 			Path source = ctx.getJarFile();
 			Path outputPath = getFatjarOutputPath();
 			if (outputPath.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
@@ -474,7 +474,7 @@ public class Export extends BaseCommand {
 				relativeOP = "." + File.separator + Util.getCwd().relativize(outputPath);
 			}
 			if (outputPath.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + relativeOP + " already exists. Use --force to overwrite.");
@@ -550,7 +550,7 @@ public class Export extends BaseCommand {
 		int apply(BuildContext ctx) throws IOException {
 			Path projectDir = getOutputPath("");
 			if (projectDir.toFile().exists()) {
-				if (force) {
+				if (Boolean.TRUE.equals(force)) {
 					Util.deletePath(projectDir, false);
 				} else {
 					Util.errorMsg("Cannot export as " + projectDir + " already exists. Use --force to overwrite.");

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -329,7 +329,7 @@ public class Info extends BaseCommand {
 	public static class ClassPath extends BaseInfoCommand {
 
 		@Option(name = "deps-only", hasValue = false, description = "Only include the dependencies in the output, not the application jar itself")
-		boolean dependenciesOnly;
+		Boolean dependenciesOnly;
 
 		@Override
 		public Integer doCall() throws IOException {
@@ -338,7 +338,7 @@ public class Info extends BaseCommand {
 			List<String> deps = info.resolvedDependencies != null ? info.resolvedDependencies
 					: Collections.emptyList();
 			List<String> cp = new ArrayList<>(deps.size() + 1);
-			if (!dependenciesOnly && info.applicationJar != null
+			if (!Boolean.TRUE.equals(dependenciesOnly) && info.applicationJar != null
 					&& !deps.contains(info.applicationJar)) {
 				cp.add(info.applicationJar);
 			}
@@ -364,7 +364,7 @@ public class Info extends BaseCommand {
 	public static class Docs extends BaseInfoCommand {
 
 		@Option(name = "open", hasValue = false, negatable = true, description = "Open the (first) documentation file/link in the default browser")
-		public boolean open;
+		public Boolean open;
 
 		@Override
 		public Integer doCall() throws IOException {
@@ -399,7 +399,7 @@ public class Info extends BaseCommand {
 				Util.infoMsg("No documentation files found");
 				return EXIT_OK;
 			}
-			if (!open) {
+			if (!Boolean.TRUE.equals(open)) {
 				Util.infoMsg("Use --open to open the documentation file in the default browser.");
 				return EXIT_OK;
 			}

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -45,10 +45,10 @@ public class Init extends BaseCommand {
 	public String initTemplate;
 
 	@Option(name = "force", hasValue = false, description = "Force overwrite of existing files")
-	public boolean force;
+	public Boolean force;
 
 	@Option(name = "edit", hasValue = false, description = "Open editor on the generated file(s)")
-	public boolean edit;
+	public Boolean edit;
 
 	@OptionGroup(shortName = 'D', description = "set a system property")
 	public Map<String, String> properties;
@@ -142,7 +142,7 @@ public class Init extends BaseCommand {
 					ResourceResolver.combined(tpl.catalog.catalogRef, ResourceResolver.forResources())))
 			.collect(Collectors.toList());
 
-		if (!force) {
+		if (!Boolean.TRUE.equals(force)) {
 			for (RefTarget refTarget : refTargets) {
 				Path target = refTarget.to(outDir);
 				if (Files.exists(target)) {
@@ -193,7 +193,7 @@ public class Init extends BaseCommand {
 		}
 
 		String renderedScriptOrFile = getRenderedScriptOrFile(tpl.fileRefs, refTargets, outDir, absolute);
-		if (edit) {
+		if (Boolean.TRUE.equals(edit)) {
 			info("File initialized. Opening editor for you. You can also now run it with 'jbang "
 					+ renderedScriptOrFile);
 			JBang.execute("edit", renderedScriptOrFile);

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -25,7 +25,7 @@ import dev.jbang.util.Util;
 public class JBang extends BaseCommand {
 
 	@Option(shortName = 'V', name = "version", hasValue = false, description = "Display version info (use `jbang --verbose version` for more details)")
-	boolean versionRequested;
+	Boolean versionRequested;
 
 	@Override
 	public void beforeParse() {
@@ -38,7 +38,7 @@ public class JBang extends BaseCommand {
 	}
 
 	public Integer doCall() throws IOException {
-		if (versionRequested) {
+		if (Boolean.TRUE.equals(versionRequested)) {
 			System.out.println(Util.getJBangVersion());
 			return EXIT_OK;
 		}

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -101,7 +101,7 @@ public class Jdk extends BaseCommand {
 		JdkProvidersMixin jdkMixin;
 
 		@Option(shortName = 'f', name = "force", hasValue = false, description = "Force installation even when already installed")
-		boolean force;
+		Boolean force;
 
 		@Argument(paramLabel = "versionOrId", index = "0", arity = "1", description = "The version or id to install", required = true)
 		String versionOrId;
@@ -113,7 +113,7 @@ public class Jdk extends BaseCommand {
 		public Integer doCall() throws IOException {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			dev.jbang.devkitman.Jdk jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canInstall);
-			if (force || jdk == null) {
+			if (Boolean.TRUE.equals(force) || jdk == null) {
 				if (jdk != null) {
 					((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).uninstall();
 				}
@@ -160,11 +160,11 @@ public class Jdk extends BaseCommand {
 		JdkProvidersMixin jdkMixin;
 
 		@Option(shortName = 'a', name = "available", hasValue = false, description = "Shows versions available for installation")
-		boolean available;
+		Boolean available;
 
 		@Option(shortName = 'd', name = "show-details", aliases = {
 				"details" }, hasValue = false, description = "Shows detailed information for each JDK (only when format=text)")
-		boolean details;
+		Boolean details;
 
 		@Option(name = "format", description = "Specify output format ('text' or 'json')")
 		OutputFormat format;
@@ -176,7 +176,7 @@ public class Jdk extends BaseCommand {
 			int defMajorVersion = defaultJdk != null ? defaultJdk.majorVersion() : 0;
 			PrintStream out = System.out;
 			List<? extends dev.jbang.devkitman.Jdk> jdks;
-			if (available) {
+			if (Boolean.TRUE.equals(available)) {
 				jdks = jdkMan.listAvailableJdks();
 			} else {
 				jdks = jdkMan.listInstalledJdks();
@@ -185,11 +185,11 @@ public class Jdk extends BaseCommand {
 				.map(jdk -> new JdkOut(jdk.id(), jdk.version(), jdk.provider().name(),
 						jdk.isInstalled() ? ((dev.jbang.devkitman.Jdk.InstalledJdk) jdk).home() : null,
 						null,
-						details ? jdk.equals(defaultJdk)
+						Boolean.TRUE.equals(details) ? jdk.equals(defaultJdk)
 								: jdk.majorVersion() == defMajorVersion,
 						jdk.tags()))
 				.collect(Collectors.toList());
-			if (!details) {
+			if (!Boolean.TRUE.equals(details)) {
 				// Only keep a list of unique major versions
 				Set<JdkOut> uniqueJdks = new TreeSet<>(Comparator.<JdkOut>comparingInt(j -> j.version).reversed());
 				uniqueJdks.addAll(jdkOuts);
@@ -200,7 +200,7 @@ public class Jdk extends BaseCommand {
 				parser.toJson(jdkOuts, out);
 			} else {
 				if (!jdkOuts.isEmpty()) {
-					if (!available) {
+					if (!Boolean.TRUE.equals(available)) {
 						out.println("Installed JDKs (<=default):");
 					}
 					jdkOuts.forEach(jdk -> {
@@ -208,14 +208,14 @@ public class Jdk extends BaseCommand {
 						out.print(jdk.version);
 						out.print(" (");
 						out.print(jdk.fullVersion);
-						if (details) {
+						if (Boolean.TRUE.equals(details)) {
 							out.print(", " + jdk.providerName + ", " + jdk.id);
 							if (jdk.javaHomeDir != null) {
 								out.print(", " + jdk.javaHomeDir);
 							}
 						}
 						out.print(")");
-						if (!available) {
+						if (!Boolean.TRUE.equals(available)) {
 							if (Boolean.TRUE.equals(jdk.isDefault)) {
 								out.print(" <");
 							}
@@ -223,7 +223,7 @@ public class Jdk extends BaseCommand {
 						out.println();
 					});
 				} else {
-					out.printf("No JDKs %s%n", available ? "available" : "installed");
+					out.printf("No JDKs %s%n", Boolean.TRUE.equals(available) ? "available" : "installed");
 				}
 			}
 			return EXIT_OK;
@@ -391,11 +391,11 @@ public class Jdk extends BaseCommand {
 		String versionOrId;
 
 		@Option(name = "for-version", shortName = 'v', hasValue = false, description = "Sets the default for the specified major version")
-		boolean forVersion;
+		Boolean forVersion;
 
 		@Option(shortName = 'd', name = "show-details", aliases = {
 				"details" }, hasValue = false, description = "Shows detailed information for each JDK (only when format=text)")
-		boolean details;
+		Boolean details;
 
 		@Option(name = "format", description = "Specify output format ('text' or 'json')")
 		OutputFormat format;
@@ -409,11 +409,11 @@ public class Jdk extends BaseCommand {
 			}
 			if (versionOrId != null) {
 				dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getOrInstallJdk(versionOrId);
-				dev.jbang.devkitman.Jdk.InstalledJdk defjdk = forVersion
+				dev.jbang.devkitman.Jdk.InstalledJdk defjdk = Boolean.TRUE.equals(forVersion)
 						? jdkMan.getDefaultJdkForVersion(jdk.majorVersion())
 						: jdkMan.getDefaultJdk();
 				if (defjdk == null || (!jdk.equals(defjdk) && !Objects.equals(jdk.home(), defjdk.home()))) {
-					if (forVersion) {
+					if (Boolean.TRUE.equals(forVersion)) {
 						jdkMan.setDefaultJdkForVersion(jdk);
 					} else {
 						jdkMan.setDefaultJdk(jdk);
@@ -443,7 +443,7 @@ public class Jdk extends BaseCommand {
 							}
 							out.print(" -> ");
 							out.print(jdk.linkedId);
-							if (details) {
+							if (Boolean.TRUE.equals(details)) {
 								out.print(" (" + jdk.realHomeDir + ", " + jdk.fullVersion + ", " + jdk.id);
 								if (!jdk.tags.isEmpty()) {
 									out.print(", " + jdk.tags);

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -56,7 +56,7 @@ public class Template extends BaseCommand {
 		String name;
 
 		@Option(name = "force", hasValue = false, description = "Force overwriting of existing template")
-		boolean force;
+		Boolean force;
 
 		@Arguments(paramLabel = "files", arity = "1..*", description = "Paths or URLs to template files", required = true)
 		List<String> fileRefs;
@@ -119,7 +119,7 @@ public class Template extends BaseCommand {
 			Map<String, TemplateProperty> propertiesMap = parseProperties(propertyStrings);
 
 			Path catFile = catalogOptions.getCatalogOrDefault();
-			if (force || !CatalogUtil.hasTemplate(catFile, name)) {
+			if (Boolean.TRUE.equals(force) || !CatalogUtil.hasTemplate(catFile, name)) {
 				CatalogUtil.addTemplate(catFile, name, fileRefsMap, description, propertiesMap);
 			} else {
 				Util.infoMsg("A template with name '" + name + "' already exists, use '--force' to add anyway.");
@@ -226,13 +226,13 @@ public class Template extends BaseCommand {
 	public static class TemplateList extends BaseTemplateCommand {
 
 		@Option(name = "show-origin", hasValue = false, description = "Show the origin of the template")
-		boolean showOrigin;
+		Boolean showOrigin;
 
 		@Option(name = "show-files", hasValue = false, description = "Show list of files for each template")
-		boolean showFiles;
+		Boolean showFiles;
 
 		@Option(name = "show-properties", hasValue = false, description = "Show list of properties for each template")
-		boolean showProperties;
+		Boolean showProperties;
 
 		@Argument(paramLabel = "name", description = "The name of a catalog")
 		String catalogName;
@@ -254,10 +254,12 @@ public class Template extends BaseCommand {
 			} else {
 				catalog = Catalog.getMerged(true, false);
 			}
-			if (showOrigin) {
-				printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, format);
+			if (Boolean.TRUE.equals(showOrigin)) {
+				printTemplatesWithOrigin(out, catalogName, catalog, Boolean.TRUE.equals(showFiles),
+						Boolean.TRUE.equals(showProperties), format);
 			} else {
-				printTemplates(out, catalogName, catalog, showFiles, showProperties, format);
+				printTemplates(out, catalogName, catalog, Boolean.TRUE.equals(showFiles),
+						Boolean.TRUE.equals(showProperties), format);
 			}
 			return EXIT_OK;
 		}

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -15,22 +15,22 @@ import dev.jbang.util.VersionChecker;
 public class Version extends BaseCommand {
 
 	@Option(name = "check", hasValue = false, description = "Check if a new version of jbang is available")
-	boolean checkForUpdate;
+	Boolean checkForUpdate;
 
 	@Option(name = "update", hasValue = false, description = "Update jbang to the latest version")
-	boolean update;
+	Boolean update;
 
 	@Override
 	public Integer doCall() {
-		if (update) {
-			if (VersionChecker.updateOrInform(checkForUpdate)) {
+		if (Boolean.TRUE.equals(update)) {
+			if (VersionChecker.updateOrInform(Boolean.TRUE.equals(checkForUpdate))) {
 				try {
 					App.AppInstall.installJBang(true);
 				} catch (IOException e) {
 					throw new ExitException(EXIT_INTERNAL_ERROR, "Could not install command", e);
 				}
 			}
-		} else if (checkForUpdate) {
+		} else if (Boolean.TRUE.equals(checkForUpdate)) {
 			System.out.println(Util.getJBangVersion());
 			VersionChecker.checkNowAndInform();
 		} else {

--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -35,7 +35,7 @@ public class Wrapper extends BaseCommand {
 		Path dest;
 
 		@Option(shortName = 'f', name = "force", hasValue = false, description = "Force installation of wrapper even if files already exist")
-		boolean force;
+		Boolean force;
 
 		@Override
 		public Integer doCall() {
@@ -43,7 +43,7 @@ public class Wrapper extends BaseCommand {
 			if (!Files.isDirectory(destPath)) {
 				throw new ExitException(EXIT_INVALID_INPUT, "Destination folder does not exist");
 			}
-			if ((checkScripts(destPath) || checkJar(destPath.resolve(DIR_NAME))) && !force) {
+			if ((checkScripts(destPath) || checkJar(destPath.resolve(DIR_NAME))) && !Boolean.TRUE.equals(force)) {
 				Util.warnMsg("Wrapper already exists. Use --force to install anyway");
 				return EXIT_OK;
 			}

--- a/src/test/java/dev/jbang/architecture/CliArchitectureTest.java
+++ b/src/test/java/dev/jbang/architecture/CliArchitectureTest.java
@@ -1,0 +1,110 @@
+package dev.jbang.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.aesh.command.option.Argument;
+import org.aesh.command.option.Arguments;
+import org.aesh.command.option.Option;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+
+/**
+ * Ensures that Aesh CLI annotations ({@code @Option}, {@code @Argument},
+ * {@code @Arguments}, {@code @OptionList}, {@code @OptionGroup}) never target
+ * fields with Java primitive types.
+ * <p>
+ * Primitive types have implicit defaults ({@code false}, {@code 0}, etc.) which
+ * make it impossible for {@link dev.jbang.cli.JBangDefaultValueProvider} to
+ * distinguish "user didn't pass the flag" from "user explicitly set the
+ * default". This breaks config-file overriding: a config value can never be
+ * negated from the CLI because the primitive default shadows it.
+ * <p>
+ * Use the corresponding boxed type instead ({@code Boolean} instead of
+ * {@code boolean}, {@code Integer} instead of {@code int}, etc.) so the field
+ * is {@code null} when unset, allowing the default-value provider and
+ * {@code afterParse()} logic to work correctly.
+ *
+ * @see dev.jbang.cli.JBangDefaultValueProvider
+ * @see <a href="https://github.com/jbangdev/jbang/issues/2504">Issue 2504</a>
+ */
+@AnalyzeClasses(packages = "dev.jbang")
+class CliArchitectureTest {
+
+	private static final Set<Class<?>> PRIMITIVE_TYPES = new HashSet<>(Arrays.asList(
+			boolean.class, byte.class, char.class, short.class,
+			int.class, long.class, float.class, double.class));
+
+	// --- @Option fields must not use primitive types ---
+
+	@ArchTest
+	static final ArchRule option_fields_must_not_be_primitive = fields()
+		.that()
+		.areAnnotatedWith(Option.class)
+		.should(notBePrimitiveType("@Option"));
+
+	// --- @Argument fields must not use primitive types ---
+
+	@ArchTest
+	static final ArchRule argument_fields_must_not_be_primitive = fields()
+		.that()
+		.areAnnotatedWith(Argument.class)
+		.should(notBePrimitiveType("@Argument"));
+
+	// --- @Arguments fields must not use primitive types ---
+
+	@ArchTest
+	static final ArchRule arguments_fields_must_not_be_primitive = fields()
+		.that()
+		.areAnnotatedWith(Arguments.class)
+		.should(notBePrimitiveType("@Arguments"));
+
+	private static ArchCondition<JavaField> notBePrimitiveType(String annotationName) {
+		return new ArchCondition<JavaField>(
+				"not use a primitive type as JBangDefaultValueProvider cannot distinguish between not set and default value.") {
+			@Override
+			public void check(JavaField field, ConditionEvents events) {
+				JavaClass rawType = field.getRawType();
+				for (Class<?> primitive : PRIMITIVE_TYPES) {
+					if (rawType.isEquivalentTo(primitive)) {
+						events.add(SimpleConditionEvent.violated(
+								field,
+								field.getOwner().getName() + "." + field.getName()
+										+ ": use " + boxedName(primitive) + " instead of "
+										+ primitive.getName()));
+					}
+				}
+			}
+		};
+	}
+
+	private static String boxedName(Class<?> primitive) {
+		if (primitive == boolean.class)
+			return "Boolean";
+		if (primitive == byte.class)
+			return "Byte";
+		if (primitive == char.class)
+			return "Character";
+		if (primitive == short.class)
+			return "Short";
+		if (primitive == int.class)
+			return "Integer";
+		if (primitive == long.class)
+			return "Long";
+		if (primitive == float.class)
+			return "Float";
+		if (primitive == double.class)
+			return "Double";
+		return primitive.getName();
+	}
+}


### PR DESCRIPTION
## Summary

Add an ArchUnit test (`CliArchitectureTest`) that ensures all Aesh CLI annotation fields (`@Option`, `@Argument`, `@Arguments`, `@OptionList`, `@OptionGroup`) use boxed types instead of Java primitives.

## Problem

Primitive types have implicit defaults (`false`, `0`, etc.) which make it impossible for `JBangDefaultValueProvider` to distinguish "user didn't pass the flag" from "user explicitly set the default value". This breaks config-file overriding — a config value can never be negated from the CLI because the primitive default shadows it.

For example, with `boolean insecure`, setting `insecure=true` in `jbang.properties` works, but passing `--no-insecure` on the CLI can't override it because `false` (the primitive default) is indistinguishable from "not set".

## What this PR adds

- **ArchUnit dependency** (`archunit-junit5:1.4.0`) in `build.gradle`
- **`CliArchitectureTest`** with 5 rules (one per Aesh annotation), checking all 8 Java primitive types

## Current violations detected

The test currently **fails intentionally** to document the 36 existing violations:
- 35 `boolean` fields that should be `Boolean`
- 1 `int` field (`Deps.max`) that should be `Integer`

Example violation message:
```
dev.jbang.cli.BaseCommand.insecure: @Option field must not be primitive (boolean);
use Boolean so JBangDefaultValueProvider can distinguish 'not set' from the default value
```

## Next steps

The actual migration of primitive → boxed types should be done in a follow-up PR, with null checks added where each field is read.

Refs #2504