### PR TITLE
fix: close shell configuration file stream

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -516,9 +516,7 @@ public class App extends BaseCommand {
 		private static boolean changeBashOrZshRcScript(Path binDir, Path javaHome, Path rcFile) {
 			try {
 				// Detect if JBang has already been set up before
-				boolean jbangFound = Files.exists(rcFile)
-						&& Files.lines(rcFile)
-							.anyMatch(ln -> ln.trim().startsWith("#") && ln.toLowerCase().contains("jbang"));
+				boolean jbangFound = hasJBangSetup(rcFile);
 				if (!jbangFound) {
 					// Add lines to add JBang to PATH
 					String lines = "\n# Add JBang to environment\n" +
@@ -540,6 +538,15 @@ public class App extends BaseCommand {
 				Util.verboseMsg("Couldn't change script: " + rcFile, e);
 			}
 			return false;
+		}
+
+		static boolean hasJBangSetup(Path rcFile) throws IOException {
+			if (!Files.exists(rcFile)) {
+				return false;
+			}
+			try (Stream<String> lines = Files.lines(rcFile)) {
+				return lines.anyMatch(ln -> ln.trim().startsWith("#") && ln.toLowerCase().contains("jbang"));
+			}
 		}
 
 		private static Path getHome() {

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import dev.jbang.BaseTest;
 import dev.jbang.Settings;
@@ -45,6 +46,18 @@ public class TestApp extends BaseTest {
 			"jbang run com.h2database:h2:1.4.200 %*");
 	private static final List<String> h2ps1Contents = Collections.singletonList(
 			"jbang run com.h2database:h2:1.4.200 @args");
+
+	@Test
+	void testHasJBangSetup(@TempDir Path tempDir) throws IOException {
+		Path rcFile = tempDir.resolve(".bashrc");
+		assertThat(App.AppSetup.hasJBangSetup(rcFile), is(false));
+
+		Files.write(rcFile, Collections.singletonList("export PATH=/usr/bin"));
+		assertThat(App.AppSetup.hasJBangSetup(rcFile), is(false));
+
+		Files.write(rcFile, Collections.singletonList("# Add JBang to environment"));
+		assertThat(App.AppSetup.hasJBangSetup(rcFile), is(true));
+	}
 
 	@Test
 	void testAppInstallFile() throws Exception {


### PR DESCRIPTION
  ## Summary

  Closed the stream returned by `Files.lines()` when checking shell configuration files for an existing JBang setup.

  The detection logic is extracted into `hasJBangSetup()`, which uses try-with-resources to ensure the underlying file resource is released. This is similar to the resource issue
  addressed in #2482, but occurs independently in `App.AppSetup`.

  ## Changes
  - Added tests for missing, matching, and non-matching configuration files

  ## Testing
  - `./gradlew test --tests "dev.jbang.cli.TestApp"`
  - `./gradlew test`
  - `./gradlew spotlessCheck`
 - ` ./gradlew build`
  All tests pass.