### PR TITLE
PoC: "smart" module-path resolution

### DIFF
--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -29,6 +29,14 @@ public class ModularClassPath {
 	// `org.openjfx:jdk-jsobject`.
 	static final String JDK_JSOBJECT_MODULE = "jdk.jsobject";
 
+	// Proof-of-concept flag, enabled with `-Djbang.hybrid.module.resolve=true`.
+	// When set, jbang stops special-casing JavaFX and instead promotes every
+	// resolved
+	// dependency that is a real (non-automatic) module onto the `--module-path`,
+	// leaving plain jars on the class-path. See
+	// https://github.com/jbangdev/jbang/pull/2511
+	static final String HYBRID_MODULE_RESOLVE_PROPERTY = "jbang.hybrid.module.resolve";
+
 	private final List<ArtifactInfo> artifacts;
 
 	private List<String> classPaths;
@@ -70,6 +78,9 @@ public class ModularClassPath {
 	}
 
 	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
+		if (Boolean.getBoolean(HYBRID_MODULE_RESOLVE_PROPERTY) && supportsModules(jdk)) {
+			return getHybridModuleArguments();
+		}
 		if (hasJavaFX() && supportsModules(jdk)) {
 			List<String> commandArguments = new ArrayList<>();
 
@@ -137,6 +148,72 @@ public class ModularClassPath {
 			}
 			return commandArguments;
 		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	/**
+	 * Proof-of-concept "hybrid" module resolution (see
+	 * https://github.com/jbangdev/jbang/pull/2511), enabled with
+	 * {@code -Djbang.hybrid.module.resolve=true}.
+	 * <p>
+	 * Instead of special-casing JavaFX, this treats the script as a class-path
+	 * application but moves every resolved dependency that is a real
+	 * (non-automatic) module onto the {@code --module-path}, and adds those modules
+	 * as roots so the boot layer resolves them (and whatever they {@code requires})
+	 * transitively.
+	 * <p>
+	 * Crucially, automatic modules are left on the class-path: their name is
+	 * derived from the file name and may not be a valid Java identifier (e.g.
+	 * {@code fastparse_2.13-2.3.3.jar} -> {@code fastparse.2.13}), which would
+	 * abort boot-layer initialization.
+	 */
+	private List<String> getHybridModuleArguments() {
+		List<File> fileList = artifacts.stream()
+			.map(ai -> ai.getFile().toFile())
+			.collect(Collectors.toList());
+
+		ResolvePathsRequest<File> request = ResolvePathsRequest.ofFiles(fileList)
+			.setModuleDescriptor(
+					JavaModuleDescriptor.newModule("bogus")
+						.build());
+
+		try {
+			ResolvePathsResult<File> resolvePathsResult = new LocationManager().resolvePaths(request);
+
+			List<String> modulePaths = new ArrayList<>();
+			List<String> rootModules = new ArrayList<>();
+
+			// Anything plexus already classified as a module-path element.
+			resolvePathsResult.getModulepathElements()
+				.keySet()
+				.forEach(file -> modulePaths.add(file.getPath()));
+
+			// Promote every remaining jar that is a real (non-automatic) module. Plain jars
+			// and automatic modules stay on the class-path.
+			resolvePathsResult.getPathElements().forEach((file, descriptor) -> {
+				if (descriptor != null && descriptor.name() != null && !descriptor.isAutomatic()) {
+					modulePaths.add(file.getPath());
+					rootModules.add(descriptor.name());
+				}
+			});
+
+			if (modulePaths.isEmpty()) {
+				return Collections.emptyList();
+			}
+
+			List<String> commandArguments = new ArrayList<>();
+			commandArguments.add("--module-path");
+			commandArguments.add(modulePaths.stream()
+				.distinct()
+				.collect(Collectors.joining(File.pathSeparator)));
+			if (!rootModules.isEmpty()) {
+				commandArguments.add("--add-modules");
+				commandArguments.add(rootModules.stream().distinct().collect(Collectors.joining(",")));
+			}
+			return commandArguments;
+		} catch (IOException io) {
+			Util.errorMsg("Error resolving hybrid module-path", io);
 			return Collections.emptyList();
 		}
 	}

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -5,13 +5,17 @@ import static dev.jbang.Settings.CP_SEPARATOR;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codehaus.plexus.languages.java.jpms.JavaModuleDescriptor;
@@ -159,14 +163,16 @@ public class ModularClassPath {
 	 * <p>
 	 * Instead of special-casing JavaFX, this treats the script as a class-path
 	 * application but moves every resolved dependency that is a real
-	 * (non-automatic) module onto the {@code --module-path}, and adds those modules
-	 * as roots so the boot layer resolves them (and whatever they {@code requires})
-	 * transitively.
+	 * (non-automatic) module onto the {@code --module-path}, plus every module they
+	 * {@code requires} transitively, and adds those modules as roots.
 	 * <p>
-	 * Crucially, automatic modules are left on the class-path: their name is
-	 * derived from the file name and may not be a valid Java identifier (e.g.
-	 * {@code fastparse_2.13-2.3.3.jar} -> {@code fastparse.2.13}), which would
-	 * abort boot-layer initialization.
+	 * Automatic and plain jars that nobody requires are left on the class-path:
+	 * their name is derived from the file name and may not be a valid Java
+	 * identifier (e.g. {@code fastparse_2.13-2.3.3.jar} -> {@code fastparse.2.13}),
+	 * which would abort boot-layer initialization if forced onto the module-path.
+	 * An automatic module that <em>is</em> required by a promoted module is
+	 * promoted too, since a valid {@code requires} clause guarantees it has a
+	 * usable name.
 	 */
 	private List<String> getHybridModuleArguments() {
 		List<File> fileList = artifacts.stream()
@@ -189,13 +195,48 @@ public class ModularClassPath {
 				.keySet()
 				.forEach(file -> modulePaths.add(file.getPath()));
 
-			// Promote every remaining jar that is a real (non-automatic) module. Plain jars
-			// and automatic modules stay on the class-path.
+			// Index every resolved module (real and automatic) by name so we can follow
+			// `requires` edges below.
+			Map<String, String> moduleNameToPath = new HashMap<>();
+			Map<String, JavaModuleDescriptor> moduleNameToDescriptor = new HashMap<>();
 			resolvePathsResult.getPathElements().forEach((file, descriptor) -> {
-				if (descriptor != null && descriptor.name() != null && !descriptor.isAutomatic()) {
-					modulePaths.add(file.getPath());
-					rootModules.add(descriptor.name());
+				if (descriptor != null && descriptor.name() != null) {
+					moduleNameToPath.put(descriptor.name(), file.getPath());
+					moduleNameToDescriptor.put(descriptor.name(), descriptor);
 				}
+			});
+
+			// Seed with the real (non-automatic) modules, then transitively pull in every
+			// module they `requires`. This also promotes an *automatic* module when it is
+			// required by a promoted module: such a module necessarily has a valid name
+			// (otherwise it could not appear in a `requires` clause), so it is safe on the
+			// module-path. Automatic and plain jars that nobody requires stay on the
+			// class-path, where their file-name-derived (possibly invalid) module name does
+			// no harm.
+			Set<String> promoted = new HashSet<>();
+			Deque<String> toVisit = moduleNameToDescriptor.entrySet()
+				.stream()
+				.filter(e -> !e.getValue().isAutomatic())
+				.map(Map.Entry::getKey)
+				.collect(Collectors.toCollection(ArrayDeque::new));
+			while (!toVisit.isEmpty()) {
+				String name = toVisit.poll();
+				if (!promoted.add(name)) {
+					continue;
+				}
+				JavaModuleDescriptor descriptor = moduleNameToDescriptor.get(name);
+				if (descriptor != null) {
+					descriptor.requires()
+						.stream()
+						.map(JavaModuleDescriptor.JavaRequires::name)
+						.filter(moduleNameToDescriptor::containsKey)
+						.forEach(toVisit::add);
+				}
+			}
+
+			promoted.forEach(name -> {
+				modulePaths.add(moduleNameToPath.get(name));
+				rootModules.add(name);
 			});
 
 			if (modulePaths.isEmpty()) {

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -13,8 +13,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -28,23 +26,9 @@ import dev.jbang.devkitman.Jdk;
 import dev.jbang.util.Util;
 
 public class ModularClassPath {
-	static final String JAVAFX_PREFIX = "javafx";
-	// Required by `javafx.web`; removed from the JDK in 26 and now shipped as
-	// `org.openjfx:jdk-jsobject`.
-	static final String JDK_JSOBJECT_MODULE = "jdk.jsobject";
-
-	// Proof-of-concept flag, enabled with `-Djbang.hybrid.module.resolve=true`.
-	// When set, jbang stops special-casing JavaFX and instead promotes every
-	// resolved
-	// dependency that is a real (non-automatic) module onto the `--module-path`,
-	// leaving plain jars on the class-path. See
-	// https://github.com/jbangdev/jbang/pull/2511
-	static final String HYBRID_MODULE_RESOLVE_PROPERTY = "jbang.hybrid.module.resolve";
-
 	private final List<ArtifactInfo> artifacts;
 
 	private List<String> classPaths;
-	private Optional<Boolean> javafx = Optional.empty();
 
 	public ModularClassPath(List<ArtifactInfo> artifacts) {
 		this.artifacts = artifacts;
@@ -73,93 +57,9 @@ public class ModularClassPath {
 			.collect(Collectors.joining(" "));
 	}
 
-	boolean hasJavaFX() {
-		if (!javafx.isPresent()) {
-			javafx = Optional.of(
-					getClassPath().contains("org/openjfx/javafx-") || getClassPath().contains("org\\openjfx\\javafx-"));
-		}
-		return javafx.get();
-	}
-
-	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
-		if (Boolean.getBoolean(HYBRID_MODULE_RESOLVE_PROPERTY) && supportsModules(jdk)) {
-			return getHybridModuleArguments();
-		}
-		if (hasJavaFX() && supportsModules(jdk)) {
-			List<String> commandArguments = new ArrayList<>();
-
-			List<File> fileList = artifacts.stream()
-				.map(ai -> ai.getFile().toFile())
-				.collect(Collectors.toList());
-
-			ResolvePathsRequest<File> result = ResolvePathsRequest.ofFiles(fileList)
-				.setModuleDescriptor(
-						JavaModuleDescriptor.newModule("bogus")
-							.build());
-
-			LocationManager lm = new LocationManager();
-
-			try {
-				ResolvePathsResult<File> resolvePathsResult = lm.resolvePaths(result);
-
-				List<String> modulePaths = new ArrayList<>();
-				Map<String, JavaModuleDescriptor> pathElements = new HashMap<>();
-
-				resolvePathsResult.getModulepathElements()
-					.keySet()
-					.forEach(file -> modulePaths.add(file.getPath()));
-
-				resolvePathsResult.getPathElements().forEach((key, value) -> pathElements.put(key.getPath(), value));
-
-				pathElements.forEach((k, v) -> {
-					if (v != null && v.name() != null
-							&& (v.name().startsWith(JAVAFX_PREFIX) || v.name().equals(JDK_JSOBJECT_MODULE))) {
-						// JavaFX jars belong on the module-path. So does `jdk.jsobject`, which is
-						// required by `javafx.web`: until JDK 25 it was part of the JDK, but JDK 26
-						// removed it and openjfx now ships it as the separate
-						// `org.openjfx:jdk-jsobject`
-						// artifact. Left on the class-path the boot layer cannot find it and fails with
-						// `Module jdk.jsobject not found, required by javafx.web`.
-						// See https://github.com/jbangdev/jbang/issues/559
-						modulePaths.add(k);
-					} else {
-						// classpathElements.add(k);
-					}
-				});
-
-				if (!modulePaths.isEmpty()) {
-					commandArguments.add("--module-path");
-					String modulePath = String.join(File.pathSeparator, modulePaths);
-					commandArguments.add(modulePath);
-				}
-
-				String modules = pathElements.values()
-					.stream()
-					.filter(Objects::nonNull)
-					.map(JavaModuleDescriptor::name)
-					.filter(Objects::nonNull)
-					.filter(module -> module.startsWith(JAVAFX_PREFIX)
-							&& !module.endsWith("Empty"))
-					.collect(Collectors.joining(","));
-				if (!Util.isBlankString(modules)) {
-					commandArguments.add("--add-modules");
-					commandArguments.add(modules);
-				}
-
-			} catch (IOException io) {
-				Util.errorMsg("Error processing javafx modules", io);
-				return Collections.emptyList();
-			}
-			return commandArguments;
-		} else {
-			return Collections.emptyList();
-		}
-	}
-
 	/**
-	 * Proof-of-concept "hybrid" module resolution (see
-	 * https://github.com/jbangdev/jbang/pull/2511), enabled with
-	 * {@code -Djbang.hybrid.module.resolve=true}.
+	 * "Hybrid" module resolution (see
+	 * https://github.com/jbangdev/jbang/pull/2511).
 	 * <p>
 	 * Instead of special-casing JavaFX, this treats the script as a class-path
 	 * application but moves every resolved dependency that is a real
@@ -174,7 +74,10 @@ public class ModularClassPath {
 	 * promoted too, since a valid {@code requires} clause guarantees it has a
 	 * usable name.
 	 */
-	private List<String> getHybridModuleArguments() {
+	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
+		if (!supportsModules(jdk)) {
+			return Collections.emptyList();
+		}
 		List<File> fileList = artifacts.stream()
 			.map(ai -> ai.getFile().toFile())
 			.collect(Collectors.toList());

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ public class ModularClassPath {
 	private final List<ArtifactInfo> artifacts;
 
 	private List<String> classPaths;
+	private Optional<Boolean> javafx = Optional.empty();
 
 	public ModularClassPath(List<ArtifactInfo> artifacts) {
 		this.artifacts = artifacts;
@@ -57,14 +59,32 @@ public class ModularClassPath {
 			.collect(Collectors.joining(" "));
 	}
 
+	boolean hasJavaFX() {
+		if (!javafx.isPresent()) {
+			javafx = Optional.of(
+					getClassPath().contains("org/openjfx/javafx-") || getClassPath().contains("org\\openjfx\\javafx-"));
+		}
+		return javafx.get();
+	}
+
 	/**
-	 * "Hybrid" module resolution (see
+	 * Builds the {@code --module-path}/{@code --add-modules} arguments for a JavaFX
+	 * application, using a "hybrid" resolution (see
 	 * https://github.com/jbangdev/jbang/pull/2511).
 	 * <p>
-	 * Instead of special-casing JavaFX, this treats the script as a class-path
-	 * application but moves every resolved dependency that is a real
-	 * (non-automatic) module onto the {@code --module-path}, plus every module they
-	 * {@code requires} transitively, and adds those modules as roots.
+	 * This only kicks in when JavaFX is detected on the class-path. A plain
+	 * class-path application (e.g. Quarkus) must <em>stay</em> on the class-path:
+	 * promoting its jars to the module-path turns them into named modules, which
+	 * lose the relaxed reflective access of the unnamed module that many frameworks
+	 * rely on (e.g. {@code jboss-logging} building a logger proxy for a type that
+	 * is still on the class-path). {@code //MODULE} scripts are not handled here
+	 * either - the command generators put their whole class-path on the module-path
+	 * via {@code -p} and launch with {@code -m}.
+	 * <p>
+	 * Rather than special-casing JavaFX module names, the resolution moves every
+	 * resolved dependency that is a real (non-automatic) module onto the
+	 * {@code --module-path}, plus every module they {@code requires} transitively,
+	 * and adds those modules as roots.
 	 * <p>
 	 * Automatic and plain jars that nobody requires are left on the class-path:
 	 * their name is derived from the file name and may not be a valid Java
@@ -72,10 +92,11 @@ public class ModularClassPath {
 	 * which would abort boot-layer initialization if forced onto the module-path.
 	 * An automatic module that <em>is</em> required by a promoted module is
 	 * promoted too, since a valid {@code requires} clause guarantees it has a
-	 * usable name.
+	 * usable name (this is how {@code jdk.jsobject}, required by {@code javafx.web}
+	 * and shipped separately since JDK 26, lands on the module-path).
 	 */
 	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
-		if (!supportsModules(jdk)) {
+		if (!hasJavaFX() || !supportsModules(jdk)) {
 			return Collections.emptyList();
 		}
 		List<File> fileList = artifacts.stream()

--- a/src/main/java/dev/jbang/dependencies/ModularClassPath.java
+++ b/src/main/java/dev/jbang/dependencies/ModularClassPath.java
@@ -81,19 +81,27 @@ public class ModularClassPath {
 	 * either - the command generators put their whole class-path on the module-path
 	 * via {@code -p} and launch with {@code -m}.
 	 * <p>
-	 * Rather than special-casing JavaFX module names, the resolution moves every
-	 * resolved dependency that is a real (non-automatic) module onto the
-	 * {@code --module-path}, plus every module they {@code requires} transitively,
-	 * and adds those modules as roots.
+	 * Resolution is seeded with the JavaFX modules themselves and then follows
+	 * their {@code requires} edges transitively: every {@code javafx.*} module and
+	 * everything they require lands on the {@code --module-path} and is added as a
+	 * root. Crucially it does <em>not</em> promote unrelated real modules that
+	 * merely happen to be on the class-path - a quarkus-fx style application
+	 * bundles plenty of those (e.g. {@code jboss-logging},
+	 * {@code smallrye-config}), and turning some of them into named modules while
+	 * their collaborators stay on the class-path is exactly what breaks reflective
+	 * access (a named {@code jboss-logging} cannot build a logger proxy for
+	 * {@code smallrye-config}'s {@code ConfigLogging} interface that is still in
+	 * the unnamed module).
 	 * <p>
-	 * Automatic and plain jars that nobody requires are left on the class-path:
-	 * their name is derived from the file name and may not be a valid Java
-	 * identifier (e.g. {@code fastparse_2.13-2.3.3.jar} -> {@code fastparse.2.13}),
-	 * which would abort boot-layer initialization if forced onto the module-path.
-	 * An automatic module that <em>is</em> required by a promoted module is
-	 * promoted too, since a valid {@code requires} clause guarantees it has a
-	 * usable name (this is how {@code jdk.jsobject}, required by {@code javafx.web}
-	 * and shipped separately since JDK 26, lands on the module-path).
+	 * Automatic and plain jars that no JavaFX module requires are left on the
+	 * class-path: their name is derived from the file name and may not be a valid
+	 * Java identifier (e.g. {@code fastparse_2.13-2.3.3.jar} ->
+	 * {@code fastparse.2.13}), which would abort boot-layer initialization if
+	 * forced onto the module-path. An automatic module that <em>is</em> required by
+	 * a JavaFX module is promoted too, since a valid {@code requires} clause
+	 * guarantees it has a usable name (this is how {@code jdk.jsobject}, required
+	 * by {@code javafx.web} and shipped separately since JDK 26, lands on the
+	 * module-path).
 	 */
 	public List<String> getAutoDectectedModuleArguments(@NonNull Jdk jdk) {
 		if (!hasJavaFX() || !supportsModules(jdk)) {
@@ -130,18 +138,17 @@ public class ModularClassPath {
 				}
 			});
 
-			// Seed with the real (non-automatic) modules, then transitively pull in every
-			// module they `requires`. This also promotes an *automatic* module when it is
-			// required by a promoted module: such a module necessarily has a valid name
-			// (otherwise it could not appear in a `requires` clause), so it is safe on the
-			// module-path. Automatic and plain jars that nobody requires stay on the
-			// class-path, where their file-name-derived (possibly invalid) module name does
-			// no harm.
+			// Seed with the JavaFX modules, then transitively pull in every module they
+			// `requires`. This also promotes an *automatic* module when it is required by a
+			// JavaFX module: such a module necessarily has a valid name (otherwise it could
+			// not appear in a `requires` clause), so it is safe on the module-path. Every
+			// other jar - automatic or real - stays on the class-path; promoting unrelated
+			// real modules (e.g. jboss-logging) is what breaks frameworks that rely on the
+			// relaxed reflective access of the unnamed module.
 			Set<String> promoted = new HashSet<>();
-			Deque<String> toVisit = moduleNameToDescriptor.entrySet()
+			Deque<String> toVisit = moduleNameToDescriptor.keySet()
 				.stream()
-				.filter(e -> !e.getValue().isAutomatic())
-				.map(Map.Entry::getKey)
+				.filter(name -> name.startsWith("javafx."))
 				.collect(Collectors.toCollection(ArrayDeque::new));
 			while (!toVisit.isEmpty()) {
 				String name = toVisit.poll();

--- a/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
+++ b/src/test/java/dev/jbang/dependencies/DependencyResolverTest.java
@@ -218,6 +218,39 @@ class DependencyResolverTest extends BaseTest {
 	}
 
 	@Test
+	void testResolveJavaModulesKeepsUnrelatedRealModulesOnClasspath() throws IOException {
+		// A "quarkus-fx" style mix: JavaFX (which must go on the module-path) next to
+		// an unrelated *real* module that a framework reflects on at runtime. Promoting
+		// such a module to a named module while its collaborators stay on the
+		// class-path
+		// breaks reflective access - the original symptom was jboss-logging (named)
+		// failing to build a logger proxy for smallrye-config's ConfigLogging interface
+		// that is still in the unnamed module. See
+		// https://github.com/jbangdev/jbang/pull/2511.
+		List<String> deps = Arrays.asList("org.openjfx:javafx-graphics:11.0.2:mac",
+				"org.jboss.logging:jboss-logging:3.6.0.Final");
+
+		ModularClassPath cp = new ModularClassPath(
+				DependencyUtil.resolveDependencies(deps, Collections.emptyList(), false, false, false, true, false)
+					.getArtifacts()) {
+			@Override
+			protected boolean supportsModules(Jdk jdk) {
+				return true;
+			}
+		};
+
+		List<String> ma = cp.getAutoDectectedModuleArguments(defaultJdkManager().getOrInstallJdk(null));
+		String moduleArgs = String.join(" ", ma);
+
+		// JavaFX is promoted to the module-path...
+		assertThat(ma, hasItem("--module-path"));
+		assertThat(moduleArgs, containsString("javafx"));
+		// ...but the unrelated real module is left on the class-path.
+		assertThat(moduleArgs, not(containsString("jboss-logging")));
+		assertThat(cp.getClassPath(), containsString("jboss-logging"));
+	}
+
+	@Test
 	void testImportPOM() {
 
 		List<String> deps = Arrays.asList("org.slf4j:slf4j-bom:2.0.17@pom", "org.slf4j:slf4j-api");


### PR DESCRIPTION
## Related comments and issues

- https://github.com/jbangdev/jbang/pull/2511#issuecomment-4646421656
- Refs https://github.com/jbangdev/jbang/issues/2126

---

Claude-generated information:

## Proof of concept — hybrid module-path resolution

Follow-up to #2511 / #559. PoC for the idea @quintesse raised (at https://github.com/jbangdev/jbang/pull/2511#issuecomment-4646421656): instead of special-casing JavaFX, treat the script as a class-path application but move any dependency that **is** a module onto the `--module-path`, and see if that resolves the JavaFX/`jdk.jsobject` case (and works in general).

Gated behind a system property so default behaviour is unchanged:

```
jbang -Djbang.hybrid.module.resolve=true myscript.java
```

### What it does

When the flag is set, `ModularClassPath.getAutoDectectedModuleArguments` skips the JavaFX path entirely and instead:

1. Promotes every resolved dependency that is a **real (non-automatic) module** onto `--module-path`.
2. Walks their `requires` edges transitively and promotes any required module present in the resolved artifacts — **including an automatic module**, which is safe because a valid `requires` clause guarantees a usable module name.
3. Adds the promoted modules as `--add-modules` roots so the boot layer resolves them.
4. Leaves plain jars (and automatic modules nobody requires) on the class-path.

The key rule: **never force an automatic module onto the module-path unless it is required by a real module.** Their name is derived from the file name and may be an invalid Java identifier (e.g. `fastparse_2.13-2.3.3.jar` → `fastparse.2.13`), which aborts boot-layer init — this is exactly what killed the naive "put everything on the module-path" attempt.

### MWE / verification

Reproducer for the original bug (fails on stock jbang `0.138`):

```java
//JAVA 26+
//DEPS org.openjfx:javafx-web:26.0.1:${os.detected.jfxname}
//RUNTIME_OPTIONS --enable-native-access=ALL-UNNAMED

public class fxweb {
    public static void main(String[] args) {
        System.out.println("Boot layer OK: javafx.web + jdk.jsobject resolved");
    }
}
```

`0.138` → `FindException: Module jdk.jsobject not found, required by javafx.web`.

Tested the hybrid path on a mixed dependency set that contains both real modules and the offending non-modular jar:

```java
//DEPS org.openjfx:javafx-web:26.0.1:${os.detected.jfxname}
//DEPS com.lihaoyi:fastparse_2.13:2.3.3
```

With `-Djbang.hybrid.module.resolve=true`:
- `javafx.*` + `jdk.jsobject` → module-path
- `fastparse_2.13` (+ transitives) → class-path
- boots fine, **no JavaFX special-casing involved**

### Status

This is a proof of concept for discussion, not a finished feature — happy to iterate on how/whether to expose it to users (and whether it should eventually replace the JavaFX special-casing merged in #2511).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
