### PR TITLE
build: upgrade to aesh 3.13 and fix primitive option types (#2504, #2…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,11 +156,11 @@ dependencies {
 	implementation 'org.jspecify:jspecify:1.0.0'
 	implementation 'org.apache.commons:commons-text:1.15.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'
-	implementation('org.aesh:aesh:3.12.1') {
+	implementation('org.aesh:aesh:3.14.2') {
 		exclude group: 'org.aesh', module: 'readline'
 	}
-	implementation 'org.aesh:readline-api:3.11'
-	annotationProcessor 'org.aesh:aesh-processor:3.12.1'
+	implementation 'org.aesh:readline-api:3.14'
+	annotationProcessor 'org.aesh:aesh-processor:3.14.2'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
 	implementation 'com.google.code.gson:gson:2.13.2'

--- a/src/main/java/dev/jbang/cli/AIOptions.java
+++ b/src/main/java/dev/jbang/cli/AIOptions.java
@@ -4,15 +4,15 @@ import org.aesh.command.option.Option;
 
 public class AIOptions {
 
-	@Option(name = "ai-provider", description = "Provider to use (openai, openrouter, etc.) when using init with a prompt")
+	@Option(name = "ai-provider", defaultValue = "${env:JBANG_AI_PROVIDER:-}", description = "Provider to use (openai, openrouter, etc.) when using init with a prompt")
 	String provider;
 
-	@Option(name = "ai-api-key", description = "API Key/token to use for the AI Provider")
+	@Option(name = "ai-api-key", defaultValue = "${env:JBANG_AI_API_KEY:-}", description = "API Key/token to use for the AI Provider")
 	String apiKey;
 
-	@Option(name = "ai-endpoint", description = "OpenAI compatible Endpoint to use for the AI Provider when using init with a prompt")
+	@Option(name = "ai-endpoint", defaultValue = "${env:JBANG_AI_ENDPOINT:-}", description = "OpenAI compatible Endpoint to use for the AI Provider when using init with a prompt")
 	String endpoint;
 
-	@Option(name = "ai-model", description = "Model string to use for init prompting")
+	@Option(name = "ai-model", defaultValue = "${env:JBANG_AI_MODEL:-}", description = "Model string to use for init prompting")
 	String model;
 }

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -68,7 +68,7 @@ public class Alias extends BaseCommand {
 		boolean force;
 
 		@Option(name = "enable-preview", hasValue = false, description = "Activate Java preview features")
-		Boolean enablePreviewRequested;
+		boolean enablePreviewRequested;
 
 		@Arguments(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
 		List<String> userParams;
@@ -80,7 +80,6 @@ public class Alias extends BaseCommand {
 		public void afterParse() {
 			super.afterParse();
 			dependencyInfoMixin.applyIgnoreTransitiveRepositories();
-			runMixin.resolveAfterParse();
 		}
 
 		@Override
@@ -149,10 +148,11 @@ public class Alias extends BaseCommand {
 		}
 
 		private List<JavaAgent> createJavaAgents() {
-			if (runMixin.javaAgentSlots == null) {
+			Map<String, String> slots = runMixin.getJavaAgentSlots();
+			if (slots == null) {
 				return Collections.emptyList();
 			}
-			return runMixin.javaAgentSlots.entrySet()
+			return slots.entrySet()
 				.stream()
 				.map(e -> new JavaAgent(e.getKey(), e.getValue()))
 				.collect(Collectors.toList());

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -77,16 +77,7 @@ public class App extends BaseCommand {
 		String name;
 
 		@Arguments(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
-		public List<String> userParams;
-
-		@Override
-		public void afterParse() {
-			super.afterParse();
-			if (userParams == null) {
-				userParams = new ArrayList<>();
-			}
-			runMixin.resolveAfterParse();
-		}
+		public List<String> userParams = new ArrayList<>();
 
 		@Override
 		public Integer doCall() throws IOException {

--- a/src/main/java/dev/jbang/cli/BaseBuildCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseBuildCommand.java
@@ -34,12 +34,6 @@ public abstract class BaseBuildCommand extends BaseCommand {
 	@Override
 	public void afterParse() {
 		super.afterParse();
-		if (buildMixin.javaVersion != null && !buildMixin.javaVersion.matches("\\d+[+]?")) {
-			throw new ExitException(EXIT_INVALID_INPUT,
-					String.format(
-							"Invalid value for '--java': '%s' should be a number optionally followed by a plus sign",
-							buildMixin.javaVersion));
-		}
 		dependencyInfoMixin.applyIgnoreTransitiveRepositories();
 	}
 

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -190,7 +190,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 			}
 		}
 
-		if (insecure) {
+		if (Boolean.TRUE.equals(insecure)) {
 			enableInsecure();
 		}
 	}

--- a/src/main/java/dev/jbang/cli/BuildMixin.java
+++ b/src/main/java/dev/jbang/cli/BuildMixin.java
@@ -14,7 +14,7 @@ public class BuildMixin {
 	@Mixin
 	public JdkProvidersMixin jdkMixin;
 
-	@Option(shortName = 'j', name = "java", description = "JDK version to use for running the script.")
+	@Option(shortName = 'j', name = "java", validator = JavaVersionValidator.class, description = "JDK version to use for running the script.")
 	public String javaVersion;
 
 	@Option(shortName = 'm', name = "main", description = "Main class to use when running. Used primarily for running jar's. Can be a glob pattern using ? and *.")

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -52,7 +52,7 @@ public class Catalog extends BaseCommand {
 		boolean force;
 
 		@Option(name = "import", description = "Import catalog items into the catalog's scope")
-		Boolean importItems;
+		boolean importItems;
 
 		@Argument(paramLabel = "fileOrURL", description = "A file or URL to a catalog file", required = true)
 		String urlOrFile;

--- a/src/main/java/dev/jbang/cli/DebugConverter.java
+++ b/src/main/java/dev/jbang/cli/DebugConverter.java
@@ -1,0 +1,31 @@
+package dev.jbang.cli;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.aesh.command.converter.Converter;
+import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.validator.OptionValidatorException;
+
+/**
+ * Converts the raw --debug string (e.g. "4004", "*:5000",
+ * "suspend=n,address=host:5000") into a structured Map&lt;String, String&gt;.
+ * Bare values (no '=') are treated as an "address" entry.
+ */
+public class DebugConverter implements Converter<Map<String, String>, ConverterInvocation> {
+
+	@Override
+	public Map<String, String> convert(ConverterInvocation input) throws OptionValidatorException {
+		String raw = input.getInput();
+		Map<String, String> result = new LinkedHashMap<>();
+		for (String part : raw.split(",")) {
+			if (part.contains("=")) {
+				String[] kv = part.split("=", 2);
+				result.put(kv[0], kv[1]);
+			} else {
+				result.put("address", part);
+			}
+		}
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/cli/DebugOptionParser.java
+++ b/src/main/java/dev/jbang/cli/DebugOptionParser.java
@@ -50,7 +50,8 @@ public class DebugOptionParser implements OptionParser {
 			}
 		}
 
-		addOptionValue(option, "");
+		// Don't call addValue — let aesh's fallback chain handle it:
+		// provider fallbackValue() -> annotation fallbackValue -> default
 	}
 
 	private void addOptionValue(ProcessedOption option, String value) {

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -53,25 +53,12 @@ public class Edit extends BaseCommand {
 	public void afterParse() {
 		super.afterParse();
 		dependencyInfoMixin.applyIgnoreTransitiveRepositories();
-		applyEditorDefaults();
-	}
-
-	private void applyEditorDefaults() {
-		String envEditor = System.getenv("JBANG_EDITOR");
-		if (envEditor != null && !envEditor.isEmpty()) {
-			editor = envEditor;
-		} else if (editor != null && editor.isEmpty()) {
-			String cfgEditor = dev.jbang.Configuration.instance().get("edit.open");
-			if (cfgEditor != null) {
-				editor = cfgEditor;
-			}
-		}
 	}
 
 	@Option(name = "live", hasValue = false, description = "Open directory in IDE's that support JBang or generate temporary project with option to regenerate project on dependency changes.")
 	public boolean live;
 
-	@Option(name = "open", fallbackValue = "", description = "Opens editor/IDE on the temporary project.")
+	@Option(name = "open", defaultValue = "${env:JBANG_EDITOR:-}", fallbackValue = "${env:JBANG_EDITOR:-}", description = "Opens editor/IDE on the temporary project.")
 	public String editor;
 
 	@Option(name = "no-open", hasValue = false, description = "Explicitly prevent JBang from opening an editor/IDE")

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -35,7 +35,7 @@ import io.quarkus.qute.TemplateInstance;
 @CommandDefinition(name = "init", description = "Initialize a script.", generateHelp = true, helpGroup = "Editing")
 public class Init extends BaseCommand {
 
-	@Option(shortName = 'j', name = "java", description = "JDK version to use for running the script.")
+	@Option(shortName = 'j', name = "java", validator = JavaVersionValidator.class, description = "JDK version to use for running the script.")
 	String javaVersion;
 
 	@Mixin
@@ -61,23 +61,6 @@ public class Init extends BaseCommand {
 
 	@Arguments(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the generation")
 	List<String> params;
-
-	@Override
-	public void afterParse() {
-		super.afterParse();
-		if (aiOptions.provider == null) {
-			aiOptions.provider = System.getenv("JBANG_AI_PROVIDER");
-		}
-		if (aiOptions.apiKey == null) {
-			aiOptions.apiKey = System.getenv("JBANG_AI_API_KEY");
-		}
-		if (aiOptions.endpoint == null) {
-			aiOptions.endpoint = System.getenv("JBANG_AI_ENDPOINT");
-		}
-		if (aiOptions.model == null) {
-			aiOptions.model = System.getenv("JBANG_AI_MODEL");
-		}
-	}
 
 	public void requireScriptArgument() {
 		if (scriptOrFile == null) {

--- a/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
+++ b/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
@@ -15,11 +15,11 @@ import dev.jbang.Configuration;
 
 public class JBangDefaultValueProvider implements DefaultValueProvider {
 
-	// Options that use fallbackValue="" or DebugOptionParser for three-state
-	// semantics (null=not specified, ""=bare flag, "value"=explicit). The provider
-	// must not supply defaults for these because the empty-string sentinel triggers
-	// config-file lookup in RunMixin.resolveAfterParse() instead.
-	private static final Set<String> FALLBACK_OPTIONS = new HashSet<>(Arrays.asList("debug", "jfr"));
+	// Options where config defaults should only apply as fallback values (when
+	// the option is explicitly used bare, e.g. --debug), not as default values
+	// (when the option is omitted entirely). This prevents config-set debug/jfr
+	// from activating on every command invocation.
+	private static final Set<String> FALLBACK_ONLY_OPTIONS = new HashSet<>(Arrays.asList("debug", "jfr"));
 
 	private static volatile Map<Class<?>, String> classToPath;
 
@@ -29,7 +29,7 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			return null;
 		}
 
-		if (FALLBACK_OPTIONS.contains(option.name())) {
+		if (FALLBACK_ONLY_OPTIONS.contains(option.name())) {
 			return null;
 		}
 
@@ -52,6 +52,26 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			}
 		}
 
+		return getValue(optName);
+	}
+
+	@Override
+	public String fallbackValue(ProcessedOption option) {
+		if (option.name() == null) {
+			return null;
+		}
+		String optName = option.name().replace("-", "");
+		String fullPath = null;
+		if (option.parent() != null && option.parent().getCommand() != null) {
+			fullPath = getCommandPathForClass(option.parent().getCommand().getClass());
+		}
+		if (fullPath != null) {
+			String key = fullPath + "." + optName;
+			String val = getValue(key);
+			if (val != null) {
+				return val;
+			}
+		}
 		return getValue(optName);
 	}
 

--- a/src/main/java/dev/jbang/cli/JavaVersionValidator.java
+++ b/src/main/java/dev/jbang/cli/JavaVersionValidator.java
@@ -1,0 +1,23 @@
+package dev.jbang.cli;
+
+import org.aesh.command.validator.OptionValidator;
+import org.aesh.command.validator.OptionValidatorException;
+import org.aesh.command.validator.ValidatorInvocation;
+
+/**
+ * Validates that the --java option value is a number optionally followed by a
+ * plus sign (e.g. "11", "17+").
+ */
+public class JavaVersionValidator implements OptionValidator<ValidatorInvocation<String, ?>> {
+
+	@Override
+	public void validate(ValidatorInvocation<String, ?> invocation) throws OptionValidatorException {
+		String value = invocation.getValue();
+		if (value != null && !value.matches("\\d+[+]?")) {
+			throw new OptionValidatorException(
+					String.format(
+							"Invalid value for '--java': '%s' should be a number optionally followed by a plus sign",
+							value));
+		}
+	}
+}

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -48,7 +48,7 @@ public class Jdk extends BaseCommand {
 		String realHomeDir;
 		String linkedId;
 		@SerializedName("default")
-		Boolean isDefault;
+		boolean isDefault;
 		Set<String> tags;
 
 		public JdkOut(String id, String version, String providerName, Path home, String linkedId,

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -4,7 +4,11 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.aesh.command.CommandDefinition;
@@ -38,16 +42,7 @@ public class Run extends BaseBuildCommand {
 	public String literalScript;
 
 	@Arguments(paramLabel = "userParams", index = "1..*", arity = "0..*", description = "Parameters for the script")
-	public List<String> userParams;
-
-	@Override
-	public void afterParse() {
-		super.afterParse();
-		runMixin.resolveAfterParse();
-		if (userParams == null) {
-			userParams = new ArrayList<>();
-		}
-	}
+	public List<String> userParams = new ArrayList<>();
 
 	protected void requireScriptArgument() {
 		if (scriptMixin.scriptOrFile == null && ((runMixin.interactive != Boolean.TRUE && literalScript == null)
@@ -122,7 +117,7 @@ public class Run extends BaseBuildCommand {
 
 	void buildAgents(BuildContext ctx) throws IOException {
 		Project prj = ctx.getProject();
-		Map<String, String> agents = runMixin.javaAgentSlots;
+		Map<String, String> agents = runMixin.getJavaAgentSlots();
 		if (agents == null && prj.getResourceRef() instanceof AliasResourceResolver.AliasedResourceRef) {
 			AliasResourceResolver.AliasedResourceRef aref = (AliasResourceResolver.AliasedResourceRef) prj
 				.getResourceRef();
@@ -151,7 +146,8 @@ public class Run extends BaseBuildCommand {
 
 	private List<String> javaAgentOptions(BuildContext agentCtx, String agentOptions) {
 		return Collections.singletonList(
-				"-javaagent:" + agentCtx.getJarFile() + (agentOptions != null ? "=" + agentOptions : ""));
+				"-javaagent:" + agentCtx.getJarFile()
+						+ (agentOptions != null && !agentOptions.isEmpty() ? "=" + agentOptions : ""));
 	}
 
 	ProjectBuilder createProjectBuilderForRun() {

--- a/src/main/java/dev/jbang/cli/RunMixin.java
+++ b/src/main/java/dev/jbang/cli/RunMixin.java
@@ -1,14 +1,12 @@
 package dev.jbang.cli;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.aesh.command.option.Option;
+import org.aesh.command.option.OptionGroup;
 import org.aesh.command.option.OptionList;
-
-import dev.jbang.Configuration;
 
 public class RunMixin {
 
@@ -19,9 +17,7 @@ public class RunMixin {
 	@Option(name = "jfr", fallbackValue = "", description = "Launch with Java Flight Recorder enabled.")
 	public String flightRecorderString;
 
-	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
-	public String debugRaw;
-
+	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, converter = DebugConverter.class, fallbackValue = "4004", description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
 	public Map<String, String> debugString;
 
 	@Option(name = "enableassertions", aliases = { "ea" }, hasValue = false, description = "Enable assertions")
@@ -31,9 +27,7 @@ public class RunMixin {
 			"esa" }, hasValue = false, description = "Enable system assertions")
 	public Boolean enableSystemAssertions;
 
-	@OptionList(name = "javaagent")
-	List<String> javaAgentRaw;
-
+	@OptionGroup(name = "javaagent", defaultValue = "", description = "Java agent to use")
 	public Map<String, String> javaAgentSlots;
 
 	@Option(name = "cds", hasValue = false, negatable = true, description = "If specified Class Data Sharing (CDS) will be used for building and running (requires Java 13+)")
@@ -42,46 +36,8 @@ public class RunMixin {
 	@Option(shortName = 'i', name = "interactive", hasValue = false, description = "Activate interactive mode")
 	public Boolean interactive;
 
-	public void resolveAfterParse() {
-		Configuration cfg = Configuration.instance();
-		if ("".equals(debugRaw)) {
-			String cfgDebug = cfg.get("run.debug");
-			debugRaw = cfgDebug != null ? cfgDebug : "4004";
-		}
-		if ("".equals(flightRecorderString)) {
-			String cfgJfr = cfg.get("run.jfr");
-			flightRecorderString = cfgJfr != null ? cfgJfr : "";
-		}
-		resolveDebugArgs();
-		resolveJavaAgentSlots();
-	}
-
-	public void resolveDebugArgs() {
-		if (debugRaw != null && !debugRaw.isEmpty()) {
-			debugString = new LinkedHashMap<>();
-			for (String part : debugRaw.split(",")) {
-				if (part.contains("=")) {
-					String[] kv = part.split("=", 2);
-					debugString.put(kv[0], kv[1]);
-				} else {
-					debugString.put("address", part);
-				}
-			}
-		}
-	}
-
-	void resolveJavaAgentSlots() {
-		if (javaAgentRaw != null && !javaAgentRaw.isEmpty()) {
-			javaAgentSlots = new LinkedHashMap<>();
-			for (String raw : javaAgentRaw) {
-				int eq = raw.indexOf('=');
-				if (eq >= 0) {
-					javaAgentSlots.put(raw.substring(0, eq), raw.substring(eq + 1));
-				} else {
-					javaAgentSlots.put(raw, null);
-				}
-			}
-		}
+	public Map<String, String> getJavaAgentSlots() {
+		return javaAgentSlots;
 	}
 
 	public Boolean getCds() {
@@ -115,8 +71,9 @@ public class RunMixin {
 		if (Boolean.TRUE.equals(enableSystemAssertions)) {
 			opts.add("--enablesystemassertions");
 		}
-		if (javaAgentSlots != null) {
-			for (Map.Entry<String, String> e : javaAgentSlots.entrySet()) {
+		Map<String, String> agentSlots = getJavaAgentSlots();
+		if (agentSlots != null) {
+			for (Map.Entry<String, String> e : agentSlots.entrySet()) {
 				opts.add("--javaagent");
 				opts.add(e.getValue() == null || e.getValue().isEmpty()
 						? e.getKey()

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -255,9 +255,11 @@ public class Template extends BaseCommand {
 				catalog = Catalog.getMerged(true, false);
 			}
 			if (showOrigin) {
-				printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, format);
+				printTemplatesWithOrigin(out, catalogName, catalog, showFiles,
+						showProperties, format);
 			} else {
-				printTemplates(out, catalogName, catalog, showFiles, showProperties, format);
+				printTemplates(out, catalogName, catalog, showFiles,
+						showProperties, format);
 			}
 			return EXIT_OK;
 		}

--- a/src/test/java/dev/jbang/cli/TestAeshParsing.java
+++ b/src/test/java/dev/jbang/cli/TestAeshParsing.java
@@ -253,6 +253,103 @@ class TestAeshParsing extends BaseTest {
 		assertThat(Util.isVerbose(), is(false));
 	}
 
+	// --- Boolean =true/=false syntax ---
+
+	@Test
+	void testVerboseEqualsTrue() {
+		JBang.parseCommand("run", "--verbose=true", "test.java");
+		assertThat(Util.isVerbose(), is(true));
+	}
+
+	@Test
+	void testVerboseEqualsFalse() {
+		Util.setVerbose(true);
+		JBang.parseCommand("run", "--verbose=false", "test.java");
+		assertThat(Util.isVerbose(), is(false));
+	}
+
+	@Test
+	void testForceEqualsTrue() {
+		Init init = JBang.parseCommand("init", "--force=true", "dummy");
+		assertThat(init.force, is(true));
+	}
+
+	@Test
+	void testForceEqualsFalse() {
+		Init init = JBang.parseCommand("init", "--force=false", "dummy");
+		assertThat(init.force, is(false));
+	}
+
+	// --- Java version validation ---
+
+	@Test
+	void testJavaVersionValid() {
+		Run run = JBang.parseCommand("run", "--java", "17", "test.java");
+		assertThat(run.buildMixin.javaVersion, equalTo("17"));
+	}
+
+	@Test
+	void testJavaVersionValidPlus() {
+		Run run = JBang.parseCommand("run", "--java", "11+", "test.java");
+		assertThat(run.buildMixin.javaVersion, equalTo("11+"));
+	}
+
+	@Test
+	void testJavaVersionInvalid() {
+		assertThrows(RuntimeException.class,
+				() -> JBang.parseCommand("run", "--java", "abc", "test.java"));
+	}
+
+	// --- Debug option with custom OptionParser and fallback (#511) ---
+
+	@Test
+	void testBareDebugGetsFallbackValue() {
+		// --debug without a value should get the annotation fallbackValue "4004"
+		// DebugConverter converts "4004" to Map{"address" -> "4004"}
+		Run run = JBang.parseCommand("run", "--debug", "test.java");
+		assertThat(run.runMixin.debugString, hasEntry("address", "4004"));
+	}
+
+	@Test
+	void testDebugWithExplicitPort() {
+		Run run = JBang.parseCommand("run", "--debug", "5005", "test.java");
+		assertThat(run.runMixin.debugString, hasEntry("address", "5005"));
+	}
+
+	@Test
+	void testDebugWithEqualsPort() {
+		Run run = JBang.parseCommand("run", "--debug=5005", "test.java");
+		assertThat(run.runMixin.debugString, hasEntry("address", "5005"));
+	}
+
+	@Test
+	void testBareDebugGetsConfigFallback() throws IOException {
+		// Config-set debug should be used as fallback when --debug is bare
+		String config = "run.debug = 9009\n";
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
+		Configuration.instance(null);
+
+		Run run = JBang.parseCommand("run", "--debug", "test.java");
+		assertThat(run.runMixin.debugString, hasEntry("address", "9009"));
+	}
+
+	@Test
+	void testDebugExplicitOverridesConfig() throws IOException {
+		// Explicit value should override config
+		String config = "run.debug = 9009\n";
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
+		Configuration.instance(null);
+
+		Run run = JBang.parseCommand("run", "--debug=7007", "test.java");
+		assertThat(run.runMixin.debugString, hasEntry("address", "7007"));
+	}
+
+	@Test
+	void testDebugNotSpecified() {
+		Run run = JBang.parseCommand("run", "test.java");
+		assertThat(run.runMixin.debugString, is(nullValue()));
+	}
+
 	// --- Subcommand list consistency ---
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1299,8 +1299,8 @@ public class TestRun extends BaseTest {
 				"--javaagent=org.jboss.byteman:byteman:4.0.13",
 				mainFile.toAbsolutePath().toString());
 
-		assertThat(run.runMixin.javaAgentSlots.containsKey(agentFile.toAbsolutePath().toString()), is(true));
-		assertThat(run.runMixin.javaAgentSlots.get(agentFile.toAbsolutePath().toString()), equalTo("optionA"));
+		assertThat(run.runMixin.getJavaAgentSlots().containsKey(agentFile.toAbsolutePath().toString()), is(true));
+		assertThat(run.runMixin.getJavaAgentSlots().get(agentFile.toAbsolutePath().toString()), equalTo("optionA"));
 
 		ProjectBuilder pb = run.createProjectBuilderForRun().mainClass("fakemain");
 		Project prj = pb.build(mainFile);
@@ -1324,7 +1324,7 @@ public class TestRun extends BaseTest {
 	void testJavaAgentParsing() {
 		Run run = JBang.parseCommand("run", "--javaagent=xyz.jar", "wonka.java");
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("xyz.jar"));
+		assertThat(run.runMixin.getJavaAgentSlots(), hasKey("xyz.jar"));
 	}
 
 	@Test
@@ -1332,7 +1332,7 @@ public class TestRun extends BaseTest {
 		Run run = JBang.parseCommand("run",
 				"--javaagent=org.jboss.byteman:byteman:4.0.13", "wonka.java");
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("org.jboss.byteman:byteman:4.0.13"));
+		assertThat(run.runMixin.getJavaAgentSlots(), hasKey("org.jboss.byteman:byteman:4.0.13"));
 	}
 
 	@Test


### PR DESCRIPTION
Upgrade aesh from 3.12.1 to 3.14.1 and readline-api from 3.11 to 3.14.
Leverage new aesh features to remove manual post-parse boilerplate.

## aesh fixes used
- #511: Fallback value chain runs after custom OptionParser
- #512: `${env:...}` resolution on annotation processor path
- #513: LinkedHashMap for @OptionGroup (preserves insertion order)
- #514: Cascading `${key:-fallback}` variable resolution

## Changes

**DefaultValueProvider:**
- Add `fallbackValue()` to JBangDefaultValueProvider for config-based
  fallback on bare flags (`--debug`, `--jfr`, `--open`)
- Split FALLBACK_ONLY_OPTIONS to skip config defaults for debug/jfr
  when the option is omitted (prevents always-on debug)

**DebugConverter (new):**
- Converts raw `--debug` string directly into `Map<String,String>` via
  `@Option(converter=...)`, replacing separate debugRaw/debugString fields

**DebugOptionParser:**
- No longer sets empty sentinel for bare `--debug`; aesh's fallback
  chain (provider fallbackValue -> annotation fallbackValue) handles it

**@OptionGroup for --javaagent:**
- Replace `@OptionList` + manual string splitting + lazy getter with
  `@OptionGroup(defaultValue="")` which handles key=value parsing,
  key-only entries, and insertion order natively

**Boolean field cleanup:**
- Keep `Boolean` wrapper for negatable inherited flags (`verbose`, `quiet`,
  `offline`, `fresh`, `preview`, `printExceptions`) to support tri-state
  config override semantics (e.g. `jbang config set verbose true`
  overridden with `--no-verbose` on the CLI)
- Convert non-negatable options to primitive `boolean` where null
  semantics aren't needed (`insecure`, `enablePreviewRequested`, etc.)

**Env var defaults via `${env:VAR:-}` (aesh#514):**
- AIOptions: `defaultValue = "${env:JBANG_AI_*:-}"` replaces manual
  `System.getenv()` lookups in `Init.afterParse()`

**Other simplifications:**
- Field initializers for userParams (`List<String> = new ArrayList<>()`)
- Remove `resolveAfterParse()` calls from Run, App, Alias
- Remove redundant config fallback from `Edit.applyEditorDefaults()`
- Remove empty `afterParse()` overrides

Co-authored-by: Max Rydahl Andersen <max@xam.dk>