### PR TITLE
fix: mark early-access releases as pre-release instead of draft

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -74,6 +74,14 @@ jobs:
           version: ${{ env.JRELEASER_VERSION }}
           arguments: full-release --yolo
           setup-java: false
+      - name: Mark release as pre-release (not draft)
+        if: steps.version.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases/tags/early-access --jq '.id')
+          gh api --method PATCH repos/${{ github.repository }}/releases/$RELEASE_ID \
+            -F draft=false -F prerelease=true
       - name: JReleaser output
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7


### PR DESCRIPTION
Early-access releases were being left as drafts (or regular releases) on GitHub. This adds a `gh api` step after JReleaser to explicitly set `draft=false` and `prerelease=true`, so they show up as proper GitHub pre-releases.