### PR TITLE
fix: use proper versioned download URL for native

### DIFF
--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -281,11 +281,16 @@ if [[ -z "$binaryPath" ]]; then
 fi
 if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
   if [[ ! -f "$JBDIR/bin/jbang.jar" || ! -f "$JBDIR/bin/jbang" ]]; then
+    if [[ "$JBANG_USE_NATIVE" == "true" ]]; then
+      bundleName="jbang-${os}-${arch}.tar"
+    else
+      bundleName="jbang.tar"
+    fi
     mkdir -p "$TDIR/urls"
     if [ -n "$JBANG_DOWNLOAD_URL" ]; then
       jburl="$JBANG_DOWNLOAD_URL";
     elif [ -z "$JBANG_DOWNLOAD_VERSION" ]; then
-      jburl="${jbangDownloadBaseUrl}/latest/download/jbang.tar";
+      jburl="${jbangDownloadBaseUrl}/latest/download/$bundleName";
     else
       # Numeric versions get a 'v' prefix (e.g. 0.120.0 -> v0.120.0); named
       # release tags (e.g. 'early-access', '1.0.0-rc1') are used as-is.
@@ -293,7 +298,7 @@ if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
         *[!0-9.]*) jbtag="$JBANG_DOWNLOAD_VERSION" ;;
         *)         jbtag="v$JBANG_DOWNLOAD_VERSION" ;;
       esac
-      jburl="${jbangDownloadBaseUrl}/download/$jbtag/jbang.tar";
+      jburl="${jbangDownloadBaseUrl}/download/$jbtag/$bundleName";
     fi
     echo "Downloading JBang ${JBANG_DOWNLOAD_VERSION:-latest} from $jburl..." 1>&2
     download "$jburl" "$TDIR/urls/jbang.tar"


### PR DESCRIPTION
<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced JBang's auto-download mechanism to intelligently select platform-specific distribution bundles based on native mode settings and system architecture, ensuring users receive optimized versions tailored to their operating system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->