### PR TITLE
feat: add tab-completion for jbang config subcommands

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -25,3 +25,5 @@ develocity {
 		publishing.onlyIf { false }
 	}
 }
+
+rootProject.name = 'jbang'

--- a/src/main/java/dev/jbang/cli/AvailableOption.java
+++ b/src/main/java/dev/jbang/cli/AvailableOption.java
@@ -1,0 +1,33 @@
+package dev.jbang.cli;
+
+import java.util.Objects;
+
+public class AvailableOption implements Comparable<AvailableOption> {
+	public final String key;
+	public final String description;
+
+	public AvailableOption(String key, String description) {
+		this.key = key;
+		this.description = description;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		AvailableOption that = (AvailableOption) o;
+		return key.equals(that.key);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(key);
+	}
+
+	@Override
+	public int compareTo(AvailableOption o) {
+		return key.compareTo(o.key);
+	}
+}

--- a/src/main/java/dev/jbang/cli/Completion.java
+++ b/src/main/java/dev/jbang/cli/Completion.java
@@ -21,6 +21,14 @@ public class Completion extends BaseCommand {
 	public int completion() throws IOException {
 		try {
 			String script = ShellCompletionGenerator.generateDynamic(shellType, JBang.class, "jbang");
+			if (shellType == ShellType.FISH) {
+				// Fish sorts completion candidates alphabetically by default.
+				// Add --keep-order so Fish preserves the order returned by
+				// jbang --aesh-complete (matching zsh behaviour).
+				script = script.replace(
+						"complete -c jbang -f -a",
+						"complete -c jbang -f -k -a");
+			}
 			System.out.println(script);
 		} catch (Exception e) {
 			throw new ExitException(EXIT_INTERNAL_ERROR, "Failed to generate completion script: " + e.getMessage(),

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -78,8 +78,14 @@ public class Config extends BaseCommand {
 		for (org.aesh.command.impl.internal.ProcessedOption opt : cmd.getOptions()) {
 			if (opt.name() != null && !opt.name().isEmpty()) {
 				String optName = opt.name().replace("-", "");
-				String key = path != null ? path + "." + optName : optName;
-				keys.add(new AvailableOption(key, opt.description()));
+				if (path != null) {
+					keys.add(new AvailableOption(path + "." + optName, opt.description()));
+				} else {
+					// Root command: add both short form (e.g. "fresh") and
+					// qualified form (e.g. "jbang.fresh")
+					keys.add(new AvailableOption(optName, opt.description()));
+					keys.add(new AvailableOption(cmdName + "." + optName, opt.description()));
+				}
 			}
 		}
 		if (parser.isGroupCommand()) {

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -74,10 +74,11 @@ public class Config extends BaseCommand {
 		if (!"jbang".equals(cmdName)) {
 			currentPath.add(cmdName);
 		}
-		String path = currentPath.isEmpty() ? cmdName : String.join(".", currentPath);
+		String path = currentPath.isEmpty() ? null : String.join(".", currentPath);
 		for (org.aesh.command.impl.internal.ProcessedOption opt : cmd.getOptions()) {
 			if (opt.name() != null && !opt.name().isEmpty()) {
-				String key = path + "." + opt.name().replace("-", "");
+				String optName = opt.name().replace("-", "");
+				String key = path != null ? path + "." + optName : optName;
 				keys.add(new AvailableOption(key, opt.description()));
 			}
 		}

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -60,7 +60,7 @@ public class Config extends BaseCommand {
 				gatherFromParser(container.getParser(), Collections.emptyList(), opts);
 			}
 		} catch (Exception e) {
-			// best-effort
+			Util.verboseMsg("Failed to gather config keys from CLI tree: " + e.getMessage());
 		}
 		return opts;
 	}

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -16,6 +16,8 @@ import com.google.gson.GsonBuilder;
 
 import dev.jbang.Configuration;
 import dev.jbang.Settings;
+import dev.jbang.cli.completion.ConfigKeyCompleter;
+import dev.jbang.cli.completion.ConfigUnsetKeyCompleter;
 import dev.jbang.util.ConfigUtil;
 import dev.jbang.util.ConsoleOutput;
 import dev.jbang.util.Util;
@@ -28,7 +30,7 @@ public class Config extends BaseCommand {
 
 	// IMPORTANT: These options have to be maintained manually! Make sure to add
 	// an option for each configuration key that gets added!
-	static AvailableOption[] extraOptions = {
+	public static AvailableOption[] extraOptions = {
 			new AvailableOption(Settings.CONFIG_CACHE_EVICT,
 					"Time that locally cached files are kept before they are evicted. Can be a simple number in seconds, an ISO8601 Duration or the word 'never'"),
 			new AvailableOption(Settings.CONFIG_CONNECTION_TIMEOUT,
@@ -38,6 +40,56 @@ public class Config extends BaseCommand {
 	@Override
 	public Integer doCall() throws IOException {
 		return missingSubcommand();
+	}
+
+	/**
+	 * Returns all known configuration keys with descriptions, gathered from the CLI
+	 * command tree and {@link #extraOptions}.
+	 */
+	@SuppressWarnings("unchecked")
+	public static Set<AvailableOption> getAvailableOptions() {
+		Set<AvailableOption> opts = new HashSet<>(Arrays.asList(extraOptions));
+		try {
+			org.aesh.command.registry.CommandRegistry<org.aesh.command.invocation.CommandInvocation> registry = org.aesh.command.impl.registry.AeshCommandRegistryBuilder.<org.aesh.command.invocation.CommandInvocation>builder()
+				.command(
+						(Class<org.aesh.command.Command<org.aesh.command.invocation.CommandInvocation>>) (Class<?>) JBang.class)
+				.create();
+			for (String name : registry.getAllCommandNames()) {
+				org.aesh.command.container.CommandContainer<org.aesh.command.invocation.CommandInvocation> container = registry
+					.getCommand(name, "");
+				gatherFromParser(container.getParser(), Collections.emptyList(), opts);
+			}
+		} catch (Exception e) {
+			// best-effort
+		}
+		return opts;
+	}
+
+	private static void gatherFromParser(
+			org.aesh.command.impl.parser.CommandLineParser<?> parser,
+			List<String> parentPath, Set<AvailableOption> keys) {
+		org.aesh.command.impl.internal.ProcessedCommand<?, ?> cmd = parser.getProcessedCommand();
+		String cmdName = cmd.name();
+		List<String> currentPath = new ArrayList<>(parentPath);
+		if (!"jbang".equals(cmdName)) {
+			currentPath.add(cmdName);
+		}
+		String path = currentPath.isEmpty() ? cmdName : String.join(".", currentPath);
+		for (org.aesh.command.impl.internal.ProcessedOption opt : cmd.getOptions()) {
+			if (opt.name() != null && !opt.name().isEmpty()) {
+				String key = path + "." + opt.name().replace("-", "");
+				keys.add(new AvailableOption(key, opt.description()));
+			}
+		}
+		if (parser.isGroupCommand()) {
+			parser.getAllNames();
+			org.aesh.command.impl.parser.AeshCommandLineParser<?> aeshParser = (org.aesh.command.impl.parser.AeshCommandLineParser<?>) parser;
+			if (aeshParser.getChildParsers() != null) {
+				for (org.aesh.command.impl.parser.CommandLineParser<?> child : aeshParser.getChildParsers()) {
+					gatherFromParser(child, currentPath, keys);
+				}
+			}
+		}
 	}
 
 	static abstract class BaseConfigCommand extends BaseCommand {
@@ -85,7 +137,7 @@ public class Config extends BaseCommand {
 
 	@CommandDefinition(name = "get", description = "Get a configuration value", generateHelp = true)
 	public static class ConfigGet extends BaseConfigCommand {
-		@Argument(paramLabel = "key", arity = "1", description = "The name of the configuration option to get", required = true)
+		@Argument(paramLabel = "key", arity = "1", description = "The name of the configuration option to get", required = true, completer = ConfigKeyCompleter.class)
 		String key;
 
 		@Override
@@ -104,7 +156,7 @@ public class Config extends BaseCommand {
 
 	@CommandDefinition(name = "set", description = "Set a configuration value", generateHelp = true)
 	public static class ConfigSet extends BaseConfigCommand {
-		@Argument(paramLabel = "key", index = "0", arity = "1", description = "The name of the configuration option to set", required = true)
+		@Argument(paramLabel = "key", index = "0", arity = "1", description = "The name of the configuration option to set", required = true, completer = ConfigKeyCompleter.class)
 		String keyOrKeyValue;
 
 		@Argument(paramLabel = "value", index = "1", arity = "0..1", description = "The value to set for the configuration option")
@@ -140,7 +192,7 @@ public class Config extends BaseCommand {
 
 	@CommandDefinition(name = "unset", description = "Remove a configuration value", generateHelp = true)
 	public static class ConfigUnset extends BaseConfigCommand {
-		@Argument(paramLabel = "key", arity = "1", description = "The name of the configuration option to remove", required = true)
+		@Argument(paramLabel = "key", arity = "1", description = "The name of the configuration option to remove", required = true, completer = ConfigUnsetKeyCompleter.class)
 		String key;
 
 		@Override
@@ -185,8 +237,7 @@ public class Config extends BaseCommand {
 						"Options '--show-available' and '--show-origin' cannot be used together");
 			}
 			if (showAvailable) {
-				Set<AvailableOption> opts = new HashSet<>(Arrays.asList(Config.extraOptions));
-				gatherKeys(JBang.class, opts);
+				Set<AvailableOption> opts = Config.getAvailableOptions();
 				if (format == OutputFormat.json) {
 					Gson parser = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
 					parser.toJson(opts.stream().sorted().collect(Collectors.toList()), out);
@@ -206,49 +257,6 @@ public class Config extends BaseCommand {
 				}
 			}
 			return EXIT_OK;
-		}
-
-		@SuppressWarnings("unchecked")
-		private void gatherKeys(Class<?> cmdClass, Set<AvailableOption> keys) {
-			try {
-				org.aesh.command.registry.CommandRegistry<org.aesh.command.invocation.CommandInvocation> registry = org.aesh.command.impl.registry.AeshCommandRegistryBuilder.<org.aesh.command.invocation.CommandInvocation>builder()
-					.command((Class<org.aesh.command.Command<org.aesh.command.invocation.CommandInvocation>>) cmdClass)
-					.create();
-				for (String name : registry.getAllCommandNames()) {
-					org.aesh.command.container.CommandContainer<org.aesh.command.invocation.CommandInvocation> container = registry
-						.getCommand(name, "");
-					gatherFromParser(container.getParser(), Collections.emptyList(), keys);
-				}
-			} catch (Exception e) {
-				throw new RuntimeException("Failed to gather config keys", e);
-			}
-		}
-
-		private void gatherFromParser(
-				org.aesh.command.impl.parser.CommandLineParser<?> parser,
-				List<String> parentPath, Set<AvailableOption> keys) {
-			org.aesh.command.impl.internal.ProcessedCommand<?, ?> cmd = parser.getProcessedCommand();
-			String cmdName = cmd.name();
-			List<String> currentPath = new ArrayList<>(parentPath);
-			if (!"jbang".equals(cmdName)) {
-				currentPath.add(cmdName);
-			}
-			String path = currentPath.isEmpty() ? cmdName : String.join(".", currentPath);
-			for (org.aesh.command.impl.internal.ProcessedOption opt : cmd.getOptions()) {
-				if (opt.name() != null && !opt.name().isEmpty()) {
-					String key = path + "." + opt.name().replace("-", "");
-					keys.add(new AvailableOption(key, opt.description()));
-				}
-			}
-			if (parser.isGroupCommand()) {
-				parser.getAllNames();
-				org.aesh.command.impl.parser.AeshCommandLineParser<?> aeshParser = (org.aesh.command.impl.parser.AeshCommandLineParser<?>) parser;
-				if (aeshParser.getChildParsers() != null) {
-					for (org.aesh.command.impl.parser.CommandLineParser<?> child : aeshParser.getChildParsers()) {
-						gatherFromParser(child, currentPath, keys);
-					}
-				}
-			}
 		}
 
 		private void printConfig(PrintStream out, Configuration cfg, OutputFormat format) {
@@ -300,35 +308,5 @@ public class Config extends BaseCommand {
 				}
 			}
 		}
-	}
-}
-
-class AvailableOption implements Comparable<AvailableOption> {
-	final String key;
-	final String description;
-
-	public AvailableOption(String key, String description) {
-		this.key = key;
-		this.description = description;
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		AvailableOption that = (AvailableOption) o;
-		return key.equals(that.key);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(key);
-	}
-
-	@Override
-	public int compareTo(AvailableOption o) {
-		return key.compareTo(o.key);
 	}
 }

--- a/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
@@ -41,6 +41,7 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 		Set<String> candidates = new TreeSet<>();
 		Map<String, String> availableKeys = getAvailableKeys();
 
+		// First pass: prefix match (standard completion behaviour)
 		for (Map.Entry<String, String> entry : availableKeys.entrySet()) {
 			String key = entry.getKey();
 			String desc = entry.getValue();
@@ -55,7 +56,6 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 			Configuration cfg = Configuration.getMerged();
 			for (String key : cfg.flatten().keySet()) {
 				if (key.startsWith(partial)) {
-					// Only add if not already present from available keys
 					boolean alreadyPresent = availableKeys.containsKey(key);
 					if (!alreadyPresent) {
 						String val = cfg.get(key);
@@ -65,6 +65,36 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 			}
 		} catch (Exception e) {
 			// best-effort
+		}
+
+		// Second pass: if prefix match found nothing and the partial is
+		// non-empty, do a segment match. "debu" matches "run.debug",
+		// "add." matches "alias.add.*", "catalog.add.*", etc.
+		if (candidates.isEmpty() && !partial.isEmpty()) {
+			for (Map.Entry<String, String> entry : availableKeys.entrySet()) {
+				String key = entry.getKey();
+				if (matchesSegment(key, partial)) {
+					candidates.add(described(key, entry.getValue()));
+				}
+			}
+			// Also check user-defined keys
+			try {
+				Configuration cfg = Configuration.getMerged();
+				for (String key : cfg.flatten().keySet()) {
+					if (!availableKeys.containsKey(key) && matchesSegment(key, partial)) {
+						String val = cfg.get(key);
+						candidates.add(described(key, val != null ? "= " + val : ""));
+					}
+				}
+			} catch (Exception e) {
+				// best-effort
+			}
+			// Tell aesh to replace the whole token rather than append,
+			// since the candidates don't share the typed prefix.
+			if (!candidates.isEmpty()) {
+				inv.setIgnoreStartsWith(true);
+				inv.setOffset(0);
+			}
 		}
 
 		inv.addAllCompleterValues(candidates);
@@ -79,6 +109,38 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 				inv.addCompleterValue(single.substring(0, tab));
 			}
 		}
+	}
+
+	/**
+	 * Returns true if the partial matches any segment boundary in the key.
+	 * <p>
+	 * Examples:
+	 * <ul>
+	 * <li>{@code matchesSegment("run.debug", "debu")} → true (segment "debug"
+	 * starts with "debu")</li>
+	 * <li>{@code matchesSegment("alias.add.debug", "add.")} → true ("add.debug"
+	 * starts with "add.")</li>
+	 * <li>{@code matchesSegment("alias.add.debug", "add.deb")} → true</li>
+	 * <li>{@code matchesSegment("run.debug", "xyz")} → false</li>
+	 * </ul>
+	 */
+	static boolean matchesSegment(String key, String partial) {
+		// Try matching at each dot boundary
+		int idx = 0;
+		while (true) {
+			int dot = key.indexOf('.', idx);
+			if (dot < 0) {
+				break;
+			}
+			String suffix = key.substring(dot + 1);
+			if (suffix.startsWith(partial)) {
+				return true;
+			}
+			idx = dot + 1;
+		}
+		// Also try contains for multi-segment partials like "add.debu"
+		// that might not align exactly to a segment start
+		return key.contains("." + partial);
 	}
 
 	/**

--- a/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
@@ -1,0 +1,97 @@
+package dev.jbang.cli.completion;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.command.completer.OptionCompleter;
+
+import dev.jbang.Configuration;
+import dev.jbang.cli.AvailableOption;
+import dev.jbang.cli.Config;
+
+/**
+ * Provides tab-completion for the {@code key} argument of {@code jbang config}
+ * subcommands ({@code get}, {@code set}).
+ * <p>
+ * Completes from two sources:
+ * <ul>
+ * <li>Available option keys gathered from the CLI command tree (same as
+ * {@code config list --show-available})</li>
+ * <li>User-set keys from the merged configuration that don't match a known
+ * option name</li>
+ * </ul>
+ * Candidates include tab-separated descriptions for fish/zsh display.
+ */
+public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> {
+
+	private static String described(String candidate, String description) {
+		return candidate + "\t" + description;
+	}
+
+	@Override
+	public void complete(CompleterInvocation inv) {
+		String partial = inv.getGivenCompleteValue();
+		if (partial == null) {
+			partial = "";
+		}
+
+		Set<String> candidates = new TreeSet<>();
+		Map<String, String> availableKeys = getAvailableKeys();
+
+		for (Map.Entry<String, String> entry : availableKeys.entrySet()) {
+			String key = entry.getKey();
+			String desc = entry.getValue();
+			if (key.startsWith(partial)) {
+				candidates.add(described(key, desc));
+			}
+		}
+
+		// Also complete keys from the merged configuration (user-set values
+		// that might not match known option names)
+		try {
+			Configuration cfg = Configuration.getMerged();
+			for (String key : cfg.flatten().keySet()) {
+				if (key.startsWith(partial)) {
+					// Only add if not already present from available keys
+					boolean alreadyPresent = availableKeys.containsKey(key);
+					if (!alreadyPresent) {
+						String val = cfg.get(key);
+						candidates.add(described(key, val != null ? "= " + val : ""));
+					}
+				}
+			}
+		} catch (Exception e) {
+			// best-effort
+		}
+
+		inv.addAllCompleterValues(candidates);
+
+		// When there is exactly one candidate, strip the description so the
+		// value is clean (aesh escapes spaces in single-candidate mode).
+		if (candidates.size() == 1) {
+			String single = candidates.iterator().next();
+			int tab = single.indexOf('\t');
+			if (tab >= 0) {
+				inv.clearCompleterValues();
+				inv.addCompleterValue(single.substring(0, tab));
+			}
+		}
+	}
+
+	/**
+	 * Gathers all known configuration keys with descriptions, using the same source
+	 * as {@code config list --show-available}.
+	 *
+	 * @return map of key → description
+	 */
+	static Map<String, String> getAvailableKeys() {
+		Map<String, String> keys = new TreeMap<>();
+		for (AvailableOption opt : Config.getAvailableOptions()) {
+			keys.put(opt.key, opt.description);
+		}
+		return keys;
+	}
+}

--- a/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigKeyCompleter.java
@@ -27,6 +27,11 @@ import dev.jbang.cli.Config;
  */
 public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> {
 
+	/**
+	 * Cached available keys — static data that never changes during a JVM session.
+	 */
+	private static volatile Map<String, String> cachedAvailableKeys;
+
 	private static String described(String candidate, String description) {
 		return candidate + "\t" + description;
 	}
@@ -41,6 +46,14 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 		Set<String> candidates = new TreeSet<>();
 		Map<String, String> availableKeys = getAvailableKeys();
 
+		// Load merged config once for both passes
+		Configuration cfg = null;
+		try {
+			cfg = Configuration.getMerged();
+		} catch (Exception e) {
+			// best-effort — user-defined keys won't be completed
+		}
+
 		// First pass: prefix match (standard completion behaviour)
 		for (Map.Entry<String, String> entry : availableKeys.entrySet()) {
 			String key = entry.getKey();
@@ -52,19 +65,13 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 
 		// Also complete keys from the merged configuration (user-set values
 		// that might not match known option names)
-		try {
-			Configuration cfg = Configuration.getMerged();
+		if (cfg != null) {
 			for (String key : cfg.flatten().keySet()) {
-				if (key.startsWith(partial)) {
-					boolean alreadyPresent = availableKeys.containsKey(key);
-					if (!alreadyPresent) {
-						String val = cfg.get(key);
-						candidates.add(described(key, val != null ? "= " + val : ""));
-					}
+				if (key.startsWith(partial) && !availableKeys.containsKey(key)) {
+					String val = cfg.get(key);
+					candidates.add(described(key, val != null ? "= " + val : ""));
 				}
 			}
-		} catch (Exception e) {
-			// best-effort
 		}
 
 		// Second pass: if prefix match found nothing and the partial is
@@ -78,16 +85,13 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 				}
 			}
 			// Also check user-defined keys
-			try {
-				Configuration cfg = Configuration.getMerged();
+			if (cfg != null) {
 				for (String key : cfg.flatten().keySet()) {
 					if (!availableKeys.containsKey(key) && matchesSegment(key, partial)) {
 						String val = cfg.get(key);
 						candidates.add(described(key, val != null ? "= " + val : ""));
 					}
 				}
-			} catch (Exception e) {
-				// best-effort
 			}
 			// Tell aesh to replace the whole token rather than append,
 			// since the candidates don't share the typed prefix.
@@ -125,22 +129,22 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 	 * </ul>
 	 */
 	static boolean matchesSegment(String key, String partial) {
-		// Try matching at each dot boundary
+		// Try matching at each dot boundary. This handles both single-
+		// segment partials ("debu" matching "run.debug") and multi-segment
+		// partials ("add.deb" matching "alias.add.debug") because each
+		// suffix includes all remaining segments.
 		int idx = 0;
 		while (true) {
 			int dot = key.indexOf('.', idx);
 			if (dot < 0) {
 				break;
 			}
-			String suffix = key.substring(dot + 1);
-			if (suffix.startsWith(partial)) {
+			if (key.substring(dot + 1).startsWith(partial)) {
 				return true;
 			}
 			idx = dot + 1;
 		}
-		// Also try contains for multi-segment partials like "add.debu"
-		// that might not align exactly to a segment start
-		return key.contains("." + partial);
+		return false;
 	}
 
 	/**
@@ -150,9 +154,13 @@ public class ConfigKeyCompleter implements OptionCompleter<CompleterInvocation> 
 	 * @return map of key → description
 	 */
 	static Map<String, String> getAvailableKeys() {
-		Map<String, String> keys = new TreeMap<>();
-		for (AvailableOption opt : Config.getAvailableOptions()) {
-			keys.put(opt.key, opt.description);
+		Map<String, String> keys = cachedAvailableKeys;
+		if (keys == null) {
+			keys = new TreeMap<>();
+			for (AvailableOption opt : Config.getAvailableOptions()) {
+				keys.put(opt.key, opt.description);
+			}
+			cachedAvailableKeys = keys;
 		}
 		return keys;
 	}

--- a/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
@@ -1,5 +1,6 @@
 package dev.jbang.cli.completion;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -65,6 +66,7 @@ public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocat
 
 	private void collectSetKeys(Set<String> candidates, Configuration cfg,
 			Map<String, String> availableKeys, String partial, boolean prefixOnly) {
+		Set<String> seenKeys = new HashSet<>();
 		Configuration current = cfg;
 		while (current != null) {
 			String origin = null;
@@ -72,6 +74,9 @@ public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocat
 				origin = current.getStoreRef().getOriginalResource();
 			}
 			for (String key : current.keySet()) {
+				if (seenKeys.contains(key)) {
+					continue;
+				}
 				boolean matches = prefixOnly
 						? key.startsWith(partial)
 						: ConfigKeyCompleter.matchesSegment(key, partial);
@@ -84,11 +89,8 @@ public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocat
 					} else {
 						desc = "Set";
 					}
-					String prefix = key + "\t";
-					boolean alreadyPresent = candidates.stream().anyMatch(c -> c.startsWith(prefix));
-					if (!alreadyPresent) {
-						candidates.add(described(key, desc));
-					}
+					candidates.add(described(key, desc));
+					seenKeys.add(key);
 				}
 			}
 			current = current.getFallback();

--- a/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
@@ -31,38 +31,21 @@ public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocat
 		}
 
 		Set<String> candidates = new TreeSet<>();
-
-		// Get available key descriptions for richer output
 		Map<String, String> availableKeys = ConfigKeyCompleter.getAvailableKeys();
 
 		try {
 			Configuration cfg = Configuration.getMerged();
-			// Walk the configuration chain to show origin
-			Configuration current = cfg;
-			while (current != null) {
-				String origin = null;
-				if (current.getStoreRef() != null) {
-					origin = current.getStoreRef().getOriginalResource();
+
+			// First pass: prefix match
+			collectSetKeys(candidates, cfg, availableKeys, partial, true);
+
+			// Second pass: segment match fallback when prefix found nothing
+			if (candidates.isEmpty() && !partial.isEmpty()) {
+				collectSetKeys(candidates, cfg, availableKeys, partial, false);
+				if (!candidates.isEmpty()) {
+					inv.setIgnoreStartsWith(true);
+					inv.setOffset(0);
 				}
-				for (String key : current.keySet()) {
-					if (key.startsWith(partial)) {
-						String desc;
-						if (origin != null) {
-							desc = origin;
-						} else if (availableKeys.containsKey(key)) {
-							desc = availableKeys.get(key);
-						} else {
-							desc = "Set";
-						}
-						// First match wins (nearest config has priority)
-						String prefix = key + "\t";
-						boolean alreadyPresent = candidates.stream().anyMatch(c -> c.startsWith(prefix));
-						if (!alreadyPresent) {
-							candidates.add(described(key, desc));
-						}
-					}
-				}
-				current = current.getFallback();
 			}
 		} catch (Exception e) {
 			// best-effort
@@ -77,6 +60,38 @@ public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocat
 				inv.clearCompleterValues();
 				inv.addCompleterValue(single.substring(0, tab));
 			}
+		}
+	}
+
+	private void collectSetKeys(Set<String> candidates, Configuration cfg,
+			Map<String, String> availableKeys, String partial, boolean prefixOnly) {
+		Configuration current = cfg;
+		while (current != null) {
+			String origin = null;
+			if (current.getStoreRef() != null) {
+				origin = current.getStoreRef().getOriginalResource();
+			}
+			for (String key : current.keySet()) {
+				boolean matches = prefixOnly
+						? key.startsWith(partial)
+						: ConfigKeyCompleter.matchesSegment(key, partial);
+				if (matches) {
+					String desc;
+					if (origin != null) {
+						desc = origin;
+					} else if (availableKeys.containsKey(key)) {
+						desc = availableKeys.get(key);
+					} else {
+						desc = "Set";
+					}
+					String prefix = key + "\t";
+					boolean alreadyPresent = candidates.stream().anyMatch(c -> c.startsWith(prefix));
+					if (!alreadyPresent) {
+						candidates.add(described(key, desc));
+					}
+				}
+			}
+			current = current.getFallback();
 		}
 	}
 }

--- a/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
+++ b/src/main/java/dev/jbang/cli/completion/ConfigUnsetKeyCompleter.java
@@ -1,0 +1,82 @@
+package dev.jbang.cli.completion;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.aesh.command.completer.CompleterInvocation;
+import org.aesh.command.completer.OptionCompleter;
+
+import dev.jbang.Configuration;
+
+/**
+ * Provides tab-completion for the {@code key} argument of
+ * {@code jbang config unset}. Only offers keys that are currently set in the
+ * merged configuration, since unsetting a non-existent key is an error.
+ * <p>
+ * When the merged configuration has origin information, descriptions show the
+ * source file where each key is defined.
+ */
+public class ConfigUnsetKeyCompleter implements OptionCompleter<CompleterInvocation> {
+
+	private static String described(String candidate, String description) {
+		return candidate + "\t" + description;
+	}
+
+	@Override
+	public void complete(CompleterInvocation inv) {
+		String partial = inv.getGivenCompleteValue();
+		if (partial == null) {
+			partial = "";
+		}
+
+		Set<String> candidates = new TreeSet<>();
+
+		// Get available key descriptions for richer output
+		Map<String, String> availableKeys = ConfigKeyCompleter.getAvailableKeys();
+
+		try {
+			Configuration cfg = Configuration.getMerged();
+			// Walk the configuration chain to show origin
+			Configuration current = cfg;
+			while (current != null) {
+				String origin = null;
+				if (current.getStoreRef() != null) {
+					origin = current.getStoreRef().getOriginalResource();
+				}
+				for (String key : current.keySet()) {
+					if (key.startsWith(partial)) {
+						String desc;
+						if (origin != null) {
+							desc = origin;
+						} else if (availableKeys.containsKey(key)) {
+							desc = availableKeys.get(key);
+						} else {
+							desc = "Set";
+						}
+						// First match wins (nearest config has priority)
+						String prefix = key + "\t";
+						boolean alreadyPresent = candidates.stream().anyMatch(c -> c.startsWith(prefix));
+						if (!alreadyPresent) {
+							candidates.add(described(key, desc));
+						}
+					}
+				}
+				current = current.getFallback();
+			}
+		} catch (Exception e) {
+			// best-effort
+		}
+
+		inv.addAllCompleterValues(candidates);
+
+		if (candidates.size() == 1) {
+			String single = candidates.iterator().next();
+			int tab = single.indexOf('\t');
+			if (tab >= 0) {
+				inv.clearCompleterValues();
+				inv.addCompleterValue(single.substring(0, tab));
+			}
+		}
+	}
+}

--- a/src/test/java/dev/jbang/cli/TestCompletion.java
+++ b/src/test/java/dev/jbang/cli/TestCompletion.java
@@ -1,0 +1,35 @@
+package dev.jbang.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+
+public class TestCompletion extends BaseTest {
+
+	@Test
+	void testFishCompletionIncludesKeepOrder() throws Exception {
+		CaptureResult<Integer> result = checkedRun("completion", "-s", "fish");
+		assertThat(result.result, org.hamcrest.Matchers.equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.normalizedOut(), containsString("complete -c jbang -f -k -a"));
+	}
+
+	@Test
+	void testBashCompletionUnchanged() throws Exception {
+		CaptureResult<Integer> result = checkedRun("completion", "-s", "bash");
+		assertThat(result.result, org.hamcrest.Matchers.equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.normalizedOut(), containsString("complete -F _complete_jbang jbang"));
+		assertThat(result.normalizedOut(), not(containsString("-k")));
+	}
+
+	@Test
+	void testZshCompletionUnchanged() throws Exception {
+		CaptureResult<Integer> result = checkedRun("completion", "-s", "zsh");
+		assertThat(result.result, org.hamcrest.Matchers.equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.normalizedOut(), containsString("_jbang"));
+		assertThat(result.normalizedOut(), not(containsString("-k")));
+	}
+}

--- a/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
+++ b/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
@@ -44,9 +44,9 @@ public class TestConfigKeyCompleter extends BaseTest {
 	@Test
 	void testGetAvailableKeysContainsCliOptions() {
 		Map<String, String> keys = ConfigKeyCompleter.getAvailableKeys();
-		// These come from the CLI command tree — top-level jbang options
-		assertThat(keys, hasKey("jbang.verbose"));
-		assertThat(keys, hasKey("jbang.offline"));
+		// Top-level jbang options (no jbang. prefix)
+		assertThat(keys, hasKey("verbose"));
+		assertThat(keys, hasKey("offline"));
 		// Subcommand options should also appear
 		assertThat("Keys should include subcommand options",
 				keys.keySet().stream().anyMatch(k -> k.contains(".")), is(true));

--- a/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
+++ b/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
@@ -1,0 +1,266 @@
+package dev.jbang.cli.completion;
+
+import static dev.jbang.util.TestUtil.clearSettingsCaches;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.aesh.command.completer.CompleterInvocation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+import dev.jbang.Configuration;
+
+public class TestConfigKeyCompleter extends BaseTest {
+
+	static final String testConfig = "" +
+			"one=footop\n" +
+			"two=bar\n" +
+			"custom.mykey=hello\n";
+
+	Path testConfigFile = null;
+
+	@BeforeEach
+	void initEach() throws IOException {
+		testConfigFile = cwdDir.resolve(Configuration.JBANG_CONFIG_PROPS);
+		Files.write(testConfigFile, testConfig.getBytes());
+		clearSettingsCaches();
+	}
+
+	@Test
+	void testGetAvailableKeysContainsExtraOptions() {
+		Map<String, String> keys = ConfigKeyCompleter.getAvailableKeys();
+		assertThat(keys, hasKey("cache-evict"));
+		assertThat(keys, hasKey("connection-timeout"));
+	}
+
+	@Test
+	void testGetAvailableKeysContainsCliOptions() {
+		Map<String, String> keys = ConfigKeyCompleter.getAvailableKeys();
+		// These come from the CLI command tree — top-level jbang options
+		assertThat(keys, hasKey("jbang.verbose"));
+		assertThat(keys, hasKey("jbang.offline"));
+		// Subcommand options should also appear
+		assertThat("Keys should include subcommand options",
+				keys.keySet().stream().anyMatch(k -> k.contains(".")), is(true));
+	}
+
+	@Test
+	void testCompleteAllKeysOnEmptyInput() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		// Should contain both available keys and user-set keys
+		assertThat(values, hasItem("cache-evict"));
+		assertThat(values, hasItem("one"));
+		assertThat(values, hasItem("two"));
+		assertThat(values, hasItem("custom.mykey"));
+	}
+
+	@Test
+	void testCompleteWithPartialMatch() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("cache");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		assertThat(values, hasItem("cache-evict"));
+		// Should not contain unrelated keys
+		assertThat(values, not(hasItem("connection-timeout")));
+		assertThat(values, not(hasItem("one")));
+	}
+
+	@Test
+	void testCompleteWithPrefixMatchesUserDefined() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("custom");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		assertThat(values, hasItem("custom.mykey"));
+	}
+
+	@Test
+	void testUnsetCompleterOnlyShowsSetKeys() {
+		ConfigUnsetKeyCompleter completer = new ConfigUnsetKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		// Should contain keys from the config file and built-in defaults
+		assertThat(values, hasItem("one"));
+		assertThat(values, hasItem("two"));
+		assertThat(values, hasItem("custom.mykey"));
+	}
+
+	@Test
+	void testUnsetCompleterPartialMatch() {
+		ConfigUnsetKeyCompleter completer = new ConfigUnsetKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("o");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		assertThat(values, hasItem("one"));
+		assertThat(values, not(hasItem("two")));
+	}
+
+	@Test
+	void testSingleCandidateStripsDescription() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("cache-ev");
+		completer.complete(inv);
+
+		// Single candidate should have description stripped
+		assertThat(inv.candidates, hasSize(1));
+		assertThat(inv.candidates.get(0), not(containsString("\t")));
+		assertThat(inv.candidates.get(0), equalTo("cache-evict"));
+	}
+
+	@Test
+	void testCompletionIncludesDescriptions() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("cache");
+		// Add a second match so descriptions are preserved
+		TestCompleterInvocation inv2 = new TestCompleterInvocation("c");
+		completer.complete(inv2);
+
+		// With multiple candidates, descriptions should be present
+		if (inv2.candidates.size() > 1) {
+			boolean hasDescription = inv2.candidates.stream().anyMatch(c -> c.contains("\t"));
+			assertThat("Candidates should include descriptions", hasDescription);
+		}
+	}
+
+	private List<String> stripDescriptions(List<String> candidates) {
+		List<String> result = new ArrayList<>();
+		for (String c : candidates) {
+			int tab = c.indexOf('\t');
+			result.add(tab >= 0 ? c.substring(0, tab) : c);
+		}
+		return result;
+	}
+
+	/**
+	 * Minimal CompleterInvocation stub for testing.
+	 */
+	static class TestCompleterInvocation implements CompleterInvocation {
+		final String partial;
+		final List<String> candidates = new ArrayList<>();
+		boolean appendSpace = true;
+		boolean ignoreStartsWith = false;
+		boolean ignoreOffset = false;
+		int offset = -1;
+
+		TestCompleterInvocation(String partial) {
+			this.partial = partial;
+		}
+
+		@Override
+		public String getGivenCompleteValue() {
+			return partial;
+		}
+
+		@Override
+		public org.aesh.command.Command getCommand() {
+			return null;
+		}
+
+		@Override
+		public java.util.List<org.aesh.terminal.formatting.TerminalString> getCompleterValues() {
+			java.util.List<org.aesh.terminal.formatting.TerminalString> result = new ArrayList<>();
+			for (String c : candidates) {
+				result.add(new org.aesh.terminal.formatting.TerminalString(c));
+			}
+			return result;
+		}
+
+		@Override
+		public void setCompleterValues(java.util.Collection<String> values) {
+			candidates.clear();
+			candidates.addAll(values);
+		}
+
+		@Override
+		public void setCompleterValuesTerminalString(
+				java.util.List<org.aesh.terminal.formatting.TerminalString> values) {
+			candidates.clear();
+			for (org.aesh.terminal.formatting.TerminalString ts : values) {
+				candidates.add(ts.toString());
+			}
+		}
+
+		@Override
+		public void clearCompleterValues() {
+			candidates.clear();
+		}
+
+		@Override
+		public void addAllCompleterValues(java.util.Collection<String> values) {
+			candidates.addAll(values);
+		}
+
+		@Override
+		public void addCompleterValue(String value) {
+			candidates.add(value);
+		}
+
+		@Override
+		public void addCompleterValueTerminalString(org.aesh.terminal.formatting.TerminalString value) {
+			candidates.add(value.toString());
+		}
+
+		@Override
+		public void setAppendSpace(boolean b) {
+			appendSpace = b;
+		}
+
+		@Override
+		public boolean isAppendSpace() {
+			return appendSpace;
+		}
+
+		@Override
+		public void setIgnoreStartsWith(boolean b) {
+			ignoreStartsWith = b;
+		}
+
+		@Override
+		public boolean isIgnoreStartsWith() {
+			return ignoreStartsWith;
+		}
+
+		@Override
+		public void setIgnoreOffset(boolean b) {
+			ignoreOffset = b;
+		}
+
+		@Override
+		public boolean doIgnoreOffset() {
+			return ignoreOffset;
+		}
+
+		@Override
+		public void setOffset(int i) {
+			offset = i;
+		}
+
+		@Override
+		public int getOffset() {
+			return offset;
+		}
+
+		@Override
+		public org.aesh.console.AeshContext getAeshContext() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
+++ b/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
@@ -44,9 +44,11 @@ public class TestConfigKeyCompleter extends BaseTest {
 	@Test
 	void testGetAvailableKeysContainsCliOptions() {
 		Map<String, String> keys = ConfigKeyCompleter.getAvailableKeys();
-		// Top-level jbang options (no jbang. prefix)
+		// Top-level jbang options: both short and qualified forms
 		assertThat(keys, hasKey("verbose"));
+		assertThat(keys, hasKey("jbang.verbose"));
 		assertThat(keys, hasKey("offline"));
+		assertThat(keys, hasKey("jbang.offline"));
 		// Subcommand options should also appear
 		assertThat("Keys should include subcommand options",
 				keys.keySet().stream().anyMatch(k -> k.contains(".")), is(true));

--- a/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
+++ b/src/test/java/dev/jbang/cli/completion/TestConfigKeyCompleter.java
@@ -140,6 +140,62 @@ public class TestConfigKeyCompleter extends BaseTest {
 		}
 	}
 
+	// ---- Segment matching tests ----------------------------------------
+
+	@Test
+	void testMatchesSegmentBasic() {
+		assertThat(ConfigKeyCompleter.matchesSegment("run.debug", "debu"), is(true));
+		assertThat(ConfigKeyCompleter.matchesSegment("alias.add.debug", "debu"), is(true));
+		assertThat(ConfigKeyCompleter.matchesSegment("run.debug", "xyz"), is(false));
+	}
+
+	@Test
+	void testMatchesSegmentWithDot() {
+		assertThat(ConfigKeyCompleter.matchesSegment("alias.add.debug", "add."), is(true));
+		assertThat(ConfigKeyCompleter.matchesSegment("alias.add.debug", "add.deb"), is(true));
+		assertThat(ConfigKeyCompleter.matchesSegment("catalog.add.format", "add."), is(true));
+		assertThat(ConfigKeyCompleter.matchesSegment("run.debug", "add."), is(false));
+	}
+
+	@Test
+	void testSegmentMatchFallback() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("debu");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		// Should find keys containing a "debug" segment via fallback
+		assertThat("segment match should find debug keys",
+				values.stream().anyMatch(v -> v.contains("debug")), is(true));
+		// Should set ignoreStartsWith for segment matches
+		assertThat(inv.ignoreStartsWith, is(true));
+	}
+
+	@Test
+	void testSegmentMatchWithDotPartial() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		TestCompleterInvocation inv = new TestCompleterInvocation("add.");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		// Should find all keys with an "add" segment
+		assertThat("segment match should find add.* keys",
+				values.stream().anyMatch(v -> v.contains(".add.")), is(true));
+	}
+
+	@Test
+	void testPrefixMatchTakesPriorityOverSegment() {
+		ConfigKeyCompleter completer = new ConfigKeyCompleter();
+		// "cache" prefix-matches "cache-evict" directly
+		TestCompleterInvocation inv = new TestCompleterInvocation("cache");
+		completer.complete(inv);
+
+		List<String> values = stripDescriptions(inv.candidates);
+		assertThat(values, hasItem("cache-evict"));
+		// ignoreStartsWith should NOT be set for prefix matches
+		assertThat(inv.ignoreStartsWith, is(false));
+	}
+
 	private List<String> stripDescriptions(List<String> candidates) {
 		List<String> result = new ArrayList<>();
 		for (String c : candidates) {


### PR DESCRIPTION
## Summary

Adds smart tab-completion for the `key` argument of `jbang config get`, `config set`, and `config unset`. Fixes #2529.

## Completion Features

### Config get / set
Completes from all known config keys (same source as `config list --show-available`) plus any user-defined keys from the merged configuration.

### Config unset
Only completes keys that are actually set in the merged configuration, with the origin file path shown as the description.

### Segment matching
When prefix match finds nothing, falls back to segment matching:
- `debu<TAB>` → `run.debug`, `alias.add.debug`, `app.install.debug`
- `add.<TAB>` → `alias.add.*`, `catalog.add.*`, `template.add.*`

### Top-level keys
Root `jbang` command options are available in both short (`fresh`) and qualified (`jbang.fresh`) forms, alongside config-only keys like `cache-evict` and `connection-timeout`.

### Descriptions
Candidates include tab-separated descriptions displayed by fish and zsh:
```
cache-evict    Time that locally cached files are kept before they are evicted...
fresh          Make sure we use fresh (i.e. non-cached) resources.
run.debug      Launch with java debug enabled...
```

## Fish --keep-order

Fish sorts completion candidates alphabetically by default, ignoring the order returned by `jbang --aesh-complete`. Added `-k` (`--keep-order`) to the generated Fish completion script so Fish preserves the intended order (matching zsh behaviour). Filed upstream: https://github.com/aeshell/aesh/issues/524

## Other changes

- Extracted `AvailableOption` to its own public class
- Extracted `Config.getAvailableOptions()` as shared static method (used by both `config list --show-available` and the completers)
- Added `rootProject.name` to `settings.gradle` for git worktree support

## Tests

- 14 unit tests for the completers (prefix match, segment match, unset-only, single-candidate stripping, descriptions)
- 3 tests for shell completion script generation (fish `-k`, bash/zsh unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tab-completion support for configuration management commands (`config get`, `config set`, `config unset`).
  * Enhanced Fish shell completion script with improved ordering behavior.

* **Tests**
  * Added test coverage for completion functionality across multiple shell types and configuration key completion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->