### PR TITLE
fix: improve error messages for catalog download failures

### DIFF
--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -327,7 +327,7 @@ public class Catalog {
 					if (result != null)
 						return result;
 				} catch (Exception e) {
-					Util.verboseMsg("Unable to read catalog " + cr.catalogRef + " because " + e);
+					Util.verboseMsg("Unable to read catalog " + cr.catalogRef + ": " + e.getMessage(), e);
 				}
 			}
 		}

--- a/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import dev.jbang.util.NetUtil;
 import dev.jbang.util.Util;
 
 public class ImplicitCatalogRef {
@@ -88,6 +89,12 @@ public class ImplicitCatalogRef {
 			return Optional.of(url);
 		} catch (Exception ex) {
 			Util.verboseMsg("No catalog found at " + url, ex);
+			String authMethod = NetUtil.describeAuthMethod(url);
+			if (authMethod != null) {
+				Util.warnMsg("Could not download catalog from " + url
+						+ ". Authentication via " + authMethod + " was used but may be expired or invalid."
+						+ " Try updating or removing the credentials.");
+			}
 			return Optional.empty();
 		}
 	}

--- a/src/main/java/dev/jbang/util/NetUtil.java
+++ b/src/main/java/dev/jbang/util/NetUtil.java
@@ -641,14 +641,60 @@ public class NetUtil {
 	}
 
 	private static boolean isAGithubUrl(URLConnection urlConnection) {
-		String host = urlConnection.getURL().getHost();
+		return isAGithubHost(urlConnection.getURL().getHost());
+	}
+
+	private static boolean isAGithubHost(String host) {
 		return host.equals("github.com") || host.endsWith(".github.com")
 				|| host.equals("githubusercontent.com") || host.endsWith(".githubusercontent.com");
 	}
 
 	private static boolean isAGitlabUrl(URLConnection urlConnection) {
-		String host = urlConnection.getURL().getHost();
+		return isAGitlabHost(urlConnection.getURL().getHost());
+	}
+
+	private static boolean isAGitlabHost(String host) {
 		return host.equals("gitlab.com") || host.endsWith(".gitlab.com");
+	}
+
+	/**
+	 * Returns a human-readable description of the authentication method that would
+	 * be used for the given URL, or {@code null} if no authentication is
+	 * configured.
+	 */
+	public static String describeAuthMethod(String url) {
+		try {
+			URL u = new URL(url);
+			String host = u.getHost();
+
+			// 1. Well-known env vars for specific hosts
+			if (isAGithubHost(host) && !isNullOrBlankString(System.getenv("GITHUB_TOKEN"))) {
+				return "GITHUB_TOKEN";
+			}
+			if (isAGitlabHost(host) && !isNullOrBlankString(System.getenv("GITLAB_TOKEN"))) {
+				return "GITLAB_TOKEN";
+			}
+
+			// 2. URL userinfo
+			if (u.getUserInfo() != null) {
+				return "URL credentials";
+			}
+
+			// 3. .netrc
+			NetrcParser.NetrcEntry entry = getNetrc().getEntry(host).orElse(null);
+			if (entry != null && !isNullOrBlankString(entry.getLogin()) && !isNullOrBlankString(entry.getPassword())) {
+				return ".netrc";
+			}
+
+			// 4. Global basic auth env vars
+			if (!isNullOrBlankString(System.getenv(JBANG_AUTH_BASIC_USERNAME))
+					&& !isNullOrBlankString(System.getenv(JBANG_AUTH_BASIC_PASSWORD))) {
+				return "JBANG_AUTH_BASIC_USERNAME/PASSWORD";
+			}
+		} catch (Exception e) {
+			// ignore
+		}
+		return null;
 	}
 
 	public static String getDispositionFilename(String disposition) {

--- a/src/test/java/dev/jbang/util/TestDescribeAuthMethod.java
+++ b/src/test/java/dev/jbang/util/TestDescribeAuthMethod.java
@@ -1,0 +1,85 @@
+package dev.jbang.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import dev.jbang.BaseTest;
+
+/**
+ * Tests for {@link NetUtil#describeAuthMethod(String)}.
+ */
+public class TestDescribeAuthMethod extends BaseTest {
+
+	@TempDir
+	Path tempDir;
+
+	@AfterEach
+	void cleanup() {
+		NetUtil.resetNetrcCache();
+	}
+
+	private void setNetrc(String content) throws IOException {
+		Path netrc = tempDir.resolve(".netrc");
+		Files.writeString(netrc, content);
+		NetUtil.setNetrcFile(netrc);
+	}
+
+	@Test
+	void testUrlCredentialsDetected() {
+		assertThat(NetUtil.describeAuthMethod("https://user:pass@example.com/file.java"),
+				equalTo("URL credentials"));
+		// Non-matching URL without credentials returns null
+		assertThat(NetUtil.describeAuthMethod("https://example.com/file.java"), nullValue());
+	}
+
+	@Test
+	void testNetrcDetected() throws IOException {
+		setNetrc("machine myserver.example.com\nlogin admin\npassword secret\n");
+		assertThat(NetUtil.describeAuthMethod("https://myserver.example.com/path/file.java"),
+				equalTo(".netrc"));
+		// Host not in .netrc returns null
+		assertThat(NetUtil.describeAuthMethod("https://otherserver.example.com/file.java"), nullValue());
+	}
+
+	@Test
+	void testNetrcDefaultEntryDetected() throws IOException {
+		setNetrc("default\nlogin fallback\npassword fallbackpass\n");
+		assertThat(NetUtil.describeAuthMethod("https://any-host.example.com/file.java"),
+				equalTo(".netrc"));
+	}
+
+	@Test
+	void testNoAuthReturnsNull() throws IOException {
+		// Set an empty .netrc so it won't match anything
+		setNetrc("");
+		assertThat(NetUtil.describeAuthMethod("https://example.com/file.java"), nullValue());
+	}
+
+	@Test
+	void testNetrcNoMatchFallsThrough() throws IOException {
+		setNetrc("machine other.example.com\nlogin user\npassword pass\n");
+		assertThat(NetUtil.describeAuthMethod("https://nomatch.example.com/file.java"), nullValue());
+	}
+
+	@Test
+	void testInvalidUrlReturnsNull() {
+		assertThat(NetUtil.describeAuthMethod("not-a-url"), nullValue());
+	}
+
+	@Test
+	void testUrlCredentialsTakePriorityOverNetrc() throws IOException {
+		setNetrc("machine example.com\nlogin netrcuser\npassword netrcpass\n");
+		// URL credentials (step 2) should win over .netrc (step 3)
+		assertThat(NetUtil.describeAuthMethod("https://user:pass@example.com/file.java"),
+				equalTo("URL credentials"));
+	}
+}


### PR DESCRIPTION
Fixes #2559

When a catalog download fails and authentication was in play, users get an unhelpful "Unknown catalog" error with no clue that their token or credentials might be the problem.

**What changed**

`NetUtil.describeAuthMethod(url)` checks which auth method (if any) would apply for a given URL, using the same priority order as `addAuthHeaderIfNeeded`: `GITHUB_TOKEN`, `GITLAB_TOKEN`, URL credentials, `.netrc`, `JBANG_AUTH_BASIC_*`. Returns a human-readable label or null.

`ImplicitCatalogRef.tryDownload()` now calls `describeAuthMethod` on failure and warns when credentials were involved:

```
[jbang] [WARN] Could not download catalog from https://github.com/quarkusio/jbang-catalog/blob/HEAD/jbang-catalog.json. Authentication via GITHUB_TOKEN was used but may be expired or invalid. Try updating or removing the credentials.
```

This works for all auth methods, not just `GITHUB_TOKEN`.

`Catalog.findImportedCatalogsWith()` now passes both the exception message and the Throwable to `verboseMsg`, so the error reason is visible without `--verbose` and stack traces still print when verbose is on.

Tests cover `.netrc`, URL credentials, priority ordering, null returns for unmatched URLs, and invalid input.

See #2560 for a follow-up to include attempted download URLs in the "Unknown catalog" error message itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved authentication detection for remote downloads, with clearer guidance when credentials are being used.
* **Bug Fixes**
  * Download failures now show more helpful warnings when authentication may be expired or invalid.
  * Error logging is more informative, making failures easier to diagnose.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->