### PR TITLE
feat: lock/digest integrity verification (aesh + resolver SPI)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -172,6 +172,8 @@ dependencies {
 	implementation "org.jboss:jandex:2.2.3.Final"
 
 	implementation "eu.maveniverse.maven.mima:context:2.4.36"
+	implementation "org.apache.maven.resolver:maven-resolver-spi:1.9.24"
+	implementation "org.apache.maven.resolver:maven-resolver-impl:1.9.24"
 	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.36"
 	implementation "org.apache.maven:maven-model:3.9.11"
 

--- a/build.gradle
+++ b/build.gradle
@@ -172,8 +172,10 @@ dependencies {
 	implementation "org.jboss:jandex:2.2.3.Final"
 
 	implementation "eu.maveniverse.maven.mima:context:2.4.36"
-	implementation "org.apache.maven.resolver:maven-resolver-spi:1.9.24"
-	implementation "org.apache.maven.resolver:maven-resolver-impl:1.9.24"
+	compileOnly    "org.apache.maven.resolver:maven-resolver-spi:1.9.24"
+	compileOnly    "org.apache.maven.resolver:maven-resolver-impl:1.9.24"
+	testImplementation "org.apache.maven.resolver:maven-resolver-spi:1.9.24"
+	testImplementation "org.apache.maven.resolver:maven-resolver-impl:1.9.24"
 	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.36"
 	implementation "org.apache.maven:maven-model:3.9.11"
 

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -90,6 +90,7 @@ public class Main {
 			Set<String> names = new LinkedHashSet<>();
 			names.add("run");
 			names.add("build");
+			names.add("lock");
 			names.add("edit");
 			names.add("init");
 			names.add("alias");

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -17,7 +17,7 @@ import dev.jbang.Main;
 import dev.jbang.util.Util;
 
 @CommandDefinition(name = "jbang", description = "jbang is a tool for building and running .java/.jsh scripts and jar packages.", groupCommands = {
-		Run.class, Build.class, Init.class, Edit.class, Deps.class,
+		Run.class, Build.class, Lock.class, Init.class, Edit.class, Deps.class,
 		Cache.class, Export.class, Jdk.class,
 		Config.class, Trust.class, Alias.class, Template.class, Catalog.class, App.class,
 		Completion.class, Info.class, Version.class,

--- a/src/main/java/dev/jbang/cli/Lock.java
+++ b/src/main/java/dev/jbang/cli/Lock.java
@@ -2,14 +2,21 @@ package dev.jbang.cli;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmHelper;
 
+import dev.jbang.dependencies.ArtifactInfo;
+import dev.jbang.dependencies.JBangTrustedChecksumsSource;
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
@@ -37,26 +44,47 @@ public class Lock extends BaseBuildCommand {
 
 		String digest = DigestUtil.digestResource(prj, algorithm);
 		Path effectiveLockFile = DigestUtil.resolveLockFile(lockFile, ref);
+
 		List<String> sources = prj.getMainSourceSet()
 			.getSources()
 			.stream()
 			.map(s -> s.getOriginalResource() == null ? "" : s.getOriginalResource())
 			.collect(Collectors.toList());
+
 		BuildContext bctx = BuildContext.forProject(prj);
-		List<String> deps = bctx.resolveClassPath()
-			.getArtifacts()
-			.stream()
-			.map(a -> a.getCoordinate() == null ? "" : a.getCoordinate().toCanonicalForm())
+		List<ArtifactInfo> artifacts = bctx.resolveClassPath().getArtifacts();
+		List<String> deps = artifacts.stream()
+			.map(a -> a.getCoordinate() == null ? ""
+					: a.getCoordinate().toCanonicalForm())
 			.filter(s -> !s.isEmpty())
 			.collect(Collectors.toList());
-		Map<String, String> depDigests = new LinkedHashMap<>();
-		bctx.resolveClassPath().getArtifacts().forEach(a -> {
-			if (a.getCoordinate() != null) {
-				depDigests.put(a.getCoordinate().toCanonicalForm(),
-						DigestUtil.digestPath(a.getFile(), "sha256"));
+
+		// Write script digest, sources, and dep coordinates
+		LockFileUtil.write(effectiveLockFile, ref, digest, sources, deps, null);
+
+		// Record per-artifact checksums via TrustedChecksumsSource.Writer
+		JBangTrustedChecksumsSource tcSource = new JBangTrustedChecksumsSource(effectiveLockFile, ref);
+		TrustedChecksumsSource.Writer writer = tcSource.getTrustedArtifactChecksumsWriter(null);
+		List<ChecksumAlgorithmFactory> checksumFactories = DigestUtil.getChecksumFactories(
+				JBangTrustedChecksumsSource.algorithmNameToResolverName(algorithm));
+		LocalRepository localRepo = new LocalRepository("local");
+
+		for (ArtifactInfo ai : artifacts) {
+			if (ai.getCoordinate() != null && ai.getFile() != null) {
+				Artifact artifact = new DefaultArtifact(
+						ai.getCoordinate().getGroupId(),
+						ai.getCoordinate().getArtifactId(),
+						ai.getCoordinate().getClassifier(),
+						ai.getCoordinate().getType(),
+						ai.getCoordinate().getVersion())
+					.setFile(ai.getFile().toFile());
+
+				Map<String, String> checksums = ChecksumAlgorithmHelper
+					.calculate(ai.getFile().toFile(), checksumFactories);
+				writer.addTrustedArtifactChecksums(artifact, localRepo, checksumFactories, checksums);
 			}
-		});
-		LockFileUtil.write(effectiveLockFile, ref, digest, sources, deps, depDigests);
+		}
+
 		info("Locked " + ref + " => " + digest + " in " + effectiveLockFile);
 		return EXIT_OK;
 	}

--- a/src/main/java/dev/jbang/cli/Lock.java
+++ b/src/main/java/dev/jbang/cli/Lock.java
@@ -1,0 +1,63 @@
+package dev.jbang.cli;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+
+import dev.jbang.source.BuildContext;
+import dev.jbang.source.Project;
+import dev.jbang.source.ProjectBuilder;
+import dev.jbang.util.DigestUtil;
+import dev.jbang.util.LockFileUtil;
+
+@CommandDefinition(name = "lock", description = "Generate or refresh lock entries for script references", generateHelp = true, helpGroup = "Essentials")
+public class Lock extends BaseBuildCommand {
+
+	@Option(name = "lock-file", description = "Path to lock file (default: .jbang.lock)")
+	Path lockFile;
+
+	@Option(name = "algorithm", description = "Digest algorithm (default: sha256)", defaultValue = "sha256")
+	String algorithm;
+
+	@Override
+	public Integer doCall() throws IOException {
+		scriptMixin.validate(true);
+		String ref = scriptMixin.scriptOrFile;
+		DigestUtil.RefWithChecksum parsed = DigestUtil.splitRefAndChecksum(ref);
+		ref = parsed.ref;
+
+		ProjectBuilder pb = createBaseProjectBuilder();
+		Project prj = pb.build(ref);
+
+		String digest = DigestUtil.digestResource(prj, algorithm);
+		Path effectiveLockFile = DigestUtil.resolveLockFile(lockFile, ref);
+		List<String> sources = prj.getMainSourceSet()
+			.getSources()
+			.stream()
+			.map(s -> s.getOriginalResource() == null ? "" : s.getOriginalResource())
+			.collect(Collectors.toList());
+		BuildContext bctx = BuildContext.forProject(prj);
+		List<String> deps = bctx.resolveClassPath()
+			.getArtifacts()
+			.stream()
+			.map(a -> a.getCoordinate() == null ? "" : a.getCoordinate().toCanonicalForm())
+			.filter(s -> !s.isEmpty())
+			.collect(Collectors.toList());
+		Map<String, String> depDigests = new LinkedHashMap<>();
+		bctx.resolveClassPath().getArtifacts().forEach(a -> {
+			if (a.getCoordinate() != null) {
+				depDigests.put(a.getCoordinate().toCanonicalForm(),
+						DigestUtil.digestPath(a.getFile(), "sha256"));
+			}
+		});
+		LockFileUtil.write(effectiveLockFile, ref, digest, sources, deps, depDigests);
+		info("Locked " + ref + " => " + digest + " in " + effectiveLockFile);
+		return EXIT_OK;
+	}
+}

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -4,6 +4,8 @@ import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -19,6 +21,8 @@ import dev.jbang.source.CmdGeneratorBuilder;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.source.Source;
+import dev.jbang.util.DigestUtil;
+import dev.jbang.util.LockFileUtil;
 import dev.jbang.util.Util;
 
 @CommandDefinition(name = "run", description = "Builds and runs provided script. (default command)", generateHelp = true, stopAtFirstPositional = true, helpGroup = "Essentials")
@@ -36,6 +40,12 @@ public class Run extends BaseBuildCommand {
 
 	@Option(shortName = 'c', name = "code", fallbackValue = "", description = "Run the given string as code")
 	public String literalScript;
+
+	@Option(name = "locked", description = "Lock behavior: none, lenient, strict", defaultValue = "lenient")
+	String lockModeStr;
+
+	@Option(name = "lock-file", description = "Path to lock file (default: .jbang.lock)")
+	Path lockFile;
 
 	@Arguments(paramLabel = "userParams", index = "1..*", arity = "0..*", description = "Parameters for the script")
 	public List<String> userParams;
@@ -78,7 +88,23 @@ public class Run extends BaseBuildCommand {
 		userParams = handleRemoteFiles(userParams);
 		String script = scriptMixin.scriptOrFile;
 
+		LockMode lockMode = LockMode.valueOf(lockModeStr);
+
+		DigestUtil.RefWithChecksum refWithChecksum = script != null ? DigestUtil.splitRefAndChecksum(script) : null;
+		if (refWithChecksum != null) {
+			script = refWithChecksum.ref;
+		}
+
+		Path effectiveLockFile = DigestUtil.resolveLockFile(lockFile, script);
+		List<String> preLockSources = Collections.emptyList();
+		if (lockMode != LockMode.none && script != null && Files.exists(effectiveLockFile)) {
+			preLockSources = LockFileUtil.readSources(effectiveLockFile, script);
+		}
+
 		ProjectBuilder pb = createProjectBuilderForRun();
+		if (!preLockSources.isEmpty()) {
+			pb.lockedSourcesOverride(preLockSources);
+		}
 
 		Project prj;
 		if (literalScript != null) {
@@ -99,6 +125,10 @@ public class Run extends BaseBuildCommand {
 				// expects one to exist
 				prj = pb.build(LiteralScriptResourceResolver.stringToResourceRef(null, "", scriptMixin.getForceType()));
 			}
+		}
+
+		if (literalScript == null && script != null) {
+			verifyLockConstraints(prj, script, refWithChecksum, effectiveLockFile, lockMode);
 		}
 
 		if (Boolean.TRUE.equals(nativeMixin.nativeImage)
@@ -182,5 +212,116 @@ public class Run extends BaseBuildCommand {
 		Map<String, String> result = new HashMap<>();
 		slots.forEach((key, value) -> result.put(key, Util.substituteRemote(value)));
 		return result;
+	}
+
+	private void verifyLockConstraints(Project prj, String scriptOrFile,
+			DigestUtil.RefWithChecksum refWithChecksum, Path effectiveLockFile, LockMode lockMode) throws IOException {
+		String resolvedLocation = prj.getResourceRef().getFile().toAbsolutePath().toString();
+		String actualDigest = DigestUtil.digestResource(prj, "sha256");
+		String lockDigest = null;
+		List<String> lockSources = Collections.emptyList();
+		List<String> lockDeps = Collections.emptyList();
+		Map<String, String> lockDepDigests = Collections.emptyMap();
+		boolean hasLockFile = Files.exists(effectiveLockFile);
+		if (lockMode != LockMode.none && hasLockFile) {
+			lockDigest = LockFileUtil.readDigest(effectiveLockFile, scriptOrFile);
+			lockSources = LockFileUtil.readSources(effectiveLockFile, scriptOrFile);
+			lockDeps = LockFileUtil.readDeps(effectiveLockFile, scriptOrFile);
+			lockDepDigests = LockFileUtil.readDepDigests(effectiveLockFile, scriptOrFile);
+		}
+
+		if (refWithChecksum != null && refWithChecksum.checksum != null) {
+			DigestUtil.verifyDigestSpec(actualDigest, refWithChecksum.checksum,
+					"reference checksum for " + scriptOrFile + " (resolved " + resolvedLocation + ")");
+		}
+		if (lockMode != LockMode.none && hasLockFile) {
+			if (lockMode == LockMode.strict && lockDigest == null) {
+				throw new ExitException(EXIT_INVALID_INPUT,
+						"Lock verification failed for " + scriptOrFile + " (missing lock entry in "
+								+ effectiveLockFile
+								+ ").\nPossible security issue: expected lock data is absent.\n"
+								+ "What to do: inspect the lock file path, regenerate with `jbang lock "
+								+ scriptOrFile
+								+ "` only if trusted, or stop and review changes.",
+						null);
+			}
+			if (lockDigest != null) {
+				DigestUtil.verifyDigestSpec(actualDigest, lockDigest,
+						"lockfile for " + scriptOrFile + " (resolved " + resolvedLocation + ")",
+						lockMode != LockMode.strict);
+			}
+			if (!lockSources.isEmpty()) {
+				Set<String> expected = new LinkedHashSet<>(lockSources);
+				Set<String> actual = prj.getMainSourceSet()
+					.getSources()
+					.stream()
+					.map(s -> s.getOriginalResource() == null ? "" : s.getOriginalResource())
+					.collect(Collectors.toCollection(LinkedHashSet::new));
+				DigestUtil.verifyLockedSet("sources", scriptOrFile, expected, actual);
+			}
+			if (!lockDeps.isEmpty()) {
+				verifyLockedDeps(prj, scriptOrFile, lockDeps, lockDepDigests, lockMode);
+			}
+		}
+	}
+
+	private void verifyLockedDeps(Project prj, String scriptOrFile,
+			List<String> lockDeps, Map<String, String> lockDepDigests, LockMode lockMode) {
+		Set<String> expectedDeps = new LinkedHashSet<>(lockDeps);
+		BuildContext depCtx = BuildContext.forProject(prj);
+		Set<String> actualDeps = depCtx
+			.resolveClassPath()
+			.getArtifacts()
+			.stream()
+			.map(a -> a.getCoordinate() == null ? "" : a.getCoordinate().toCanonicalForm())
+			.filter(s -> !s.isEmpty())
+			.collect(Collectors.toCollection(LinkedHashSet::new));
+		DigestUtil.verifyLockedSet("dependency graph", scriptOrFile, expectedDeps, actualDeps);
+
+		if (lockMode == LockMode.strict && !expectedDeps.isEmpty()
+				&& lockDepDigests.size() < expectedDeps.size()) {
+			Set<String> missing = new LinkedHashSet<>(expectedDeps);
+			missing.removeAll(lockDepDigests.keySet());
+			throw new ExitException(EXIT_INVALID_INPUT,
+					"Lock verification failed for " + scriptOrFile
+							+ " (strict mode requires dependency digests for all locked dependencies).\n"
+							+ "Possible security issue: lock file is incomplete or modified.\n"
+							+ "Missing digest entries for: " + missing + "\n"
+							+ "What to do: regenerate with `jbang lock " + scriptOrFile
+							+ "` only if trusted, otherwise review lock/source history.",
+					null);
+		}
+
+		if (!lockDepDigests.isEmpty()) {
+			Map<String, String> actualDepDigests = depCtx.resolveClassPath()
+				.getArtifacts()
+				.stream()
+				.filter(a -> a.getCoordinate() != null)
+				.collect(Collectors.toMap(
+						a -> a.getCoordinate().toCanonicalForm(),
+						a -> DigestUtil.digestPath(a.getFile(), "sha256"),
+						(a, b) -> a, LinkedHashMap::new));
+			for (Map.Entry<String, String> e : lockDepDigests.entrySet()) {
+				String coord = e.getKey();
+				String expected = e.getValue();
+				String actual = actualDepDigests.get(coord);
+				if (actual == null) {
+					throw new ExitException(EXIT_INVALID_INPUT,
+							"Lock verification failed for " + scriptOrFile
+									+ " (dependency artifact missing for locked digest).\n"
+									+ "Dependency: " + coord + "\n"
+									+ "Possible security/integrity issue: resolved dependency set differs from lock.\n"
+									+ "What to do: inspect dependency changes; regenerate lock only if trusted.",
+							null);
+				}
+				DigestUtil.verifyDigestSpec(actual, expected,
+						"lock dependency digest for " + coord + " in " + scriptOrFile,
+						lockMode != LockMode.strict);
+			}
+		}
+	}
+
+	enum LockMode {
+		none, lenient, strict
 	}
 }

--- a/src/main/java/dev/jbang/dependencies/JBangTrustedChecksumsSource.java
+++ b/src/main/java/dev/jbang/dependencies/JBangTrustedChecksumsSource.java
@@ -1,0 +1,177 @@
+package dev.jbang.dependencies;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.ArtifactRepository;
+import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+
+import dev.jbang.util.LockFileUtil;
+
+/**
+ * A {@link TrustedChecksumsSource} backed by JBang's {@code .jbang.lock} file.
+ * <p>
+ * Lock file entries use the format:
+ * {@code <ref>.dep.<groupId>:<artifactId>:<type>:<version>=<algorithmName>:<hex>}
+ * <p>
+ * Today this is used standalone by {@code Lock} and {@code Run} commands. When
+ * MIMA gains an extension point for custom trusted-checksums sources, this
+ * implementation can be injected directly into the resolver pipeline.
+ */
+public class JBangTrustedChecksumsSource implements TrustedChecksumsSource {
+
+	private final Path lockFile;
+	private final String ref;
+
+	public JBangTrustedChecksumsSource(Path lockFile, String ref) {
+		this.lockFile = lockFile;
+		this.ref = ref;
+	}
+
+	/**
+	 * Returns trusted checksums for the given artifact from the lock file, or an
+	 * empty map if no entry exists. Returns {@code null} only if the lock file
+	 * itself does not exist (meaning "source not enabled").
+	 */
+	@Override
+	public Map<String, String> getTrustedArtifactChecksums(
+			RepositorySystemSession session,
+			Artifact artifact,
+			ArtifactRepository artifactRepository,
+			List<ChecksumAlgorithmFactory> checksumAlgorithmFactories) {
+
+		try {
+			Map<String, String> depDigests = LockFileUtil.readDepDigests(lockFile, ref);
+			if (depDigests.isEmpty()) {
+				return Collections.emptyMap();
+			}
+
+			String coord = toCoordKey(artifact);
+			String stored = depDigests.get(coord);
+			if (stored == null) {
+				return Collections.emptyMap();
+			}
+
+			// stored format is "sha256:abcdef..." — split into algorithm name + hex
+			String[] parts = stored.split(":", 2);
+			if (parts.length != 2) {
+				return Collections.emptyMap();
+			}
+
+			// Map the stored algorithm name to the requested factory names
+			String storedAlgorithm = algorithmNameToResolverName(parts[0]);
+			String storedHex = parts[1];
+
+			Map<String, String> result = new HashMap<>();
+			for (ChecksumAlgorithmFactory factory : checksumAlgorithmFactories) {
+				if (factory.getName().equalsIgnoreCase(storedAlgorithm)) {
+					result.put(factory.getName(), storedHex);
+				}
+			}
+			return result;
+		} catch (IOException e) {
+			return Collections.emptyMap();
+		}
+	}
+
+	@Override
+	public Writer getTrustedArtifactChecksumsWriter(RepositorySystemSession session) {
+		return new JBangLockWriter();
+	}
+
+	/**
+	 * Writer that records artifact checksums into the lock file.
+	 */
+	private class JBangLockWriter implements Writer {
+		@Override
+		public void addTrustedArtifactChecksums(
+				Artifact artifact,
+				ArtifactRepository artifactRepository,
+				List<ChecksumAlgorithmFactory> checksumAlgorithmFactories,
+				Map<String, String> trustedArtifactChecksums) throws IOException {
+
+			String coord = toCoordKey(artifact);
+			Map<String, String> depDigests = new HashMap<>();
+
+			// Store all provided checksums, preferring SHA-256
+			for (ChecksumAlgorithmFactory factory : checksumAlgorithmFactories) {
+				String hex = trustedArtifactChecksums.get(factory.getName());
+				if (hex != null) {
+					String lockAlgName = resolverNameToAlgorithmName(factory.getName());
+					depDigests.put(coord, lockAlgName + ":" + hex);
+					break; // store one algorithm per artifact (prefer first = typically SHA-256)
+				}
+			}
+
+			if (!depDigests.isEmpty()) {
+				// Merge into existing lock file
+				LockFileUtil.write(lockFile, ref, null, null, null, depDigests);
+			}
+		}
+	}
+
+	/**
+	 * Converts an artifact to the coordinate key used in lock file entries. Matches
+	 * the format produced by
+	 * {@link dev.jbang.dependencies.MavenCoordinate#toCanonicalForm()}.
+	 */
+	static String toCoordKey(Artifact artifact) {
+		StringBuilder sb = new StringBuilder();
+		sb.append(artifact.getGroupId()).append(':').append(artifact.getArtifactId());
+		String ext = artifact.getExtension();
+		String cls = artifact.getClassifier();
+		if (ext != null && !ext.isEmpty()) {
+			if (cls != null && !cls.isEmpty()) {
+				sb.append(':').append(cls);
+			}
+			sb.append(':').append(ext);
+		}
+		sb.append(':').append(artifact.getVersion());
+		return sb.toString();
+	}
+
+	/**
+	 * Maps lock-file algorithm names (lowercase, e.g. "sha256") to resolver names
+	 * (e.g. "SHA-256").
+	 */
+	public static String algorithmNameToResolverName(String lockName) {
+		switch (lockName.toLowerCase()) {
+		case "sha256":
+			return "SHA-256";
+		case "sha512":
+			return "SHA-512";
+		case "sha1":
+			return "SHA-1";
+		case "md5":
+			return "MD5";
+		default:
+			return lockName;
+		}
+	}
+
+	/**
+	 * Maps resolver algorithm names (e.g. "SHA-256") to lock-file names (e.g.
+	 * "sha256").
+	 */
+	public static String resolverNameToAlgorithmName(String resolverName) {
+		switch (resolverName) {
+		case "SHA-256":
+			return "sha256";
+		case "SHA-512":
+			return "sha512";
+		case "SHA-1":
+			return "sha1";
+		case "MD5":
+			return "md5";
+		default:
+			return resolverName.toLowerCase();
+		}
+	}
+}

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -66,6 +66,7 @@ import dev.jbang.util.Util;
  */
 public class ProjectBuilder {
 	private List<String> additionalSources = new ArrayList<>();
+	private List<String> lockedSourcesOverride = Collections.emptyList();
 	private List<String> additionalResources = new ArrayList<>();
 	private List<String> additionalDeps = new ArrayList<>();
 	private List<String> additionalRepos = new ArrayList<>();
@@ -112,6 +113,15 @@ public class ProjectBuilder {
 			this.additionalSources = new ArrayList<>(sources);
 		} else {
 			this.additionalSources = Collections.emptyList();
+		}
+		return this;
+	}
+
+	public ProjectBuilder lockedSourcesOverride(List<String> sources) {
+		if (sources != null) {
+			this.lockedSourcesOverride = new ArrayList<>(sources);
+		} else {
+			this.lockedSourcesOverride = Collections.emptyList();
 		}
 		return this;
 	}
@@ -686,7 +696,12 @@ public class ProjectBuilder {
 				prj.addSubProject(new ProjectBuilder(buildRefs).build(subRef));
 			}
 			ResourceResolver sibRes2 = getSiblingResolver(srcRef, resolver);
-			List<Source> includedSources = allToSource(src.getDirectives().sources(), srcRef, sibRes2);
+			List<String> sourceRefs = src.getDirectives().sources();
+			if (!lockedSourcesOverride.isEmpty() && prj.getMainSource() != null
+					&& srcRef.equals(prj.getMainSource().getResourceRef())) {
+				sourceRefs = lockedSourcesOverride;
+			}
+			List<Source> includedSources = allToSource(sourceRefs, srcRef, sibRes2);
 			for (Source includedSource : includedSources) {
 				updateProject(includedSource, prj, resolver);
 			}

--- a/src/main/java/dev/jbang/util/DigestUtil.java
+++ b/src/main/java/dev/jbang/util/DigestUtil.java
@@ -1,0 +1,160 @@
+package dev.jbang.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
+
+import dev.jbang.cli.BaseCommand;
+import dev.jbang.cli.ExitException;
+import dev.jbang.source.Project;
+
+public final class DigestUtil {
+
+	private static final int MIN_DIGEST_PREFIX_LENGTH = 12;
+
+	private DigestUtil() {
+	}
+
+	public static String digestPath(Path path, String algorithm) {
+		try {
+			MessageDigest md = MessageDigest.getInstance(algorithm.toUpperCase(Locale.ROOT));
+			try (InputStream in = Files.newInputStream(path)) {
+				byte[] buffer = new byte[8192];
+				int read;
+				while ((read = in.read(buffer)) >= 0) {
+					md.update(buffer, 0, read);
+				}
+			}
+			return algorithm.toLowerCase(Locale.ROOT) + ":" + toHex(md.digest());
+		} catch (IOException | NoSuchAlgorithmException e) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Unable to digest file: " + path, e);
+		}
+	}
+
+	public static String digestResource(Project prj, String algorithm) throws IOException {
+		try {
+			MessageDigest md = MessageDigest.getInstance(algorithm.toUpperCase(Locale.ROOT));
+			try (InputStream in = prj.getResourceRef().getInputStream()) {
+				byte[] buffer = new byte[8192];
+				int read;
+				while ((read = in.read(buffer)) >= 0) {
+					md.update(buffer, 0, read);
+				}
+			}
+			return algorithm.toLowerCase(Locale.ROOT) + ":" + toHex(md.digest());
+		} catch (NoSuchAlgorithmException e) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Unsupported digest algorithm: " + algorithm, e);
+		}
+	}
+
+	public static Path resolveLockFile(Path lockFileOverride, String ref) {
+		if (lockFileOverride != null) {
+			return lockFileOverride;
+		}
+		if (ref != null) {
+			Path p = Paths.get(ref);
+			Path candidate = p.isAbsolute() ? p : Util.getCwd().resolve(p);
+			if (Files.exists(candidate) && Files.isRegularFile(candidate)) {
+				return Paths.get(ref + ".lock");
+			}
+		}
+		return Util.getCwd().resolve(".jbang.lock");
+	}
+
+	public static void verifyLockedSet(String kind, String ref,
+			java.util.Set<String> expected, java.util.Set<String> actual) {
+		if (!actual.equals(expected)) {
+			java.util.Set<String> missing = new java.util.LinkedHashSet<>(expected);
+			missing.removeAll(actual);
+			java.util.Set<String> extra = new java.util.LinkedHashSet<>(actual);
+			extra.removeAll(expected);
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Lock verification failed for " + ref + " (" + kind + " mismatch).\n"
+							+ "Possible security issue: lock file and resolved content differ.\n"
+							+ "Missing from resolved: " + missing + "\n"
+							+ "Unexpected in resolved: " + extra + "\n"
+							+ "What to do: inspect lock/source changes; regenerate with `jbang lock " + ref
+							+ "` only if trusted.",
+					null);
+		}
+	}
+
+	public static void verifyDigestSpec(String actualDigest, String expectedDigest, String source) {
+		verifyDigestSpec(actualDigest, expectedDigest, source, true);
+	}
+
+	public static void verifyDigestSpec(String actualDigest, String expectedDigest, String source,
+			boolean allowPrefix) {
+		String[] actualParts = actualDigest.split(":", 2);
+		String[] expectedParts = expectedDigest.split(":", 2);
+		if (expectedParts.length != 2) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Lock verification failed: invalid digest format from " + source + ": " + expectedDigest + "\n"
+							+ "What to do: use `sha256:<digest>` (or valid algorithm prefix).",
+					null);
+		}
+		if (!actualParts[0].equalsIgnoreCase(expectedParts[0])) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Lock verification failed: digest algorithm mismatch in " + source + ": expected "
+							+ expectedParts[0] + ", got " + actualParts[0] + "\n"
+							+ "What to do: regenerate lock or use matching digest algorithm if trusted.",
+					null);
+		}
+		String expectedHex = expectedParts[1].toLowerCase(Locale.ROOT);
+		String actualHex = actualParts[1].toLowerCase(Locale.ROOT);
+		if (allowPrefix && expectedHex.length() < MIN_DIGEST_PREFIX_LENGTH) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Lock verification failed: digest prefix too short in " + source + ". Use at least "
+							+ MIN_DIGEST_PREFIX_LENGTH + " hex characters.\n"
+							+ "What to do: provide a longer checksum prefix or full digest.",
+					null);
+		}
+		if (allowPrefix ? !actualHex.startsWith(expectedHex) : !actualHex.equals(expectedHex)) {
+			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					"Lock verification failed: digest mismatch in " + source + ": expected " + expectedDigest
+							+ ", got " + actualDigest + "\n"
+							+ "Possible security issue: content differs from lock/checksum.\n"
+							+ "What to do: inspect changes; regenerate lock only if trusted.",
+					null);
+		}
+	}
+
+	/**
+	 * Splits a ref like "alias@catalog#sha256:abcdef" into the ref part and the
+	 * checksum part.
+	 */
+	public static RefWithChecksum splitRefAndChecksum(String ref) {
+		int idx = ref.lastIndexOf('#');
+		if (idx < 0 || idx == ref.length() - 1) {
+			return new RefWithChecksum(ref, null);
+		}
+		String suffix = ref.substring(idx + 1);
+		String digest = suffix.contains(":") ? suffix : "sha256:" + suffix;
+		return new RefWithChecksum(ref.substring(0, idx), digest);
+	}
+
+	public static final class RefWithChecksum {
+		public final String ref;
+		public final String checksum;
+
+		public RefWithChecksum(String ref, String checksum) {
+			this.ref = ref;
+			this.checksum = checksum;
+		}
+	}
+
+	private static String toHex(byte[] bytes) {
+		StringBuilder sb = new StringBuilder(bytes.length * 2);
+		for (byte b : bytes) {
+			sb.append(String.format("%02x", b));
+		}
+		return sb.toString();
+	}
+}

