### PR TITLE
fix: update GraalVM native image metadata

### DIFF
--- a/src/native-image/config/reachability-metadata.json
+++ b/src/native-image/config/reachability-metadata.json
@@ -446,6 +446,7 @@
     {
       "type": "dev.jbang.devkitman.jdkinstallers.FoojayJdkInstaller$JdkResult",
       "fields": [
+        { "name": "distribution" },
         { "name": "java_version" },
         { "name": "javafx_bundled" },
         { "name": "links" },


### PR DESCRIPTION
Without tests for now because getting the tests to work is much harder than fixing the actual issue.