### PR TITLE
fix: use daemon thread for version check to prevent JVM hang

### DIFF
--- a/src/main/java/dev/jbang/util/VersionChecker.java
+++ b/src/main/java/dev/jbang/util/VersionChecker.java
@@ -172,7 +172,11 @@ public class VersionChecker {
 
 	private static Future<String> retrieveLatestVersionAsync() {
 		if (versionCheckResult == null) {
-			versionCheckResult = Executors.newSingleThreadExecutor().submit(VersionChecker::retrieveLatestVersion);
+			versionCheckResult = Executors.newSingleThreadExecutor(r -> {
+				Thread t = new Thread(r, "jbang-version-check");
+				t.setDaemon(true);
+				return t;
+			}).submit(VersionChecker::retrieveLatestVersion);
 		}
 		return versionCheckResult;
 	}


### PR DESCRIPTION
Fixes #2523

`Executors.newSingleThreadExecutor()` creates non-daemon threads by default. After the version check task completes, the worker thread parks in `LinkedBlockingQueue.take()` waiting for tasks that never come, preventing JVM exit.

This causes jbang to occasionally hang indefinitely after a command completes.

## Fix

Use a daemon thread factory with a descriptive thread name (`jbang-version-check`) so the JVM can exit normally when the main thread finishes.

## Stack trace (from @maxandersen)

```
"pool-1-thread-1" #21 prio=5 cpu=216.66ms elapsed=112.83s
   java.lang.Thread.State: WAITING (parking)
    at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
    at java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
    ...

"DestroyJavaVM" #22 prio=5 cpu=185.54ms elapsed=112.67s
   java.lang.Thread.State: RUNNABLE
```