### PR TITLE
test: add native download URL tests and apply JBANG_USE_NATIVE to jbang.ps1

### DIFF
--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -151,11 +151,16 @@ if (-not $binaryPath) {
 }
 if (-not $binaryPath -and -not $jarPath) {
   if (-not (Test-Path "$JBDIR\bin\jbang.jar") -or -not (Test-Path "$JBDIR\bin\jbang.ps1")) {
+    if ($env:JBANG_USE_NATIVE -eq "true") {
+      $bundleName = "jbang-windows-${jbang_arch}.zip"
+    } else {
+      $bundleName = "jbang.zip"
+    }
     New-Item -ItemType Directory -Force -Path "$TDIR\urls" >$null 2>&1
     if (Test-Path env:JBANG_DOWNLOAD_URL) {
         $jburl=$env:JBANG_DOWNLOAD_URL
     } elseif (-not (Test-Path env:JBANG_DOWNLOAD_VERSION)) {
-        $jburl="$jbangDownloadBaseUrl/latest/download/jbang.zip"
+        $jburl="$jbangDownloadBaseUrl/latest/download/$bundleName"
     } else {
         # Numeric versions get a 'v' prefix (e.g. 0.120.0 -> v0.120.0); named
         # release tags (e.g. 'early-access', '1.0.0-rc1') are used as-is.
@@ -164,7 +169,7 @@ if (-not $binaryPath -and -not $jarPath) {
         } else {
             $jbtag = $env:JBANG_DOWNLOAD_VERSION
         }
-        $jburl="$jbangDownloadBaseUrl/download/$jbtag/jbang.zip";
+        $jburl="$jbangDownloadBaseUrl/download/$jbtag/$bundleName";
     }
     $dlVersion = if ($env:JBANG_DOWNLOAD_VERSION) { $env:JBANG_DOWNLOAD_VERSION } else { 'latest' }
     [Console]::Error.WriteLine("Downloading JBang $dlVersion from $jburl...")

--- a/src/test/java/dev/jbang/cli/AbstractScriptTest.java
+++ b/src/test/java/dev/jbang/cli/AbstractScriptTest.java
@@ -1,0 +1,263 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+/**
+ * Shared infrastructure for functional tests of JBang startup scripts. Provides
+ * WireMock lifecycle, process execution helpers, archive creation utilities,
+ * and base environment maps for bash and PowerShell tests.
+ */
+abstract class AbstractScriptTest {
+
+	protected static final Path BASH_SCRIPT = Paths.get("src/main/scripts/jbang").toAbsolutePath();
+	protected static final Path PS1_SCRIPT = Paths.get("src/main/scripts/jbang.ps1").toAbsolutePath();
+
+	protected WireMockServer wm;
+	protected String psCommand;
+
+	@TempDir
+	protected Path tempDir;
+
+	@BeforeEach
+	void startWireMock() {
+		wm = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+		wm.start();
+	}
+
+	@AfterEach
+	void stopWireMock() {
+		if (wm != null) {
+			wm.stop();
+		}
+	}
+
+	/**
+	 * Creates a unique subdirectory path under {@link #tempDir}. The directory is
+	 * not created on disk — startup scripts will create it as needed.
+	 */
+	protected Path tempSubDir(String name) {
+		return tempDir.resolve(name);
+	}
+
+	// -------------------------------------------------------------------------
+	// Command availability checks
+	// -------------------------------------------------------------------------
+
+	protected static boolean isCommandAvailable(String command) {
+		try {
+			Process p = new ProcessBuilder(command, "--version")
+				.redirectErrorStream(true)
+				.start();
+			p.getInputStream().transferTo(new ByteArrayOutputStream());
+			return p.waitFor(5, TimeUnit.SECONDS) && p.exitValue() == 0;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	protected void requireBash() {
+		assumeTrue(isCommandAvailable("bash"), "bash is not available");
+	}
+
+	protected void requirePowerShell() {
+		if (isCommandAvailable("pwsh")) {
+			psCommand = "pwsh";
+		} else if (isCommandAvailable("powershell")) {
+			psCommand = "powershell";
+		} else {
+			assumeTrue(false, "PowerShell is not available (neither pwsh nor powershell found)");
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Process execution
+	// -------------------------------------------------------------------------
+
+	protected static RunResult runProcess(List<String> cmd, Map<String, String> env) throws Exception {
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		pb.environment().putAll(env);
+		pb.redirectErrorStream(false);
+		Process process = pb.start();
+
+		ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+		ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+		Thread t1 = new Thread(() -> {
+			try {
+				process.getInputStream().transferTo(stdout);
+			} catch (Exception e) {
+				/* ignore */ }
+		});
+		Thread t2 = new Thread(() -> {
+			try {
+				process.getErrorStream().transferTo(stderr);
+			} catch (Exception e) {
+				/* ignore */ }
+		});
+		t1.start();
+		t2.start();
+
+		boolean finished = process.waitFor(120, TimeUnit.SECONDS);
+		if (!finished) {
+			process.destroyForcibly();
+		}
+		t1.join(5000);
+		t2.join(5000);
+		assertTrue(finished, "script timed out");
+		return new RunResult(process.exitValue(),
+				stdout.toString(StandardCharsets.UTF_8),
+				stderr.toString(StandardCharsets.UTF_8));
+	}
+
+	static class RunResult {
+		final int exitCode;
+		final String stdout;
+		final String stderr;
+
+		RunResult(int exitCode, String stdout, String stderr) {
+			this.exitCode = exitCode;
+			this.stdout = stdout;
+			this.stderr = stderr;
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Archive creation
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Creates a minimal jbang.tar containing jbang/bin/jbang (a dummy script that
+	 * just exits 0) and an empty jbang/bin/jbang.jar.
+	 */
+	protected byte[] createJbangTar() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (TarArchiveOutputStream tar = new TarArchiveOutputStream(baos)) {
+			byte[] script = "#!/bin/bash\nexit 0\n".getBytes(StandardCharsets.UTF_8);
+			TarArchiveEntry entry = new TarArchiveEntry("jbang/bin/jbang");
+			entry.setSize(script.length);
+			entry.setMode(0755);
+			tar.putArchiveEntry(entry);
+			tar.write(script);
+			tar.closeArchiveEntry();
+
+			TarArchiveEntry jarEntry = new TarArchiveEntry("jbang/bin/jbang.jar");
+			jarEntry.setSize(0);
+			tar.putArchiveEntry(jarEntry);
+			tar.closeArchiveEntry();
+		}
+		return baos.toByteArray();
+	}
+
+	/**
+	 * Creates a minimal jbang.zip containing jbang/bin/jbang.ps1 (a dummy script
+	 * that just exits 0), an empty jbang/bin/jbang.jar, and jbang/bin/jbang.cmd.
+	 */
+	protected byte[] createJbangZip() throws Exception {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try (ZipOutputStream zip = new ZipOutputStream(baos)) {
+			zip.putNextEntry(new ZipEntry("jbang/bin/jbang.ps1"));
+			zip.write("exit 0\n".getBytes(StandardCharsets.UTF_8));
+			zip.closeEntry();
+
+			zip.putNextEntry(new ZipEntry("jbang/bin/jbang.jar"));
+			zip.closeEntry();
+
+			zip.putNextEntry(new ZipEntry("jbang/bin/jbang.cmd"));
+			zip.write("@exit /b 0\r\n".getBytes(StandardCharsets.UTF_8));
+			zip.closeEntry();
+		}
+		return baos.toByteArray();
+	}
+
+	// -------------------------------------------------------------------------
+	// Base environment maps
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns a base environment map for bash tests with JBANG_DIR,
+	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. JAVA_HOME is removed.
+	 * Subclasses should add their specific env vars on top.
+	 */
+	protected Map<String, String> baseBashEnv(String suffix) {
+		Path jbdir = tempSubDir("jbdir-" + suffix);
+		Path tdir = tempSubDir("cache-" + suffix);
+		Map<String, String> env = new HashMap<>(System.getenv());
+		env.put("JBANG_DIR", jbdir.toString());
+		env.put("JBANG_CACHE_DIR", tdir.toString());
+		env.put("JBANG_NO_VERSION_CHECK", "true");
+		env.remove("JAVA_HOME");
+		return env;
+	}
+
+	/**
+	 * Returns a base environment map for PowerShell tests with JBANG_DIR,
+	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. JAVA_HOME is removed.
+	 * Subclasses should add their specific env vars on top.
+	 */
+	protected Map<String, String> basePsEnv(String suffix) {
+		Path jbdir = tempSubDir("jbdir-" + suffix);
+		Path tdir = tempSubDir("cache-" + suffix);
+		Map<String, String> env = new HashMap<>(System.getenv());
+		env.put("JBANG_DIR", jbdir.toString());
+		env.put("JBANG_CACHE_DIR", tdir.toString());
+		env.put("JBANG_NO_VERSION_CHECK", "true");
+		env.remove("JAVA_HOME");
+		return env;
+	}
+
+	// -------------------------------------------------------------------------
+	// Command builders
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Builds a command list for running the bash startup script.
+	 */
+	protected List<String> bashCmd(String... args) {
+		List<String> cmd = new ArrayList<>();
+		cmd.add("bash");
+		cmd.add(BASH_SCRIPT.toString());
+		for (String arg : args) {
+			cmd.add(arg);
+		}
+		return cmd;
+	}
+
+	/**
+	 * Builds a command list for running the PowerShell startup script. Requires
+	 * {@link #requirePowerShell()} to have been called first.
+	 */
+	protected List<String> psCmd(String... args) {
+		List<String> cmd = new ArrayList<>();
+		cmd.add(psCommand);
+		cmd.add("-NoProfile");
+		cmd.add("-ExecutionPolicy");
+		cmd.add("Bypass");
+		cmd.add("-File");
+		cmd.add(PS1_SCRIPT.toString());
+		for (String arg : args) {
+			cmd.add(arg);
+		}
+		return cmd;
+	}
+}

--- a/src/test/java/dev/jbang/cli/TestScriptDownloadVersion.java
+++ b/src/test/java/dev/jbang/cli/TestScriptDownloadVersion.java
@@ -1,31 +1,14 @@
 package dev.jbang.cli;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 /**
  * Functional tests verifying how JBANG_DOWNLOAD_VERSION is translated into a
@@ -37,86 +20,24 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
  * {@code https://github.com/jbangdev/jbang/releases/download/early-access/}
  * usable via the existing {@code JBANG_DOWNLOAD_*} variables.
  */
-class TestScriptDownloadVersion {
+class TestScriptDownloadVersion extends AbstractScriptTest {
 
-	private static final Path BASH_SCRIPT = Paths.get("src/main/scripts/jbang").toAbsolutePath();
-	private static final Path PS1_SCRIPT = Paths.get("src/main/scripts/jbang.ps1").toAbsolutePath();
-
-	private WireMockServer wm;
-
-	@TempDir
-	Path tempDir;
-
-	@BeforeEach
-	void startWireMock() {
-		wm = new WireMockServer(WireMockConfiguration.options().dynamicPort());
-		wm.start();
+	private Map<String, String> bashEnv(String version) {
+		Map<String, String> env = baseBashEnv(version);
+		env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
+		env.put("JBANG_DOWNLOAD_VERSION", version);
+		env.put("JBANG_DOWNLOAD_RETRY", "0");
+		env.remove("JBANG_DOWNLOAD_URL");
+		return env;
 	}
 
-	@AfterEach
-	void stopWireMock() {
-		if (wm != null) {
-			wm.stop();
-		}
-	}
-
-	private static boolean isCommandAvailable(String command) {
-		try {
-			Process p = new ProcessBuilder(command, "--version")
-				.redirectErrorStream(true)
-				.start();
-			p.getInputStream().transferTo(new ByteArrayOutputStream());
-			return p.waitFor(5, TimeUnit.SECONDS) && p.exitValue() == 0;
-		} catch (Exception e) {
-			return false;
-		}
-	}
-
-	private static RunResult runProcess(List<String> cmd, Map<String, String> env) throws Exception {
-		ProcessBuilder pb = new ProcessBuilder(cmd);
-		pb.environment().putAll(env);
-		pb.redirectErrorStream(false);
-		Process process = pb.start();
-
-		ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-		ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-		Thread t1 = new Thread(() -> {
-			try {
-				process.getInputStream().transferTo(stdout);
-			} catch (Exception e) {
-				/* ignore */ }
-		});
-		Thread t2 = new Thread(() -> {
-			try {
-				process.getErrorStream().transferTo(stderr);
-			} catch (Exception e) {
-				/* ignore */ }
-		});
-		t1.start();
-		t2.start();
-
-		boolean finished = process.waitFor(120, TimeUnit.SECONDS);
-		if (!finished) {
-			process.destroyForcibly();
-		}
-		t1.join(5000);
-		t2.join(5000);
-		assertTrue(finished, "script timed out");
-		return new RunResult(process.exitValue(),
-				stdout.toString(StandardCharsets.UTF_8),
-				stderr.toString(StandardCharsets.UTF_8));
-	}
-
-	static class RunResult {
-		final int exitCode;
-		final String stdout;
-		final String stderr;
-
-		RunResult(int exitCode, String stdout, String stderr) {
-			this.exitCode = exitCode;
-			this.stdout = stdout;
-			this.stderr = stderr;
-		}
+	private Map<String, String> psEnv(String version) {
+		Map<String, String> env = basePsEnv(version);
+		env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
+		env.put("JBANG_DOWNLOAD_VERSION", version);
+		env.put("JBANG_DOWNLOAD_RETRY", "0");
+		env.remove("JBANG_DOWNLOAD_URL");
+		return env;
 	}
 
 	// -------------------------------------------------------------------------
@@ -126,43 +47,9 @@ class TestScriptDownloadVersion {
 	@Nested
 	class Bash {
 
-		private byte[] createJbangTar() throws Exception {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			try (TarArchiveOutputStream tar = new TarArchiveOutputStream(baos)) {
-				byte[] script = "#!/bin/bash\nexit 0\n".getBytes(StandardCharsets.UTF_8);
-				TarArchiveEntry entry = new TarArchiveEntry("jbang/bin/jbang");
-				entry.setSize(script.length);
-				entry.setMode(0755);
-				tar.putArchiveEntry(entry);
-				tar.write(script);
-				tar.closeArchiveEntry();
-
-				TarArchiveEntry jarEntry = new TarArchiveEntry("jbang/bin/jbang.jar");
-				jarEntry.setSize(0);
-				tar.putArchiveEntry(jarEntry);
-				tar.closeArchiveEntry();
-			}
-			return baos.toByteArray();
-		}
-
-		private Map<String, String> bashEnv(String version) {
-			Path jbdir = tempDir.resolve("jbdir-" + version);
-			Path tdir = tempDir.resolve("cache-" + version);
-			Map<String, String> env = new HashMap<>(System.getenv());
-			env.put("JBANG_DIR", jbdir.toString());
-			env.put("JBANG_CACHE_DIR", tdir.toString());
-			env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
-			env.put("JBANG_DOWNLOAD_VERSION", version);
-			env.put("JBANG_DOWNLOAD_RETRY", "0");
-			env.put("JBANG_NO_VERSION_CHECK", "true");
-			env.remove("JAVA_HOME");
-			env.remove("JBANG_DOWNLOAD_URL");
-			return env;
-		}
-
 		@BeforeEach
-		void requireBash() {
-			assumeTrue(isCommandAvailable("bash"), "bash is not available");
+		void checkBash() {
+			requireBash();
 		}
 
 		@Test
@@ -171,12 +58,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/v0.120.0/jbang.tar"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv("0.120.0"));
+			RunResult result = runProcess(bashCmd("version"), bashEnv("0.120.0"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/v0.120.0/jbang.tar")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -189,12 +71,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/early-access/jbang.tar"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv("early-access"));
+			RunResult result = runProcess(bashCmd("version"), bashEnv("early-access"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/early-access/jbang.tar")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -207,12 +84,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/1.0.0-rc1/jbang.tar"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv("1.0.0-rc1"));
+			RunResult result = runProcess(bashCmd("version"), bashEnv("1.0.0-rc1"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/1.0.0-rc1/jbang.tar")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -227,49 +99,9 @@ class TestScriptDownloadVersion {
 	@Nested
 	class PowerShell {
 
-		private String psCommand;
-
-		private byte[] createJbangZip() throws Exception {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			try (ZipOutputStream zip = new ZipOutputStream(baos)) {
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.ps1"));
-				zip.write("exit 0\n".getBytes(StandardCharsets.UTF_8));
-				zip.closeEntry();
-
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.jar"));
-				zip.closeEntry();
-
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.cmd"));
-				zip.write("@exit /b 0\r\n".getBytes(StandardCharsets.UTF_8));
-				zip.closeEntry();
-			}
-			return baos.toByteArray();
-		}
-
-		private Map<String, String> psEnv(String version) {
-			Path jbdir = tempDir.resolve("jbdir-" + version);
-			Path tdir = tempDir.resolve("cache-" + version);
-			Map<String, String> env = new HashMap<>(System.getenv());
-			env.put("JBANG_DIR", jbdir.toString());
-			env.put("JBANG_CACHE_DIR", tdir.toString());
-			env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
-			env.put("JBANG_DOWNLOAD_VERSION", version);
-			env.put("JBANG_DOWNLOAD_RETRY", "0");
-			env.put("JBANG_NO_VERSION_CHECK", "true");
-			env.remove("JAVA_HOME");
-			env.remove("JBANG_DOWNLOAD_URL");
-			return env;
-		}
-
 		@BeforeEach
-		void requirePowerShell() {
-			if (isCommandAvailable("pwsh")) {
-				psCommand = "pwsh";
-			} else if (isCommandAvailable("powershell")) {
-				psCommand = "powershell";
-			} else {
-				assumeTrue(false, "PowerShell is not available (neither pwsh nor powershell found)");
-			}
+		void checkPowerShell() {
+			requirePowerShell();
 		}
 
 		@Test
@@ -278,16 +110,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/v0.120.0/jbang.zip"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv("0.120.0"));
+			RunResult result = runProcess(psCmd("version"), psEnv("0.120.0"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/v0.120.0/jbang.zip")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -300,16 +123,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/early-access/jbang.zip"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv("early-access"));
+			RunResult result = runProcess(psCmd("version"), psEnv("early-access"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/early-access/jbang.zip")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -322,16 +136,7 @@ class TestScriptDownloadVersion {
 			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/1.0.0-rc1/jbang.zip"))
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv("1.0.0-rc1"));
+			RunResult result = runProcess(psCmd("version"), psEnv("1.0.0-rc1"));
 
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/1.0.0-rc1/jbang.zip")));
 			assertTrue(!result.stderr.contains("Error downloading JBang"),

--- a/src/test/java/dev/jbang/cli/TestScriptNativeDownload.java
+++ b/src/test/java/dev/jbang/cli/TestScriptNativeDownload.java
@@ -1,0 +1,297 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+/**
+ * Functional tests verifying that JBANG_USE_NATIVE=true causes the startup
+ * script to download a platform-specific bundle (e.g. jbang-linux-x64.tar)
+ * instead of the generic jbang.tar.
+ *
+ * See https://github.com/jbangdev/jbang/pull/2534
+ */
+class TestScriptNativeDownload extends AbstractScriptTest {
+
+	/**
+	 * Returns the OS identifier used by the jbang bash script for the current
+	 * platform.
+	 */
+	private static String detectOs() {
+		String uname = System.getProperty("os.name", "").toLowerCase();
+		if (uname.contains("linux")) {
+			return "linux";
+		} else if (uname.contains("mac") || uname.contains("darwin")) {
+			return "mac";
+		} else if (uname.contains("win")) {
+			return "windows";
+		}
+		return "unknown";
+	}
+
+	/**
+	 * Returns the arch identifier used by the jbang bash script for the current
+	 * platform.
+	 */
+	private static String detectArch() {
+		String arch = System.getProperty("os.arch", "").toLowerCase();
+		if (arch.equals("aarch64") || arch.equals("arm64")) {
+			return "aarch64";
+		} else if (arch.equals("amd64") || arch.equals("x86_64")) {
+			return "x64";
+		}
+		return arch;
+	}
+
+	private Map<String, String> bashEnv(boolean useNative) {
+		Map<String, String> env = baseBashEnv("native-" + useNative);
+		env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
+		env.put("JBANG_DOWNLOAD_RETRY", "0");
+		env.put("JBANG_USE_NATIVE", useNative ? "true" : "false");
+		env.remove("JBANG_DOWNLOAD_URL");
+		env.remove("JBANG_DOWNLOAD_VERSION");
+		return env;
+	}
+
+	private Map<String, String> bashEnvWithVersion(boolean useNative, String version) {
+		Map<String, String> env = bashEnv(useNative);
+		env.put("JBANG_DIR", tempSubDir("jbdir-native-" + useNative + "-" + version).toString());
+		env.put("JBANG_CACHE_DIR", tempSubDir("cache-native-" + useNative + "-" + version).toString());
+		env.put("JBANG_DOWNLOAD_VERSION", version);
+		return env;
+	}
+
+	private Map<String, String> psEnv(boolean useNative) {
+		Map<String, String> env = basePsEnv("ps-native-" + useNative);
+		env.put("JBANG_DOWNLOAD_BASEURL", wm.baseUrl());
+		env.put("JBANG_DOWNLOAD_RETRY", "0");
+		env.put("JBANG_USE_NATIVE", useNative ? "true" : "false");
+		env.remove("JBANG_DOWNLOAD_URL");
+		env.remove("JBANG_DOWNLOAD_VERSION");
+		return env;
+	}
+
+	private Map<String, String> psEnvWithVersion(boolean useNative, String version) {
+		Map<String, String> env = psEnv(useNative);
+		env.put("JBANG_DIR", tempSubDir("jbdir-ps-native-" + useNative + "-" + version).toString());
+		env.put("JBANG_CACHE_DIR", tempSubDir("cache-ps-native-" + useNative + "-" + version).toString());
+		env.put("JBANG_DOWNLOAD_VERSION", version);
+		return env;
+	}
+
+	// -------------------------------------------------------------------------
+	// Bash tests
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Bash {
+
+		@BeforeEach
+		void checkBash() {
+			requireBash();
+		}
+
+		@Test
+		void latestDownloadUsesGenericBundleByDefault() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/latest/download/jbang.tar"))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			RunResult result = runProcess(bashCmd("version"), bashEnv(false));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/latest/download/jbang.tar")));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void latestDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String os = detectOs();
+			String arch = detectArch();
+			String expectedPath = "/latest/download/jbang-" + os + "-" + arch + ".tar";
+
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			RunResult result = runProcess(bashCmd("version"), bashEnv(true));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void versionedDownloadUsesGenericBundleByDefault() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/download/v0.120.0/jbang.tar"))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			RunResult result = runProcess(bashCmd("version"), bashEnvWithVersion(false, "0.120.0"));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/download/v0.120.0/jbang.tar")));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void versionedDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String os = detectOs();
+			String arch = detectArch();
+			String expectedPath = "/download/v0.120.0/jbang-" + os + "-" + arch + ".tar";
+
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			RunResult result = runProcess(bashCmd("version"), bashEnvWithVersion(true, "0.120.0"));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void namedTagDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String os = detectOs();
+			String arch = detectArch();
+			String expectedPath = "/download/early-access/jbang-" + os + "-" + arch + ".tar";
+
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			RunResult result = runProcess(bashCmd("version"), bashEnvWithVersion(true, "early-access"));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void downloadUrlOverrideIgnoresNativeFlag() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/custom/my-jbang.tar"))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			Map<String, String> env = bashEnv(true);
+			env.put("JBANG_DOWNLOAD_URL", wm.url("/custom/my-jbang.tar"));
+
+			RunResult result = runProcess(bashCmd("version"), env);
+
+			// When JBANG_DOWNLOAD_URL is set explicitly, it should be used as-is
+			// regardless of JBANG_USE_NATIVE
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/custom/my-jbang.tar")));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// PowerShell tests
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class PowerShellNativeDownload {
+
+		@BeforeEach
+		void checkPowerShell() {
+			requirePowerShell();
+		}
+
+		/**
+		 * Returns the arch identifier used by the jbang.ps1 script. The PS1 script uses
+		 * RuntimeInformation to detect Arm64 vs x64.
+		 */
+		private String psArch() {
+			String arch = System.getProperty("os.arch", "").toLowerCase();
+			if (arch.equals("aarch64") || arch.equals("arm64")) {
+				return "aarch64";
+			}
+			return "x64";
+		}
+
+		@Test
+		void latestDownloadUsesGenericBundleByDefault() throws Exception {
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/latest/download/jbang.zip"))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			RunResult result = runProcess(psCmd("version"), psEnv(false));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/latest/download/jbang.zip")));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void latestDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String arch = psArch();
+			String expectedPath = "/latest/download/jbang-windows-" + arch + ".zip";
+
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			RunResult result = runProcess(psCmd("version"), psEnv(true));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void versionedDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String arch = psArch();
+			String expectedPath = "/download/v0.120.0/jbang-windows-" + arch + ".zip";
+
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			RunResult result = runProcess(psCmd("version"), psEnvWithVersion(true, "0.120.0"));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void namedTagDownloadUsesPlatformBundleWhenNativeEnabled() throws Exception {
+			String arch = psArch();
+			String expectedPath = "/download/early-access/jbang-windows-" + arch + ".zip";
+
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo(expectedPath))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			RunResult result = runProcess(psCmd("version"), psEnvWithVersion(true, "early-access"));
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo(expectedPath)));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+
+		@Test
+		void downloadUrlOverrideIgnoresNativeFlag() throws Exception {
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get(WireMock.urlEqualTo("/custom/my-jbang.zip"))
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			Map<String, String> env = psEnv(true);
+			env.put("JBANG_DOWNLOAD_URL", wm.url("/custom/my-jbang.zip"));
+
+			RunResult result = runProcess(psCmd("version"), env);
+
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/custom/my-jbang.zip")));
+			assertTrue(!result.stderr.contains("Error downloading JBang"),
+					"download should have succeeded, stderr: " + result.stderr);
+		}
+	}
+}

--- a/src/test/java/dev/jbang/cli/TestScriptRetry.java
+++ b/src/test/java/dev/jbang/cli/TestScriptRetry.java
@@ -2,31 +2,14 @@ package dev.jbang.cli;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
 
 /**
@@ -37,28 +20,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario;
  *
  * See https://github.com/jbangdev/jbang/issues/2459
  */
-class TestScriptRetry {
-
-	private static final Path BASH_SCRIPT = Paths.get("src/main/scripts/jbang").toAbsolutePath();
-	private static final Path PS1_SCRIPT = Paths.get("src/main/scripts/jbang.ps1").toAbsolutePath();
-
-	private WireMockServer wm;
-
-	@TempDir
-	Path tempDir;
-
-	@BeforeEach
-	void startWireMock() {
-		wm = new WireMockServer(WireMockConfiguration.options().dynamicPort());
-		wm.start();
-	}
-
-	@AfterEach
-	void stopWireMock() {
-		if (wm != null) {
-			wm.stop();
-		}
-	}
+class TestScriptRetry extends AbstractScriptTest {
 
 	/**
 	 * Configures WireMock to fail {@code failCount} times with a 500 error, then
@@ -82,63 +44,20 @@ class TestScriptRetry {
 			.willReturn(WireMock.aResponse().withStatus(200).withBody(body)));
 	}
 
-	private static boolean isCommandAvailable(String command) {
-		try {
-			Process p = new ProcessBuilder(command, "--version")
-				.redirectErrorStream(true)
-				.start();
-			p.getInputStream().transferTo(new ByteArrayOutputStream());
-			return p.waitFor(5, TimeUnit.SECONDS) && p.exitValue() == 0;
-		} catch (Exception e) {
-			return false;
-		}
+	private Map<String, String> bashEnv(int retryCount) {
+		Map<String, String> env = baseBashEnv("retry-" + retryCount);
+		env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.tar"));
+		env.put("JBANG_DOWNLOAD_RETRY", String.valueOf(retryCount));
+		env.put("JBANG_DOWNLOAD_RETRY_DELAY", "0");
+		return env;
 	}
 
-	private static RunResult runProcess(List<String> cmd, Map<String, String> env) throws Exception {
-		ProcessBuilder pb = new ProcessBuilder(cmd);
-		pb.environment().putAll(env);
-		pb.redirectErrorStream(false);
-		Process process = pb.start();
-
-		ByteArrayOutputStream stdout = new ByteArrayOutputStream();
-		ByteArrayOutputStream stderr = new ByteArrayOutputStream();
-		Thread t1 = new Thread(() -> {
-			try {
-				process.getInputStream().transferTo(stdout);
-			} catch (Exception e) {
-				/* ignore */ }
-		});
-		Thread t2 = new Thread(() -> {
-			try {
-				process.getErrorStream().transferTo(stderr);
-			} catch (Exception e) {
-				/* ignore */ }
-		});
-		t1.start();
-		t2.start();
-
-		boolean finished = process.waitFor(120, TimeUnit.SECONDS);
-		if (!finished) {
-			process.destroyForcibly();
-		}
-		t1.join(5000);
-		t2.join(5000);
-		assertTrue(finished, "script timed out");
-		return new RunResult(process.exitValue(),
-				stdout.toString(StandardCharsets.UTF_8),
-				stderr.toString(StandardCharsets.UTF_8));
-	}
-
-	static class RunResult {
-		final int exitCode;
-		final String stdout;
-		final String stderr;
-
-		RunResult(int exitCode, String stdout, String stderr) {
-			this.exitCode = exitCode;
-			this.stdout = stdout;
-			this.stderr = stderr;
-		}
+	private Map<String, String> psEnv(int retryCount) {
+		Map<String, String> env = basePsEnv("retry-" + retryCount);
+		env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.zip"));
+		env.put("JBANG_DOWNLOAD_RETRY", String.valueOf(retryCount));
+		env.put("JBANG_DOWNLOAD_RETRY_DELAY", "0");
+		return env;
 	}
 
 	// -------------------------------------------------------------------------
@@ -149,51 +68,9 @@ class TestScriptRetry {
 	@Nested
 	class BashDownloadRetry {
 
-		/**
-		 * Creates a minimal jbang.tar containing jbang/bin/jbang (a dummy script that
-		 * just exits 0) so the real jbang script can download, extract, and "run" it
-		 * successfully.
-		 */
-		private byte[] createJbangTar() throws Exception {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			try (TarArchiveOutputStream tar = new TarArchiveOutputStream(baos)) {
-				byte[] script = "#!/bin/bash\nexit 0\n".getBytes(StandardCharsets.UTF_8);
-				TarArchiveEntry entry = new TarArchiveEntry("jbang/bin/jbang");
-				entry.setSize(script.length);
-				entry.setMode(0755);
-				tar.putArchiveEntry(entry);
-				tar.write(script);
-				tar.closeArchiveEntry();
-
-				// dummy jbang.jar (the script checks for its existence)
-				byte[] jar = new byte[0];
-				TarArchiveEntry jarEntry = new TarArchiveEntry("jbang/bin/jbang.jar");
-				jarEntry.setSize(jar.length);
-				tar.putArchiveEntry(jarEntry);
-				tar.write(jar);
-				tar.closeArchiveEntry();
-			}
-			return baos.toByteArray();
-		}
-
-		private Map<String, String> bashEnv(int retryCount) {
-			Path jbdir = tempDir.resolve("jbdir");
-			Path tdir = tempDir.resolve("cache");
-			Map<String, String> env = new HashMap<>(System.getenv());
-			env.put("JBANG_DIR", jbdir.toString());
-			env.put("JBANG_CACHE_DIR", tdir.toString());
-			env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.tar"));
-			env.put("JBANG_DOWNLOAD_RETRY", String.valueOf(retryCount));
-			env.put("JBANG_DOWNLOAD_RETRY_DELAY", "0");
-			env.put("JBANG_NO_VERSION_CHECK", "true");
-			// Remove JAVA_HOME to avoid interference
-			env.remove("JAVA_HOME");
-			return env;
-		}
-
 		@BeforeEach
-		void requireBash() {
-			assumeTrue(isCommandAvailable("bash"), "bash is not available");
+		void checkBash() {
+			requireBash();
 		}
 
 		@Test
@@ -201,12 +78,7 @@ class TestScriptRetry {
 			byte[] tar = createJbangTar();
 			stubFlakyEndpoint("/jbang.tar", 3, tar);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv(5));
+			RunResult result = runProcess(bashCmd("version"), bashEnv(5));
 
 			// Download should have succeeded (no download error in stderr)
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
@@ -218,12 +90,7 @@ class TestScriptRetry {
 			byte[] tar = createJbangTar();
 			stubFlakyEndpoint("/jbang.tar", 10, tar);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv(2));
+			RunResult result = runProcess(bashCmd("version"), bashEnv(2));
 
 			assertNotEquals(0, result.exitCode, "script should have failed");
 			assertTrue(result.stderr.contains("Error downloading JBang"),
@@ -235,12 +102,7 @@ class TestScriptRetry {
 			byte[] tar = createJbangTar();
 			stubFlakyEndpoint("/jbang.tar", 1, tar);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add("bash");
-			cmd.add(BASH_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, bashEnv(0));
+			RunResult result = runProcess(bashCmd("version"), bashEnv(0));
 
 			assertNotEquals(0, result.exitCode, "script should have failed");
 			assertTrue(result.stderr.contains("Error downloading JBang"),
@@ -256,53 +118,9 @@ class TestScriptRetry {
 	@Nested
 	class PowerShellDownloadRetry {
 
-		private String psCommand;
-
-		/**
-		 * Creates a minimal jbang.zip containing jbang/bin/jbang.ps1 (a dummy script
-		 * that just exits 0) so the real jbang.ps1 script can download, extract, and
-		 * "run" it successfully.
-		 */
-		private byte[] createJbangZip() throws Exception {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			try (ZipOutputStream zip = new ZipOutputStream(baos)) {
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.ps1"));
-				zip.write("exit 0\n".getBytes(StandardCharsets.UTF_8));
-				zip.closeEntry();
-
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.jar"));
-				zip.closeEntry();
-
-				zip.putNextEntry(new ZipEntry("jbang/bin/jbang.cmd"));
-				zip.write("@exit /b 0\r\n".getBytes(StandardCharsets.UTF_8));
-				zip.closeEntry();
-			}
-			return baos.toByteArray();
-		}
-
-		private Map<String, String> psEnv(int retryCount) {
-			Path jbdir = tempDir.resolve("jbdir");
-			Path tdir = tempDir.resolve("cache");
-			Map<String, String> env = new HashMap<>(System.getenv());
-			env.put("JBANG_DIR", jbdir.toString());
-			env.put("JBANG_CACHE_DIR", tdir.toString());
-			env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.zip"));
-			env.put("JBANG_DOWNLOAD_RETRY", String.valueOf(retryCount));
-			env.put("JBANG_DOWNLOAD_RETRY_DELAY", "0");
-			env.put("JBANG_NO_VERSION_CHECK", "true");
-			env.remove("JAVA_HOME");
-			return env;
-		}
-
 		@BeforeEach
-		void requirePowerShell() {
-			if (isCommandAvailable("pwsh")) {
-				psCommand = "pwsh";
-			} else if (isCommandAvailable("powershell")) {
-				psCommand = "powershell";
-			} else {
-				assumeTrue(false, "PowerShell is not available (neither pwsh nor powershell found)");
-			}
+		void checkPowerShell() {
+			requirePowerShell();
 		}
 
 		@Test
@@ -310,16 +128,7 @@ class TestScriptRetry {
 			byte[] zip = createJbangZip();
 			stubFlakyEndpoint("/jbang.zip", 3, zip);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv(5));
+			RunResult result = runProcess(psCmd("version"), psEnv(5));
 
 			assertTrue(!result.stderr.contains("Error downloading JBang"),
 					"download should have succeeded after retries, stderr: " + result.stderr);
@@ -330,16 +139,7 @@ class TestScriptRetry {
 			byte[] zip = createJbangZip();
 			stubFlakyEndpoint("/jbang.zip", 10, zip);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv(2));
+			RunResult result = runProcess(psCmd("version"), psEnv(2));
 
 			assertNotEquals(0, result.exitCode, "script should have failed");
 			assertTrue(result.stderr.contains("Error downloading JBang"),
@@ -351,16 +151,7 @@ class TestScriptRetry {
 			byte[] zip = createJbangZip();
 			stubFlakyEndpoint("/jbang.zip", 1, zip);
 
-			List<String> cmd = new ArrayList<>();
-			cmd.add(psCommand);
-			cmd.add("-NoProfile");
-			cmd.add("-ExecutionPolicy");
-			cmd.add("Bypass");
-			cmd.add("-File");
-			cmd.add(PS1_SCRIPT.toString());
-			cmd.add("version");
-
-			RunResult result = runProcess(cmd, psEnv(0));
+			RunResult result = runProcess(psCmd("version"), psEnv(0));
 
 			assertNotEquals(0, result.exitCode, "script should have failed");
 			assertTrue(result.stderr.contains("Error downloading JBang"),


### PR DESCRIPTION
Follow-up to #2534.

## What changed

- **`jbang.ps1`**: Apply the same `JBANG_USE_NATIVE` bundle name logic from #2534 — when `JBANG_USE_NATIVE=true`, download `jbang-windows-{arch}.zip` instead of `jbang.zip`
- **`TestScriptNativeDownload`** (new): Verifies the download URL for both bash and PowerShell scripts with `JBANG_USE_NATIVE` enabled/disabled, across latest, versioned, and named-tag downloads, plus `JBANG_DOWNLOAD_URL` override
- **`AbstractScriptTest`** (new): Extracts shared test infrastructure (WireMock lifecycle, archive builders, env helpers, process runner) from the three script test classes to reduce duplication
- **`TestScriptRetry` / `TestScriptDownloadVersion`**: Refactored to extend `AbstractScriptTest`

All 23 tests pass.