### PR TITLE
fix: register all Maven model classes for native image reflection

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -39,6 +39,14 @@ shell sh="zsh":
     {{preitest}}
     @"{{justfile_directory()}}/misc/dev-shell.sh" "{{sh}}" "{{justfile_directory()}}/build/install/jbang/bin"
 
+# build native image and install
+build-native *args:
+    ./gradlew spotlessApply nativeImage installDist -x test {{args}}
+
+# run using native image
+jbang-native *args:
+    JBANG_USE_NATIVE=true PATH="build/install/jbang/bin:$PATH" jbang {{args}}
+
 jbangdebug *args:
     JBANG_JAVA_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=1044 PATH="build/install/jbang/bin:$PATH" jbang {{args}}
 

--- a/build.gradle
+++ b/build.gradle
@@ -318,6 +318,10 @@ def commonSpec = project.copySpec {
 	}
 }
 
+tasks.named('installDist') {
+	mustRunAfter('nativeImage')
+}
+
 distributions {
 	main {
 		contents {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "graalvm-community-25"

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,3 +25,5 @@ develocity {
 		publishing.onlyIf { false }
 	}
 }
+
+rootProject.name = 'jbang'

--- a/src/native-image/config/reachability-metadata.json
+++ b/src/native-image/config/reachability-metadata.json
@@ -10,7 +10,14 @@
     },
     { "type": "java.lang.Cloneable" },
     { "type": "java.io.Serializable" },
+    { "type": "java.io.File" },
     { "type": "java.lang.Object" },
+    {
+      "type": "java.lang.String",
+      "allPublicMethods": true
+    },
+    { "type": "java.util.List" },
+    { "type": "java.util.Properties" },
     {
       "type": "java.lang.Class",
       "methods": [
@@ -505,11 +512,87 @@
     { "type": "org.apache.logging.log4j.Logger" },
     { "type": "org.jboss.logmanager.LogManager" },
     {
+      "type": "org.apache.maven.model.Activation",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.InputLocation",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ActivationFile",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ActivationOS",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ActivationProperty",
+      "allPublicMethods": true
+    },
+    {
       "type": "org.apache.maven.model.Build",
       "allPublicMethods": true
     },
     {
       "type": "org.apache.maven.model.BuildBase",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.CiManagement",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ConfigurationContainer",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Contributor",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Dependency",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.DependencyManagement",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.DeploymentRepository",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Developer",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.DistributionManagement",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Exclusion",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Extension",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.FileSet",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.IssueManagement",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.License",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.MailingList",
       "allPublicMethods": true
     },
     {
@@ -521,11 +604,87 @@
       "allPublicMethods": true
     },
     {
+      "type": "org.apache.maven.model.Notifier",
+      "allPublicMethods": true
+    },
+    {
       "type": "org.apache.maven.model.Organization",
       "allPublicMethods": true
     },
     {
+      "type": "org.apache.maven.model.Parent",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.PatternSet",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Plugin",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.PluginConfiguration",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.PluginContainer",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.PluginExecution",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.PluginManagement",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Prerequisites",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Profile",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Relocation",
+      "allPublicMethods": true
+    },
+    {
       "type": "org.apache.maven.model.Reporting",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ReportPlugin",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.ReportSet",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Repository",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.RepositoryBase",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.RepositoryPolicy",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Resource",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Scm",
+      "allPublicMethods": true
+    },
+    {
+      "type": "org.apache.maven.model.Site",
       "allPublicMethods": true
     },
     {


### PR DESCRIPTION
## Problem

Running `jbang run camel@apache/camel` with the native image binary fails with:

```
MissingReflectionRegistrationError: Cannot reflectively access the 'org.apache.maven.model.Scm'
```

## Root cause

Maven's `StringVisitorModelInterpolator` uses reflection (`Class.getMethods()` via plexus `ReflectionValueExtractor`) to interpolate POM properties. It has `visit()` methods for every Maven model class (`Scm`, `Parent`, `License`, `Developer`, etc.), and also reflects on their return types (`String`, `List`, `Properties`, `File`).

The `reachability-metadata.json` only registered 6 of the ~45 model classes (`Build`, `BuildBase`, `Model`, `ModelBase`, `Organization`, `Reporting`). Which classes get hit depends on what sections a POM contains — simple POMs worked fine, but the Camel BOM has a `<scm>` section which triggered the missing registration.

Existing tests never caught this because:
- Unit and integration tests run on the JVM, where `Class.getMethods()` works without registration
- The `--exact-reachability-metadata` native image flag makes this a hard error rather than silently working
- The failure is data-dependent — it only triggers when a resolved POM has sections whose model classes aren't registered

## Fix

- **`reachability-metadata.json`**: Register all `org.apache.maven.model.*` classes (43 total) plus `java.lang.String`, `java.util.List`, `java.util.Properties`, and `java.io.File` which appear as return types from model getters
- **`settings.gradle`**: Set `rootProject.name = 'jbang'` so the build output uses `build/install/jbang/` regardless of the working directory name
- **`build.gradle`**: Add `mustRunAfter('nativeImage')`on `installDist` to fix task ordering when both are requested together
- **`.justfile`**: Add `build-native` and `jbang-native` tasks for convenient native image development