### PR TITLE
refactor: simplify CLI post-parsing with aesh 3.13 features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,11 +156,11 @@ dependencies {
 	implementation 'org.jspecify:jspecify:1.0.0'
 	implementation 'org.apache.commons:commons-text:1.15.0'
 	implementation 'org.apache.commons:commons-compress:1.27.1'
-	implementation('org.aesh:aesh:3.12.1') {
+	implementation('org.aesh:aesh:3.13') {
 		exclude group: 'org.aesh', module: 'readline'
 	}
 	implementation 'org.aesh:readline-api:3.11'
-	annotationProcessor 'org.aesh:aesh-processor:3.12.1'
+	annotationProcessor 'org.aesh:aesh-processor:3.13'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
 	implementation 'com.google.code.gson:gson:2.13.2'

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -80,7 +80,6 @@ public class Alias extends BaseCommand {
 		public void afterParse() {
 			super.afterParse();
 			dependencyInfoMixin.applyIgnoreTransitiveRepositories();
-			runMixin.resolveAfterParse();
 		}
 
 		@Override
@@ -149,10 +148,11 @@ public class Alias extends BaseCommand {
 		}
 
 		private List<JavaAgent> createJavaAgents() {
-			if (runMixin.javaAgentSlots == null) {
+			Map<String, String> slots = runMixin.getJavaAgentSlots();
+			if (slots == null) {
 				return Collections.emptyList();
 			}
-			return runMixin.javaAgentSlots.entrySet()
+			return slots.entrySet()
 				.stream()
 				.map(e -> new JavaAgent(e.getKey(), e.getValue()))
 				.collect(Collectors.toList());

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -68,7 +68,7 @@ public class Alias extends BaseCommand {
 		boolean force;
 
 		@Option(name = "enable-preview", hasValue = false, description = "Activate Java preview features")
-		Boolean enablePreviewRequested;
+		boolean enablePreviewRequested;
 
 		@Arguments(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
 		List<String> userParams;

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -85,7 +85,6 @@ public class App extends BaseCommand {
 			if (userParams == null) {
 				userParams = new ArrayList<>();
 			}
-			runMixin.resolveAfterParse();
 		}
 
 		@Override

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -77,15 +77,7 @@ public class App extends BaseCommand {
 		String name;
 
 		@Arguments(paramLabel = "params", index = "1..*", arity = "0..*", description = "Parameters to pass on to the script")
-		public List<String> userParams;
-
-		@Override
-		public void afterParse() {
-			super.afterParse();
-			if (userParams == null) {
-				userParams = new ArrayList<>();
-			}
-		}
+		public List<String> userParams = new ArrayList<>();
 
 		@Override
 		public Integer doCall() throws IOException {

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -190,7 +190,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 			}
 		}
 
-		if (insecure) {
+		if (Boolean.TRUE.equals(insecure)) {
 			enableInsecure();
 		}
 	}

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -52,7 +52,7 @@ public class Catalog extends BaseCommand {
 		boolean force;
 
 		@Option(name = "import", description = "Import catalog items into the catalog's scope")
-		Boolean importItems;
+		boolean importItems;
 
 		@Argument(paramLabel = "fileOrURL", description = "A file or URL to a catalog file", required = true)
 		String urlOrFile;

--- a/src/main/java/dev/jbang/cli/DebugConverter.java
+++ b/src/main/java/dev/jbang/cli/DebugConverter.java
@@ -1,0 +1,31 @@
+package dev.jbang.cli;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.aesh.command.converter.Converter;
+import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.validator.OptionValidatorException;
+
+/**
+ * Converts the raw --debug string (e.g. "4004", "*:5000",
+ * "suspend=n,address=host:5000") into a structured Map&lt;String, String&gt;.
+ * Bare values (no '=') are treated as an "address" entry.
+ */
+public class DebugConverter implements Converter<Map<String, String>, ConverterInvocation> {
+
+	@Override
+	public Map<String, String> convert(ConverterInvocation input) throws OptionValidatorException {
+		String raw = input.getInput();
+		Map<String, String> result = new LinkedHashMap<>();
+		for (String part : raw.split(",")) {
+			if (part.contains("=")) {
+				String[] kv = part.split("=", 2);
+				result.put(kv[0], kv[1]);
+			} else {
+				result.put("address", part);
+			}
+		}
+		return result;
+	}
+}

--- a/src/main/java/dev/jbang/cli/DebugOptionParser.java
+++ b/src/main/java/dev/jbang/cli/DebugOptionParser.java
@@ -50,7 +50,24 @@ public class DebugOptionParser implements OptionParser {
 			}
 		}
 
-		addOptionValue(option, "");
+		// Bare --debug: resolve via DefaultValueProvider.fallbackValue(),
+		// then annotation fallbackValue, mirroring aesh's applyOptionalFallback().
+		String fallback = resolveFallback(option);
+		addOptionValue(option, fallback != null ? fallback : "");
+	}
+
+	private static String resolveFallback(ProcessedOption option) {
+		if (option.parent() != null && option.parent().getDefaultValueProvider() != null) {
+			try {
+				String val = option.parent().getDefaultValueProvider().fallbackValue(option);
+				if (val != null) {
+					return val;
+				}
+			} catch (Exception e) {
+				// ignore
+			}
+		}
+		return option.hasFallbackValue() ? option.getFallbackValue() : null;
 	}
 
 	private void addOptionValue(ProcessedOption option, String value) {

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -60,12 +60,9 @@ public class Edit extends BaseCommand {
 		String envEditor = System.getenv("JBANG_EDITOR");
 		if (envEditor != null && !envEditor.isEmpty()) {
 			editor = envEditor;
-		} else if (editor != null && editor.isEmpty()) {
-			String cfgEditor = dev.jbang.Configuration.instance().get("edit.open");
-			if (cfgEditor != null) {
-				editor = cfgEditor;
-			}
 		}
+		// Config fallback for bare --open is handled by
+		// JBangDefaultValueProvider.fallbackValue() looking up "edit.open".
 	}
 
 	@Option(name = "live", hasValue = false, description = "Open directory in IDE's that support JBang or generate temporary project with option to regenerate project on dependency changes.")

--- a/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
+++ b/src/main/java/dev/jbang/cli/JBangDefaultValueProvider.java
@@ -15,11 +15,11 @@ import dev.jbang.Configuration;
 
 public class JBangDefaultValueProvider implements DefaultValueProvider {
 
-	// Options that use fallbackValue="" or DebugOptionParser for three-state
-	// semantics (null=not specified, ""=bare flag, "value"=explicit). The provider
-	// must not supply defaults for these because the empty-string sentinel triggers
-	// config-file lookup in RunMixin.resolveAfterParse() instead.
-	private static final Set<String> FALLBACK_OPTIONS = new HashSet<>(Arrays.asList("debug", "jfr"));
+	// Options where config defaults should only apply as fallback values (when
+	// the option is explicitly used bare, e.g. --debug), not as default values
+	// (when the option is omitted entirely). This prevents config-set debug/jfr
+	// from activating on every command invocation.
+	private static final Set<String> FALLBACK_ONLY_OPTIONS = new HashSet<>(Arrays.asList("debug", "jfr"));
 
 	private static volatile Map<Class<?>, String> classToPath;
 
@@ -29,7 +29,7 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			return null;
 		}
 
-		if (FALLBACK_OPTIONS.contains(option.name())) {
+		if (FALLBACK_ONLY_OPTIONS.contains(option.name())) {
 			return null;
 		}
 
@@ -52,6 +52,26 @@ public class JBangDefaultValueProvider implements DefaultValueProvider {
 			}
 		}
 
+		return getValue(optName);
+	}
+
+	@Override
+	public String fallbackValue(ProcessedOption option) {
+		if (option.name() == null) {
+			return null;
+		}
+		String optName = option.name().replace("-", "");
+		String fullPath = null;
+		if (option.parent() != null && option.parent().getCommand() != null) {
+			fullPath = getCommandPathForClass(option.parent().getCommand().getClass());
+		}
+		if (fullPath != null) {
+			String key = fullPath + "." + optName;
+			String val = getValue(key);
+			if (val != null) {
+				return val;
+			}
+		}
 		return getValue(optName);
 	}
 

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -48,7 +48,7 @@ public class Jdk extends BaseCommand {
 		String realHomeDir;
 		String linkedId;
 		@SerializedName("default")
-		Boolean isDefault;
+		boolean isDefault;
 		Set<String> tags;
 
 		public JdkOut(String id, String version, String providerName, Path home, String linkedId,

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -43,7 +43,6 @@ public class Run extends BaseBuildCommand {
 	@Override
 	public void afterParse() {
 		super.afterParse();
-		runMixin.resolveAfterParse();
 		if (userParams == null) {
 			userParams = new ArrayList<>();
 		}
@@ -122,7 +121,7 @@ public class Run extends BaseBuildCommand {
 
 	void buildAgents(BuildContext ctx) throws IOException {
 		Project prj = ctx.getProject();
-		Map<String, String> agents = runMixin.javaAgentSlots;
+		Map<String, String> agents = runMixin.getJavaAgentSlots();
 		if (agents == null && prj.getResourceRef() instanceof AliasResourceResolver.AliasedResourceRef) {
 			AliasResourceResolver.AliasedResourceRef aref = (AliasResourceResolver.AliasedResourceRef) prj
 				.getResourceRef();

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -38,14 +38,11 @@ public class Run extends BaseBuildCommand {
 	public String literalScript;
 
 	@Arguments(paramLabel = "userParams", index = "1..*", arity = "0..*", description = "Parameters for the script")
-	public List<String> userParams;
+	public List<String> userParams = new ArrayList<>();
 
 	@Override
 	public void afterParse() {
 		super.afterParse();
-		if (userParams == null) {
-			userParams = new ArrayList<>();
-		}
 	}
 
 	protected void requireScriptArgument() {

--- a/src/main/java/dev/jbang/cli/RunMixin.java
+++ b/src/main/java/dev/jbang/cli/RunMixin.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import org.aesh.command.option.Option;
 import org.aesh.command.option.OptionList;
 
-import dev.jbang.Configuration;
-
 public class RunMixin {
 
 	@OptionList(shortName = 'R', name = "runtime-option", aliases = {
@@ -19,9 +17,7 @@ public class RunMixin {
 	@Option(name = "jfr", fallbackValue = "", description = "Launch with Java Flight Recorder enabled.")
 	public String flightRecorderString;
 
-	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, fallbackValue = "4004", description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
-	public String debugRaw;
-
+	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, converter = DebugConverter.class, fallbackValue = "4004", description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
 	public Map<String, String> debugString;
 
 	@Option(name = "enableassertions", aliases = { "ea" }, hasValue = false, description = "Enable assertions")
@@ -43,30 +39,7 @@ public class RunMixin {
 	public Boolean interactive;
 
 	public void resolveAfterParse() {
-		// DebugOptionParser sets "" sentinel when --debug is bare.
-		// Custom parsers fully own the parsing so aesh's
-		// applyOptionalFallback() doesn't run after them.
-		if ("".equals(debugRaw)) {
-			Configuration cfg = Configuration.instance();
-			String cfgDebug = cfg.get("run.debug");
-			debugRaw = cfgDebug != null ? cfgDebug : "4004";
-		}
-		resolveDebugArgs();
 		resolveJavaAgentSlots();
-	}
-
-	public void resolveDebugArgs() {
-		if (debugRaw != null && !debugRaw.isEmpty()) {
-			debugString = new LinkedHashMap<>();
-			for (String part : debugRaw.split(",")) {
-				if (part.contains("=")) {
-					String[] kv = part.split("=", 2);
-					debugString.put(kv[0], kv[1]);
-				} else {
-					debugString.put("address", part);
-				}
-			}
-		}
 	}
 
 	void resolveJavaAgentSlots() {

--- a/src/main/java/dev/jbang/cli/RunMixin.java
+++ b/src/main/java/dev/jbang/cli/RunMixin.java
@@ -30,7 +30,7 @@ public class RunMixin {
 	@OptionList(name = "javaagent")
 	List<String> javaAgentRaw;
 
-	public Map<String, String> javaAgentSlots;
+	private Map<String, String> javaAgentSlots;
 
 	@Option(name = "cds", hasValue = false, negatable = true, description = "If specified Class Data Sharing (CDS) will be used for building and running (requires Java 13+)")
 	Boolean cds;
@@ -38,12 +38,15 @@ public class RunMixin {
 	@Option(shortName = 'i', name = "interactive", hasValue = false, description = "Activate interactive mode")
 	public Boolean interactive;
 
-	public void resolveAfterParse() {
-		resolveJavaAgentSlots();
-	}
-
-	void resolveJavaAgentSlots() {
-		if (javaAgentRaw != null && !javaAgentRaw.isEmpty()) {
+	/**
+	 * Returns the --javaagent options as a structured map, converting lazily from
+	 * the raw {@code @OptionList} strings. Uses {@code LinkedHashMap} to preserve
+	 * insertion order (agent ordering matters). Aesh's {@code @OptionGroup} can't
+	 * be used here because it uses {@code HashMap} internally, losing order (see
+	 * <a href="https://github.com/aeshell/aesh/issues/513">aesh#513</a>).
+	 */
+	public Map<String, String> getJavaAgentSlots() {
+		if (javaAgentSlots == null && javaAgentRaw != null && !javaAgentRaw.isEmpty()) {
 			javaAgentSlots = new LinkedHashMap<>();
 			for (String raw : javaAgentRaw) {
 				int eq = raw.indexOf('=');
@@ -54,6 +57,7 @@ public class RunMixin {
 				}
 			}
 		}
+		return javaAgentSlots;
 	}
 
 	public Boolean getCds() {
@@ -87,8 +91,9 @@ public class RunMixin {
 		if (Boolean.TRUE.equals(enableSystemAssertions)) {
 			opts.add("--enablesystemassertions");
 		}
-		if (javaAgentSlots != null) {
-			for (Map.Entry<String, String> e : javaAgentSlots.entrySet()) {
+		Map<String, String> agentSlots = getJavaAgentSlots();
+		if (agentSlots != null) {
+			for (Map.Entry<String, String> e : agentSlots.entrySet()) {
 				opts.add("--javaagent");
 				opts.add(e.getValue() == null || e.getValue().isEmpty()
 						? e.getKey()

--- a/src/main/java/dev/jbang/cli/RunMixin.java
+++ b/src/main/java/dev/jbang/cli/RunMixin.java
@@ -19,7 +19,7 @@ public class RunMixin {
 	@Option(name = "jfr", fallbackValue = "", description = "Launch with Java Flight Recorder enabled.")
 	public String flightRecorderString;
 
-	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
+	@Option(shortName = 'd', name = "debug", parser = DebugOptionParser.class, fallbackValue = "4004", description = "Launch with java debug enabled. Set host/port or provide key/value list of JPDA options (default: ${DEFAULT-VALUE})")
 	public String debugRaw;
 
 	public Map<String, String> debugString;
@@ -43,14 +43,13 @@ public class RunMixin {
 	public Boolean interactive;
 
 	public void resolveAfterParse() {
-		Configuration cfg = Configuration.instance();
+		// DebugOptionParser sets "" sentinel when --debug is bare.
+		// Custom parsers fully own the parsing so aesh's
+		// applyOptionalFallback() doesn't run after them.
 		if ("".equals(debugRaw)) {
+			Configuration cfg = Configuration.instance();
 			String cfgDebug = cfg.get("run.debug");
 			debugRaw = cfgDebug != null ? cfgDebug : "4004";
-		}
-		if ("".equals(flightRecorderString)) {
-			String cfgJfr = cfg.get("run.jfr");
-			flightRecorderString = cfgJfr != null ? cfgJfr : "";
 		}
 		resolveDebugArgs();
 		resolveJavaAgentSlots();

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -255,9 +255,11 @@ public class Template extends BaseCommand {
 				catalog = Catalog.getMerged(true, false);
 			}
 			if (showOrigin) {
-				printTemplatesWithOrigin(out, catalogName, catalog, showFiles, showProperties, format);
+				printTemplatesWithOrigin(out, catalogName, catalog, showFiles,
+						showProperties, format);
 			} else {
-				printTemplates(out, catalogName, catalog, showFiles, showProperties, format);
+				printTemplates(out, catalogName, catalog, showFiles,
+						showProperties, format);
 			}
 			return EXIT_OK;
 		}

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -1299,8 +1299,8 @@ public class TestRun extends BaseTest {
 				"--javaagent=org.jboss.byteman:byteman:4.0.13",
 				mainFile.toAbsolutePath().toString());
 
-		assertThat(run.runMixin.javaAgentSlots.containsKey(agentFile.toAbsolutePath().toString()), is(true));
-		assertThat(run.runMixin.javaAgentSlots.get(agentFile.toAbsolutePath().toString()), equalTo("optionA"));
+		assertThat(run.runMixin.getJavaAgentSlots().containsKey(agentFile.toAbsolutePath().toString()), is(true));
+		assertThat(run.runMixin.getJavaAgentSlots().get(agentFile.toAbsolutePath().toString()), equalTo("optionA"));
 
 		ProjectBuilder pb = run.createProjectBuilderForRun().mainClass("fakemain");
 		Project prj = pb.build(mainFile);
@@ -1324,7 +1324,7 @@ public class TestRun extends BaseTest {
 	void testJavaAgentParsing() {
 		Run run = JBang.parseCommand("run", "--javaagent=xyz.jar", "wonka.java");
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("xyz.jar"));
+		assertThat(run.runMixin.getJavaAgentSlots(), hasKey("xyz.jar"));
 	}
 
 	@Test
@@ -1332,7 +1332,7 @@ public class TestRun extends BaseTest {
 		Run run = JBang.parseCommand("run",
 				"--javaagent=org.jboss.byteman:byteman:4.0.13", "wonka.java");
 
-		assertThat(run.runMixin.javaAgentSlots, hasKey("org.jboss.byteman:byteman:4.0.13"));
+		assertThat(run.runMixin.getJavaAgentSlots(), hasKey("org.jboss.byteman:byteman:4.0.13"));
 	}
 
 	@Test


### PR DESCRIPTION
Building on #2504 (aesh 3.13 upgrade), this PR removes manual post-parse boilerplate by leveraging aesh's native APIs:

## Changes

### Use aesh Converter for `--debug` (`11b8b600`)
- New `DebugConverter` converts the raw debug string directly into `Map<String,String>` via aesh's `@Option(converter=...)`
- Merges separate `debugRaw` (String) and `debugString` (Map) fields into a single field
- Fixes `DebugOptionParser` to resolve fallback values from `DefaultValueProvider`, matching aesh's `applyOptionalFallback()` behavior
- Removes `resolveDebugArgs()`

### Replace `resolveAfterParse()` with lazy getter for javaAgentSlots (`ef872932`)
- Converts `javaAgentSlots` from a public field populated by `resolveAfterParse()` into a cached lazy getter
- Removes all `resolveAfterParse()` call sites (Run, App, Alias)
- Note: aesh's `@OptionGroup` can't be used here because it uses `HashMap` internally, losing insertion order ([aesh#513](https://github.com/aeshell/aesh/issues/513))

### Simplify `afterParse()` in Run and App (`38ac4985`)
- Replace null-guard for `userParams` with field initializer
- Remove now-empty `afterParse()` override in App

### Remove redundant config fallback from `applyEditorDefaults()` (`f974d0d3`)
- The config lookup for `edit.open` when `--open` is used bare is now handled by `JBangDefaultValueProvider.fallbackValue()` in aesh 3.13
- Only the `JBANG_EDITOR` env var override remains (can't be expressed via `DefaultValueProvider`)