--- a/src/main/java/dev/jbang/util/DigestUtil.java
+++ b/src/main/java/dev/jbang/util/DigestUtil.java
@@ -7,10 +7,25 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.aether.internal.impl.checksum.DefaultChecksumAlgorithmFactorySelector;
+import org.eclipse.aether.internal.impl.checksum.Md5ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.impl.checksum.Sha1ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.impl.checksum.Sha256ChecksumAlgorithmFactory;
+import org.eclipse.aether.internal.impl.checksum.Sha512ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmHelper;
 
 import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
+import dev.jbang.dependencies.JBangTrustedChecksumsSource;
 import dev.jbang.source.Project;
 
 public final class DigestUtil {
@@ -20,18 +35,26 @@ public final class DigestUtil {
 	private DigestUtil() {
 	}
 
+	/**
+	 * Computes a digest of a file using the resolver's
+	 * {@link ChecksumAlgorithmHelper}.
+	 *
+	 * @param path      the file to digest
+	 * @param algorithm lock-file algorithm name (e.g. "sha256")
+	 * @return digest string in lock-file format, e.g. "sha256:abcdef..."
+	 */
 	public static String digestPath(Path path, String algorithm) {
 		try {
-			MessageDigest md = MessageDigest.getInstance(algorithm.toUpperCase(Locale.ROOT));
-			try (InputStream in = Files.newInputStream(path)) {
-				byte[] buffer = new byte[8192];
-				int read;
-				while ((read = in.read(buffer)) >= 0) {
-					md.update(buffer, 0, read);
-				}
+			String resolverName = JBangTrustedChecksumsSource.algorithmNameToResolverName(algorithm);
+			List<ChecksumAlgorithmFactory> factories = getChecksumFactories(resolverName);
+			Map<String, String> checksums = ChecksumAlgorithmHelper.calculate(path.toFile(), factories);
+			String hex = checksums.get(resolverName);
+			if (hex == null) {
+				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+						"Checksum algorithm " + resolverName + " not available", null);
 			}
-			return algorithm.toLowerCase(Locale.ROOT) + ":" + toHex(md.digest());
-		} catch (IOException | NoSuchAlgorithmException e) {
+			return algorithm.toLowerCase(Locale.ROOT) + ":" + hex;
+		} catch (IOException e) {
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
 					"Unable to digest file: " + path, e);
 		}
@@ -69,11 +92,11 @@ public final class DigestUtil {
 	}
 
 	public static void verifyLockedSet(String kind, String ref,
-			java.util.Set<String> expected, java.util.Set<String> actual) {
+			Set<String> expected, Set<String> actual) {
 		if (!actual.equals(expected)) {
-			java.util.Set<String> missing = new java.util.LinkedHashSet<>(expected);
+			Set<String> missing = new LinkedHashSet<>(expected);
 			missing.removeAll(actual);
-			java.util.Set<String> extra = new java.util.LinkedHashSet<>(actual);
+			Set<String> extra = new LinkedHashSet<>(actual);
 			extra.removeAll(expected);
 			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
 					"Lock verification failed for " + ref + " (" + kind + " mismatch).\n"
@@ -148,6 +171,28 @@ public final class DigestUtil {
 			this.ref = ref;
 			this.checksum = checksum;
 		}
+	}
+
+	/**
+	 * Returns a singleton list of {@link ChecksumAlgorithmFactory} for the given
+	 * resolver algorithm name. Uses the resolver's built-in factories (SHA-256,
+	 * SHA-512, SHA-1, MD5).
+	 */
+	public static List<ChecksumAlgorithmFactory> getChecksumFactories(String resolverName) {
+		// Use the resolver's built-in factories directly — they're available via
+		// the impl jar on the classpath. This avoids needing a Lookup/session.
+		DefaultChecksumAlgorithmFactorySelector selector = new DefaultChecksumAlgorithmFactorySelector(
+				getBuiltinChecksumAlgorithmFactories());
+		return selector.selectList(Collections.singletonList(resolverName));
+	}
+
+	private static Map<String, ChecksumAlgorithmFactory> getBuiltinChecksumAlgorithmFactories() {
+		Map<String, ChecksumAlgorithmFactory> result = new HashMap<>();
+		result.put("SHA-256", new Sha256ChecksumAlgorithmFactory());
+		result.put("SHA-512", new Sha512ChecksumAlgorithmFactory());
+		result.put("SHA-1", new Sha1ChecksumAlgorithmFactory());
+		result.put("MD5", new Md5ChecksumAlgorithmFactory());
+		return result;
 	}
 
 	private static String toHex(byte[] bytes) {

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -1,0 +1,104 @@
+package dev.jbang.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public final class LockFileUtil {
+
+	private LockFileUtil() {
+	}
+
+	public static String readDigest(Path lockFile, String ref) throws IOException {
+		if (!Files.exists(lockFile)) {
+			return null;
+		}
+		Properties p = new Properties();
+		try (InputStream in = Files.newInputStream(lockFile)) {
+			p.load(in);
+		}
+		return p.getProperty(ref);
+	}
+
+	public static List<String> readSources(Path lockFile, String ref) throws IOException {
+		return readList(lockFile, ref + ".sources");
+	}
+
+	public static List<String> readDeps(Path lockFile, String ref) throws IOException {
+		return readList(lockFile, ref + ".deps");
+	}
+
+	private static List<String> readList(Path lockFile, String key) throws IOException {
+		if (!Files.exists(lockFile)) {
+			return Collections.emptyList();
+		}
+		Properties p = new Properties();
+		try (InputStream in = Files.newInputStream(lockFile)) {
+			p.load(in);
+		}
+		String val = p.getProperty(key);
+		if (val == null || val.trim().isEmpty()) {
+			return Collections.emptyList();
+		}
+		return Arrays.stream(val.split(",")).filter(s -> !s.trim().isEmpty()).collect(Collectors.toList());
+	}
+
+	public static Map<String, String> readDepDigests(Path lockFile, String ref) throws IOException {
+		Map<String, String> result = new LinkedHashMap<>();
+		if (!Files.exists(lockFile)) {
+			return result;
+		}
+		Properties p = new Properties();
+		try (InputStream in = Files.newInputStream(lockFile)) {
+			p.load(in);
+		}
+		String prefix = ref + ".dep.";
+		for (String key : p.stringPropertyNames()) {
+			if (key.startsWith(prefix)) {
+				String coord = key.substring(prefix.length());
+				result.put(coord, p.getProperty(key));
+			}
+		}
+		return result;
+	}
+
+	public static void writeDigest(Path lockFile, String ref, String digest) throws IOException {
+		write(lockFile, ref, digest, null, null, null);
+	}
+
+	public static void write(Path lockFile, String ref, String digest, List<String> sources, List<String> deps,
+			Map<String, String> depDigests)
+			throws IOException {
+		Properties p = new Properties();
+		if (Files.exists(lockFile)) {
+			try (InputStream in = Files.newInputStream(lockFile)) {
+				p.load(in);
+			}
+		}
+		p.setProperty(ref, digest);
+		if (sources != null && !sources.isEmpty()) {
+			p.setProperty(ref + ".sources", String.join(",", sources));
+		}
+		if (deps != null && !deps.isEmpty()) {
+			p.setProperty(ref + ".deps", String.join(",", deps));
+		}
+		if (depDigests != null && !depDigests.isEmpty()) {
+			depDigests.forEach((coord, dg) -> p.setProperty(ref + ".dep." + coord, dg));
+		}
+		if (lockFile.getParent() != null) {
+			Files.createDirectories(lockFile.getParent());
+		}
+		try (OutputStream out = Files.newOutputStream(lockFile)) {
+			p.store(out, "JBang lockfile v1");
+		}
+	}
+}

--- a/src/main/java/dev/jbang/util/LockFileUtil.java
+++ b/src/main/java/dev/jbang/util/LockFileUtil.java
@@ -84,7 +84,9 @@ public final class LockFileUtil {
 				p.load(in);
 			}
 		}
-		p.setProperty(ref, digest);
+		if (digest != null) {
+			p.setProperty(ref, digest);
+		}
 		if (sources != null && !sources.isEmpty()) {
 			p.setProperty(ref + ".sources", String.join(",", sources));
 		}

--- a/src/native-image/config/reachability-metadata.json
+++ b/src/native-image/config/reachability-metadata.json
@@ -255,6 +255,8 @@
     { "type": "dev.jbang.cli.Deps" },
     { "type": "dev.jbang.cli.Deps$DepsAdd" },
     { "type": "dev.jbang.cli.Deps$DepsSearch" },
+    { "type": "dev.jbang.cli.Lock" },
+    { "type": "dev.jbang.cli.Lock_AeshMetadata" },
     { "type": "dev.jbang.cli.Edit" },
     { "type": "dev.jbang.cli.Export" },
     { "type": "dev.jbang.cli.Export$BaseExportCommand" },

--- a/src/test/java/dev/jbang/cli/TestRunChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestRunChecksum.java
@@ -1,0 +1,70 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.util.DigestUtil;
+
+public class TestRunChecksum {
+
+	@Test
+	void splitRefAndChecksumParsesDigestSuffix() {
+		DigestUtil.RefWithChecksum ref = DigestUtil.splitRefAndChecksum("alias@catalog#sha256:abcdef123456");
+		assertEquals("alias@catalog", ref.ref);
+		assertEquals("sha256:abcdef123456", ref.checksum);
+	}
+
+	@Test
+	void splitRefAndChecksumTreatsBareSuffixAsSha256Prefix() {
+		DigestUtil.RefWithChecksum ref = DigestUtil.splitRefAndChecksum("env@jbangdev#blanah");
+		assertEquals("env@jbangdev", ref.ref);
+		assertEquals("sha256:blanah", ref.checksum);
+	}
+
+	@Test
+	void verifyDigestSpecAcceptsPrefix() {
+		DigestUtil.verifyDigestSpec("sha256:abcdef1234567890", "sha256:abcdef123456", "test");
+	}
+
+	@Test
+	void verifyDigestSpecRejectsShortPrefix() {
+		assertThrows(ExitException.class,
+				() -> DigestUtil.verifyDigestSpec("sha256:abcdef1234567890", "sha256:abcd", "test"));
+	}
+
+	@Test
+	void verifyDigestSpecRejectsMismatch() {
+		assertThrows(ExitException.class,
+				() -> DigestUtil.verifyDigestSpec("sha256:abcdef1234567890", "sha256:bbbbbbbbbbbb", "test"));
+	}
+
+	@Test
+	void verifyLockedSetRejectsDependencyDrift() {
+		Set<String> expected = new LinkedHashSet<>();
+		expected.add("a:b:jar:1");
+		expected.add("x:y:jar:2");
+		Set<String> actual = new LinkedHashSet<>();
+		actual.add("a:b:jar:1");
+		actual.add("x:y:jar:3");
+		ExitException ex = assertThrows(ExitException.class,
+				() -> DigestUtil.verifyLockedSet("dependency graph", "demo@cat", expected, actual));
+		assertTrue(ex.getMessage().contains("Lock verification failed for demo@cat (dependency graph mismatch)"));
+	}
+
+	@Test
+	void verifyLockedSetRejectsSourcesDrift() {
+		Set<String> expected = new LinkedHashSet<>();
+		expected.add("https://example/a.java");
+		Set<String> actual = new LinkedHashSet<>();
+		actual.add("https://example/b.java");
+		ExitException ex = assertThrows(ExitException.class,
+				() -> DigestUtil.verifyLockedSet("sources", "env@jbangdev", expected, actual));
+		assertTrue(ex.getMessage().contains("Lock verification failed for env@jbangdev (sources mismatch)"));
+	}
+}

--- a/src/test/java/dev/jbang/dependencies/TestJBangTrustedChecksumsSource.java
+++ b/src/test/java/dev/jbang/dependencies/TestJBangTrustedChecksumsSource.java
@@ -1,0 +1,93 @@
+package dev.jbang.dependencies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.spi.checksums.TrustedChecksumsSource;
+import org.eclipse.aether.spi.connector.checksum.ChecksumAlgorithmFactory;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.util.DigestUtil;
+import dev.jbang.util.LockFileUtil;
+
+public class TestJBangTrustedChecksumsSource {
+
+	@Test
+	void readsTrustedChecksumsFromLockFile() throws Exception {
+		Path tmp = Files.createTempFile("jbang-tc-test", ".lock");
+		Map<String, String> depDigests = new LinkedHashMap<>();
+		depDigests.put("com.example:lib:jar:1.0", "sha256:abcdef1234567890");
+		LockFileUtil.write(tmp, "myapp.java", "sha256:rootdigest", null,
+				Arrays.asList("com.example:lib:jar:1.0"), depDigests);
+
+		JBangTrustedChecksumsSource source = new JBangTrustedChecksumsSource(tmp, "myapp.java");
+		DefaultArtifact artifact = new DefaultArtifact("com.example", "lib", "jar", "1.0");
+		LocalRepository localRepo = new LocalRepository("local");
+
+		List<ChecksumAlgorithmFactory> factories = DigestUtil.getChecksumFactories("SHA-256");
+		Map<String, String> result = source.getTrustedArtifactChecksums(null, artifact, localRepo, factories);
+
+		assertNotNull(result);
+		assertEquals(1, result.size());
+		assertEquals("abcdef1234567890", result.get("SHA-256"));
+	}
+
+	@Test
+	void returnsEmptyMapForMissingArtifact() throws Exception {
+		Path tmp = Files.createTempFile("jbang-tc-miss", ".lock");
+		LockFileUtil.write(tmp, "myapp.java", "sha256:rootdigest", null, null, null);
+
+		JBangTrustedChecksumsSource source = new JBangTrustedChecksumsSource(tmp, "myapp.java");
+		DefaultArtifact artifact = new DefaultArtifact("com.example", "missing", "jar", "1.0");
+		LocalRepository localRepo = new LocalRepository("local");
+
+		List<ChecksumAlgorithmFactory> factories = DigestUtil.getChecksumFactories("SHA-256");
+		Map<String, String> result = source.getTrustedArtifactChecksums(null, artifact, localRepo, factories);
+
+		assertNotNull(result);
+		assertTrue(result.isEmpty());
+	}
+
+	@Test
+	void writerRecordsChecksums() throws Exception {
+		Path tmp = Files.createTempFile("jbang-tc-write", ".lock");
+		LockFileUtil.write(tmp, "myapp.java", "sha256:rootdigest", null, null, null);
+
+		JBangTrustedChecksumsSource source = new JBangTrustedChecksumsSource(tmp, "myapp.java");
+		TrustedChecksumsSource.Writer writer = source.getTrustedArtifactChecksumsWriter(null);
+		assertNotNull(writer);
+
+		DefaultArtifact artifact = new DefaultArtifact("org.test", "foo", "jar", "2.0");
+		LocalRepository localRepo = new LocalRepository("local");
+		List<ChecksumAlgorithmFactory> factories = DigestUtil.getChecksumFactories("SHA-256");
+
+		Map<String, String> checksums = Collections.singletonMap("SHA-256", "deadbeef12345678");
+		writer.addTrustedArtifactChecksums(artifact, localRepo, factories, checksums);
+
+		// Read back and verify
+		Map<String, String> stored = LockFileUtil.readDepDigests(tmp, "myapp.java");
+		assertTrue(stored.containsKey("org.test:foo:jar:2.0"));
+		assertEquals("sha256:deadbeef12345678", stored.get("org.test:foo:jar:2.0"));
+	}
+
+	@Test
+	void algorithmNameMapping() {
+		assertEquals("SHA-256", JBangTrustedChecksumsSource.algorithmNameToResolverName("sha256"));
+		assertEquals("SHA-512", JBangTrustedChecksumsSource.algorithmNameToResolverName("sha512"));
+		assertEquals("SHA-1", JBangTrustedChecksumsSource.algorithmNameToResolverName("sha1"));
+		assertEquals("sha256", JBangTrustedChecksumsSource.resolverNameToAlgorithmName("SHA-256"));
+		assertEquals("sha512", JBangTrustedChecksumsSource.resolverNameToAlgorithmName("SHA-512"));
+		assertEquals("sha1", JBangTrustedChecksumsSource.resolverNameToAlgorithmName("SHA-1"));
+	}
+}

--- a/src/test/java/dev/jbang/util/TestLockFileUtil.java
+++ b/src/test/java/dev/jbang/util/TestLockFileUtil.java
@@ -1,0 +1,46 @@
+package dev.jbang.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class TestLockFileUtil {
+
+	@Test
+	void writesAndReadsDigestAndSources() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock", ".lock");
+		Map<String, String> depDigests = new LinkedHashMap<>();
+		depDigests.put("g:a:1", "sha256:aaaabbbbcccc");
+		depDigests.put("g:b:2", "sha256:ddddeeeeffff");
+		LockFileUtil.write(tmp, "alias@catalog", "sha256:abcdef123456", Arrays.asList("a.java", "b.java"),
+				Arrays.asList("g:a:1", "g:b:2"), depDigests);
+		assertEquals("sha256:abcdef123456", LockFileUtil.readDigest(tmp, "alias@catalog"));
+		assertEquals(Arrays.asList("a.java", "b.java"), LockFileUtil.readSources(tmp, "alias@catalog"));
+		assertEquals(Arrays.asList("g:a:1", "g:b:2"), LockFileUtil.readDeps(tmp, "alias@catalog"));
+		assertEquals(depDigests, LockFileUtil.readDepDigests(tmp, "alias@catalog"));
+	}
+
+	@Test
+	void missingEntriesReturnEmptyCollectionsOrNull() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock-empty", ".lock");
+		assertEquals(null, LockFileUtil.readDigest(tmp, "missing@ref"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readSources(tmp, "missing@ref"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readDeps(tmp, "missing@ref"));
+	}
+
+	@Test
+	void writeDigestDoesNotRequireSourcesOrDeps() throws Exception {
+		Path tmp = Files.createTempFile("jbang-lock-digest", ".lock");
+		LockFileUtil.writeDigest(tmp, "x:y:z", "sha256:deadbeefdead");
+		assertEquals("sha256:deadbeefdead", LockFileUtil.readDigest(tmp, "x:y:z"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readSources(tmp, "x:y:z"));
+		assertEquals(Collections.emptyList(), LockFileUtil.readDeps(tmp, "x:y:z"));
+	}
+}


### PR DESCRIPTION

This PR adds lock-based integrity + reproducibility checks for JBang refs, ported to the aesh CLI framework and wired into the Maven Resolver trusted-checksums SPI.

Supersedes #2410 (which was picocli-based and predates the aesh migration).

 p.s. The IKEA table from last time is holding up great.

## What's included

- New command: `jbang lock <ref>`
- Default lock file behavior:
  - local file refs (`app.java`) → `app.java.lock`
  - alias/GAV/URL refs → `.jbang.lock`
  - override via `--lock-file=...`
- Run policy flag: `--locked=<none|lenient|strict>`
  - `none`: ignore lock checks
  - `lenient` (default): if lock data exists, enforce it; if lock missing, run normally
  - `strict`: require lock entry when lock file exists and enforce strict matching
- Lock structure per ref:
  - `ref=sha256:...` (main resource digest)
  - `ref.sources=...` (resolved source manifest)
  - `ref.deps=...` (resolved transitive dependency coordinates)
  - `ref.dep.<gav>=sha256:...` (per-artifact dependency digests)

## Verification behavior

When lock data exists, JBang validates:

1. Main resource digest
2. Source manifest (`.sources`) consistency
3. Dependency graph (`.deps`) consistency
4. Per-artifact dependency digests (`.dep.<gav>`)

Mismatch → fail with explicit error including resolved file path and fix guidance.

## Maven Resolver integration

Per discussion with @cstamas, this implements the resolver's `TrustedChecksumsSource` SPI:

- `JBangTrustedChecksumsSource` implements `TrustedChecksumsSource` + `Writer` backed by `.jbang.lock`
- `Lock` command uses the `Writer` interface to record per-artifact checksums
- `DigestUtil` delegates to `ChecksumAlgorithmHelper.calculate()` from `maven-resolver-spi` instead of custom `MessageDigest` code
- Algorithm name mapping between lock-file format (`sha256`) and resolver format (`SHA-256`)

Today the TC source is used standalone by `Lock` and `Run`. When MIMA gains an extension point for custom trusted-checksums sources (no such API exists through 2.4.45 or 3.0.0-alpha-3), the same implementation can be injected directly into the resolver pipeline — at which point the manual dep-digest verification loop in `Run` can be deleted.

## Why this design

- Keeps "just run it" workflow intact when no lock is present.
- Provides stronger guarantees as soon as lock data exists.
- Separates mutation (`jbang lock`) from execution (`jbang run ...`).
- Reuses resolver's own checksum infrastructure instead of rolling custom crypto.
- Shared `DigestUtil` eliminates code duplication between `Lock` and `Run`.

## Feedback requested

1. Are `--locked` mode semantics (`none|lenient|strict`) right?
2. Is `<script>.lock` the right default for local file refs?
3. Is properties-based lock format acceptable for v1 with these keys?
4. Should strict mode require complete per-artifact digests for every locked dep (current behavior)?
5. Is the `TrustedChecksumsSource` SPI the right abstraction to build on for the MIMA integration path?

### Related issues

Relates to:
- #1989 (script/alias SHA verification)
- #1979 (pinning behavior for aliases/scripts)

Supersedes / consolidates discussion from:
- #2410 (original picocli-based lock PR)
- #938 (catalog checksums)
- #687 (older checksum/integrity thread)
