### PR TITLE
fix: clarify app setup messages and hint about jbang version --update

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -464,7 +464,8 @@ public class App extends BaseCommand {
 				Util.infoMsg("JBang environment setup completed...");
 			} else if (chatty) {
 				Util.infoMsg("JBang is already available in PATH.");
-				Util.infoMsg("(You can use --force to perform the setup anyway)");
+				Util.infoMsg("You can use --force to update your shell environment files anyway.");
+				Util.infoMsg("To update JBang itself, run: jbang version --update");
 			}
 			if (Util.getShell() == Util.Shell.bash) {
 				if (changed) {


### PR DESCRIPTION
When `jbang app setup` detects JBang is already on PATH, the messages now:

1. Clarify that `--force` updates **shell environment files** (not JBang itself)
2. Suggest running `jbang version --update` to update JBang itself

**Before:**
```
[jbang] JBang is already available in PATH.
[jbang] (You can use --force to perform the setup anyway)
```

**After:**
```
[jbang] JBang is already available in PATH.
[jbang] (You can use --force to update your shell environment files anyway)
[jbang] If you want to update JBang itself, run: jbang version --update
```

Fixes #2067