### PR TITLE
fix: optimize test suite performance (2m42s → ~50s)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,7 @@ buildConfig {
 tasks.withType(Test).configureEach {
 	//environment "JAVA_HOME", "/Users/manderse/.local/share/mise/installs/java/graalvm-community-25.0.1"
 	//executable = new File("/Users/manderse/.local/share/mise/installs/java/graalvm-community-25.0.1/bin/java")
-	//maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+	maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 // to enable reproducible builds

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -329,7 +329,7 @@ public class Edit extends BaseCommand {
 				options.add("Use '" + ed + "'");
 			}
 
-			int result = Util.askInput(question, 30, 0, options.toArray(new String[] {}));
+			int result = Util.askInput(question, Util.getAskInputTimeout(), 0, options.toArray(new String[] {}));
 			if (result == 0) {
 				return Optional.empty();
 			} else if (result == 1) {

--- a/src/main/java/dev/jbang/resources/resolvers/RemoteResourceResolver.java
+++ b/src/main/java/dev/jbang/resources/resolvers/RemoteResourceResolver.java
@@ -78,7 +78,7 @@ public class RemoteResourceResolver implements ResourceResolver {
 				options.add("Trust organization url in future: " + trustOrgUrl);
 			}
 
-			int result = Util.askInput(question, 30, 0, options.toArray(new String[] {}));
+			int result = Util.askInput(question, Util.getAskInputTimeout(), 0, options.toArray(new String[] {}));
 			TrustedSources ts = TrustedSources.instance();
 			if (result == 1) {
 				ts.addTemporary(trustUrl);

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -281,7 +281,8 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 
 				String[] mainClassOptions = filteredMains.map(m -> m.name().toString()).toArray(String[]::new);
 				int result = Util.askInput(
-						"No main class deduced, specified nor found in a manifest, but found these candidates:", 30, 0,
+						"No main class deduced, specified nor found in a manifest, but found these candidates:",
+						Util.getAskInputTimeout(), 0,
 						mainClassOptions);
 
 				if (result <= 0) {

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -117,6 +117,7 @@ public class Util {
 	private static Boolean downloadSources;
 	private static Instant startTime = Instant.now();
 	private static boolean printExceptions = false;
+	private static int askInputTimeout = 30;
 
 	public static void setVerbose(boolean verbose) {
 		Util.verbose = verbose;
@@ -151,6 +152,14 @@ public class Util {
 
 	public static boolean printExceptions() {
 		return printExceptions;
+	}
+
+	public static int getAskInputTimeout() {
+		return askInputTimeout;
+	}
+
+	public static void setAskInputTimeout(int askInputTimeout) {
+		Util.askInputTimeout = askInputTimeout;
 	}
 
 	public static void setOffline(boolean offline) {

--- a/src/test/java/dev/jbang/BaseTest.java
+++ b/src/test/java/dev/jbang/BaseTest.java
@@ -61,6 +61,7 @@ public abstract class BaseTest {
 	void initEnv(@TempDir Path tempPath) throws IOException {
 		Util.setQuiet(false);
 		Util.setOffline(false);
+		Util.setAskInputTimeout(0);
 		Util.setFresh(false);
 		Util.setPreview(false);
 		Util.setVerbose(true);

--- a/src/test/java/dev/jbang/util/TestUtilDownloads.java
+++ b/src/test/java/dev/jbang/util/TestUtilDownloads.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -51,7 +52,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqSimple(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqSimple(WireMockRuntimeInfo wmri) throws IOException {
 		UUID id = UUID.randomUUID();
 		stubFor(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -64,12 +65,13 @@ public class TestUtilDownloads extends BaseTest {
 		String url = wmri.getHttpBaseUrl() + "/test.txt";
 		Path file = NetUtil.downloadAndCacheFile(url);
 		FileTime lmt = Files.getLastModifiedTime(file);
-		ZonedDateTime zlmt = ZonedDateTime.ofInstant(lmt.toInstant(), ZoneId.of("GMT"));
-		String cachedLastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(zlmt);
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
+		FileTime backdatedLmt = Files.getLastModifiedTime(file);
+		ZonedDateTime zlmt = ZonedDateTime.ofInstant(backdatedLmt.toInstant(), ZoneId.of("GMT"));
+		String cachedLastModified = DateTimeFormatter.RFC_1123_DATE_TIME.format(zlmt);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -91,7 +93,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqSimpleFresh(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqSimpleFresh(WireMockRuntimeInfo wmri) throws IOException {
 		UUID id = UUID.randomUUID();
 		stubFor(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -107,7 +109,7 @@ public class TestUtilDownloads extends BaseTest {
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -168,7 +170,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqWithLastModifiedUpdated(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqWithLastModifiedUpdated(WireMockRuntimeInfo wmri) throws IOException {
 		UUID id = UUID.randomUUID();
 		stubFor(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -186,7 +188,7 @@ public class TestUtilDownloads extends BaseTest {
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -243,7 +245,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqWithLastModifiedUpdatedEvict1(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqWithLastModifiedUpdatedEvict1(WireMockRuntimeInfo wmri) throws IOException {
 		Configuration.instance().put("cache-evict", "1");
 
 		UUID id = UUID.randomUUID();
@@ -263,7 +265,7 @@ public class TestUtilDownloads extends BaseTest {
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -281,7 +283,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqWithLastModifiedUpdatedEvictPT1S(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqWithLastModifiedUpdatedEvictPT1S(WireMockRuntimeInfo wmri) throws IOException {
 		Configuration.instance().put("cache-evict", "pt1s");
 
 		UUID id = UUID.randomUUID();
@@ -301,7 +303,7 @@ public class TestUtilDownloads extends BaseTest {
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -362,7 +364,7 @@ public class TestUtilDownloads extends BaseTest {
 	}
 
 	@Test
-	void test2ReqWithETagUpdated(WireMockRuntimeInfo wmri) throws IOException, InterruptedException {
+	void test2ReqWithETagUpdated(WireMockRuntimeInfo wmri) throws IOException {
 		UUID id = UUID.randomUUID();
 		stubFor(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -382,7 +384,7 @@ public class TestUtilDownloads extends BaseTest {
 		assertThat(etag.toFile(), anExistingFile());
 		assertThat(Util.readString(etag), is("tag1"));
 
-		Thread.sleep(1100);
+		backdateCachedFile(file);
 
 		editStub(get(urlEqualTo("/test.txt"))
 			.withId(id)
@@ -418,6 +420,15 @@ public class TestUtilDownloads extends BaseTest {
 		Path file = NetUtil.downloadAndCacheFile(url);
 		assertThat(file.toFile(), anExistingFile());
 		assertThat(Util.readString(file), is("test"));
+	}
+
+	/**
+	 * Backdates a file's last-modified time by 2 seconds so cache-evict checks see
+	 * it as stale, without needing Thread.sleep(1100).
+	 */
+	private static void backdateCachedFile(Path file) throws IOException {
+		Instant past = Instant.now().minusSeconds(2);
+		Files.setLastModifiedTime(file, FileTime.from(past));
 	}
 
 	private static ValueMatcher<Request> withoutHeader(String hdr) {


### PR DESCRIPTION
## Test Suite Performance Optimization

Three independent improvements that reduce the test suite wall time from **2m 42s to ~50s** (3.2x faster).

### Commits

1. **fix: make askInput timeout configurable to avoid 60s test delay**
   - Two tests (`testHelloWorldGAVWithNoMain`, `testHelloWorldGAVWithModulesButNoManifest`) blocked 30s each waiting on interactive `Util.askInput()` timeout
   - Added `Util.getAskInputTimeout()`/`setAskInputTimeout()` following existing static field pattern
   - `BaseTest.initEnv()` sets timeout to 0 so tests fail immediately instead of waiting

2. **test: replace Thread.sleep(1100) with file backdating in TestUtilDownloads**
   - 6× `Thread.sleep(1100)` waited for filesystem timestamp granularity for cache-evict checks
   - Replaced with `Files.setLastModifiedTime()` to backdate cached files by 2 seconds

3. **build: enable parallel test execution**
   - Uncommented `maxParallelForks = availableProcessors/2` in `build.gradle`
   - Each fork runs in a separate JVM with its own WireMock and `mavenTempDir` — no concurrency issues

### Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Full test suite | **2m 42s** | **~50s** | 🟢 **3.2x faster** |
| Two timeout tests | 60s wasted | 0.6s | 60s saved |
| TestUtilDownloads | 6.9s sleeping | 0.1s | 6.3s saved |
| Parallelism | 1 fork | 7 forks | ~2x wall time reduction |
