### PR TITLE
build: use JReleaser for PR builds (same layout as early-access)

### DIFF
--- a/.github/workflows/cleanup-pr-builds.yml
+++ b/.github/workflows/cleanup-pr-builds.yml
@@ -1,0 +1,94 @@
+name: cleanup-pr-builds
+
+on:
+  # Immediate cleanup when a PR is closed or merged.
+  # Uses pull_request_target (not pull_request) so it runs in the base
+  # branch context and has access to secrets for cross-repo operations.
+  pull_request_target:
+    types: [closed]
+
+  # Weekly safety-net: remove stale releases older than 30 days
+  schedule:
+    - cron: '0 3 * * 0'  # Sunday 03:00 UTC
+
+jobs:
+  cleanup-closed-pr:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete PR build release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          github-token: ${{ secrets.PR_BUILDS_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = 'jbang-pr-builds';
+            const tag = `pr-${context.payload.pull_request.number}`;
+
+            try {
+              const { data: release } = await github.rest.repos.getReleaseByTag({
+                owner, repo, tag
+              });
+              await github.rest.repos.deleteRelease({
+                owner, repo, release_id: release.id
+              });
+              core.info(`Deleted release ${tag}`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info(`No release found for ${tag}, nothing to clean up`);
+              } else {
+                throw e;
+              }
+            }
+
+            // Also delete the tag
+            try {
+              await github.rest.git.deleteRef({
+                owner, repo, ref: `tags/${tag}`
+              });
+              core.info(`Deleted tag ${tag}`);
+            } catch (e) {
+              if (e.status !== 422 && e.status !== 404) throw e;
+            }
+
+  cleanup-stale:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete releases older than 30 days
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          github-token: ${{ secrets.PR_BUILDS_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = 'jbang-pr-builds';
+            const maxAgeDays = 30;
+            const cutoff = new Date();
+            cutoff.setDate(cutoff.getDate() - maxAgeDays);
+
+            // Paginate through all releases
+            const releases = await github.paginate(
+              github.rest.repos.listReleases,
+              { owner, repo, per_page: 100 }
+            );
+
+            let deleted = 0;
+            for (const release of releases) {
+              const createdAt = new Date(release.created_at);
+              if (createdAt < cutoff) {
+                const tag = release.tag_name;
+                await github.rest.repos.deleteRelease({
+                  owner, repo, release_id: release.id
+                });
+                try {
+                  await github.rest.git.deleteRef({
+                    owner, repo, ref: `tags/${tag}`
+                  });
+                } catch (e) {
+                  if (e.status !== 422 && e.status !== 404) throw e;
+                }
+                core.info(`Deleted stale release ${tag} (created ${createdAt.toISOString()})`);
+                deleted++;
+              }
+            }
+            core.info(`Cleaned up ${deleted} stale release(s)`);

--- a/.github/workflows/publish-pr-build.yml
+++ b/.github/workflows/publish-pr-build.yml
@@ -1,0 +1,192 @@
+name: publish-pr-build
+
+# Triggered when ci-build completes. Runs in base-branch context so it has
+# access to secrets, which lets us push artifacts to the jbang-pr-builds repo.
+on:
+  workflow_run:
+    workflows: [ci-build]
+    types: [completed]
+
+permissions:
+  actions: read          # to download artifacts from the triggering run
+  pull-requests: write   # to comment on the PR
+
+jobs:
+  publish:
+    # Only publish for successful PR builds (not workflow_dispatch or pushes)
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      JRELEASER_VERSION: early-access
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            // workflow_run.pull_requests may be empty for cross-fork PRs,
+            // so fall back to searching by head SHA
+            const prs = context.payload.workflow_run.pull_requests;
+            if (prs && prs.length > 0) {
+              core.setOutput('number', prs[0].number);
+              return;
+            }
+            // Fallback: search for PR by head SHA
+            const headSha = context.payload.workflow_run.head_sha;
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10,
+            });
+            const match = pulls.find(p => p.head.sha === headSha);
+            if (match) {
+              core.setOutput('number', match.number);
+            } else {
+              core.setFailed(`Could not determine PR number for SHA ${headSha}`);
+            }
+
+      - id: shared-build
+        uses: ./.github/actions/shared-build-setup
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: ${{ steps.shared-build.outputs.github-short-sha }}-shared-build
+          path: build
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Download native bundles
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: ${{ steps.shared-build.outputs.github-short-sha }}-jbang-native-bundles-*
+          path: build/distributions
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          if-no-files-found: warn
+
+      - name: Version extract
+        id: version
+        run: |
+          RELEASE_VERSION=$(cat build/tmp/version.txt)
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release version: $RELEASE_VERSION"
+          ls -la build/distributions
+
+      - name: Push PR tag to jbang-pr-builds
+        env:
+          GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+        run: |
+          PR_TAG="pr-${{ steps.pr.outputs.number }}"
+          # Create or update the tag in the pr-builds repo.
+          # We need a commit to attach the tag to; use the default branch HEAD.
+          DEFAULT_SHA=$(gh api repos/${{ github.repository_owner }}/jbang-pr-builds/git/ref/heads/main --jq '.object.sha' 2>/dev/null || echo "")
+          if [ -z "$DEFAULT_SHA" ]; then
+            echo "::warning::Could not find default branch in jbang-pr-builds, skipping tag push"
+          else
+            # Delete existing tag if present
+            gh api --method DELETE "repos/${{ github.repository_owner }}/jbang-pr-builds/git/refs/tags/${PR_TAG}" 2>/dev/null || true
+            # Create new tag
+            gh api --method POST "repos/${{ github.repository_owner }}/jbang-pr-builds/git/refs" \
+              -f "ref=refs/tags/${PR_TAG}" \
+              -f "sha=${DEFAULT_SHA}"
+          fi
+
+      - name: Run JReleaser
+        uses: jreleaser/release-action@97b5e2f0e845de2fe1dbbdf451ac6a21233fafff # v2
+        env:
+          JRELEASER_PROJECT_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+          # Target the pr-builds repo instead of jbang
+          JRELEASER_RELEASE_GITHUB_REPO: jbang-pr-builds
+          JRELEASER_RELEASE_GITHUB_TAG_NAME: pr-${{ steps.pr.outputs.number }}
+          JRELEASER_RELEASE_GITHUB_RELEASE_NAME: "PR #${{ steps.pr.outputs.number }} (${{ steps.version.outputs.RELEASE_VERSION }})"
+          JRELEASER_RELEASE_GITHUB_OVERWRITE: true
+          JRELEASER_RELEASE_GITHUB_SKIP_TAG: false
+          # Disable signing (no GPG keys for PR builds)
+          JRELEASER_SIGNING_ACTIVE: NEVER
+          # Disable checksum signing
+          JRELEASER_CHECKSUM_INDIVIDUAL: true
+          JRELEASER_DRAFT: false
+        with:
+          version: ${{ env.JRELEASER_VERSION }}
+          arguments: full-release --yolo
+          setup-java: false
+
+      - name: Mark release as pre-release
+        env:
+          GH_TOKEN: ${{ secrets.PR_BUILDS_TOKEN }}
+        run: |
+          PR_TAG="pr-${{ steps.pr.outputs.number }}"
+          RELEASE_ID=$(gh api "repos/${{ github.repository_owner }}/jbang-pr-builds/releases" \
+            --jq "[.[] | select(.tag_name==\"${PR_TAG}\")] | sort_by(.created_at) | last | .id")
+          if [ -n "$RELEASE_ID" ] && [ "$RELEASE_ID" != "null" ]; then
+            gh api --method PATCH "repos/${{ github.repository_owner }}/jbang-pr-builds/releases/${RELEASE_ID}" \
+              -F draft=false -F prerelease=true
+          fi
+
+      - name: JReleaser output
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: jreleaser-pr-build
+          path: |
+            out/jreleaser/trace.log
+            out/jreleaser/output.properties
+
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          RELEASE_VERSION: ${{ steps.version.outputs.RELEASE_VERSION }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const buildsRepo = 'jbang-pr-builds';
+            const tag = `pr-${prNumber}`;
+            const version = process.env.RELEASE_VERSION;
+            const releaseUrl = `https://github.com/${owner}/${buildsRepo}/releases/tag/${tag}`;
+            const downloadBase = `https://github.com/${owner}/${buildsRepo}/releases/download/${tag}`;
+            const marker = '<!-- jbang-pr-build -->';
+
+            const body = [
+              marker,
+              `### 📦 PR Build Available`,
+              '',
+              `Version: \`${version}\` | [Release](${releaseUrl}) | Built from ${context.payload.workflow_run.head_sha.substring(0, 7)}`,
+              '',
+              'Install this PR build:',
+              '```bash',
+              `# Linux / macOS / WSL`,
+              `curl -Ls https://sh.jbang.dev | JBANG_DOWNLOAD_URL=${downloadBase}/jbang.tar bash -s - version`,
+              '',
+              `# Or if jbang is already installed:`,
+              `JBANG_DOWNLOAD_URL=${downloadBase}/jbang.tar jbang version`,
+              '```',
+            ].join('\n');
+
+            // Update existing comment or create new one
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }


### PR DESCRIPTION
Follow-up to #2562. Reworks `publish-pr-build.yml` to use JReleaser instead of manually packaging tar/zip files.

### What changed

- Downloads the full `shared-build` artifact (not just `shared-build-jbang`) — has pre-built `jbang.tar`, `jbang.zip`, versioned variants, and checksums
- Downloads native bundles from all 3 OS matrix jobs — PR builds now include native images like early-access
- Runs JReleaser with env var overrides to target `jbang-pr-builds` repo:
  - `JRELEASER_RELEASE_GITHUB_REPO=jbang-pr-builds`
  - `JRELEASER_RELEASE_GITHUB_TAG_NAME=pr-<number>`
  - `JRELEASER_SIGNING_ACTIVE=NEVER` (no GPG for PR builds)
- Checks out the PR commit so JReleaser reads the correct `jreleaser.yml`

### Result

PR build releases have the exact same artifact layout as early-access — same filenames, checksums, native bundles. No hand-rolled packaging.