### PR TITLE
fix: resolve jbang deps search hang on Windows #2549

### DIFF
--- a/src/main/java/dev/jbang/cli/Deps.java
+++ b/src/main/java/dev/jbang/cli/Deps.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Arguments;
 import org.aesh.command.option.Option;
+import org.aesh.terminal.Connection;
 import org.eclipse.aether.artifact.Artifact;
 
 import dev.jbang.dependencies.DependencyUtil;
@@ -85,7 +86,11 @@ public class Deps extends BaseCommand {
 			}
 
 			try {
-				Artifact artifact = new ArtifactSearchWidget().search(query != null ? query : "");
+				Connection connection = null;
+				if (commandInvocation != null && commandInvocation.getShell() != null) {
+					connection = commandInvocation.getShell().connection();
+				}
+				Artifact artifact = new ArtifactSearchWidget().search(connection, query != null ? query : "");
 				if (targetPath != null) {
 					DepsAdd.updateFile(targetPath, Collections.singletonList(artifactGav(artifact)));
 					info("Added " + artifactGav(artifact) + " to " + targetPath);

--- a/src/main/java/dev/jbang/search/ArtifactSearchWidget.java
+++ b/src/main/java/dev/jbang/search/ArtifactSearchWidget.java
@@ -13,11 +13,13 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.aesh.terminal.Connection;
 import org.eclipse.aether.artifact.Artifact;
 
 import dev.jbang.dependencies.ArtifactResolver;
 import dev.jbang.util.Util;
 
+import dev.tamboui.backend.aesh.AeshBackend;
 import dev.tamboui.style.Color;
 import dev.tamboui.style.Modifier;
 import dev.tamboui.style.Style;
@@ -25,6 +27,7 @@ import dev.tamboui.toolkit.app.ToolkitRunner;
 import dev.tamboui.toolkit.element.Element;
 import dev.tamboui.toolkit.element.StyledElement;
 import dev.tamboui.toolkit.event.EventResult;
+import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.bindings.Actions;
 import dev.tamboui.tui.bindings.BindingSets;
 import dev.tamboui.tui.bindings.Bindings;
@@ -86,6 +89,10 @@ public class ArtifactSearchWidget {
 	 * @return the selected Artifacts (one or more)
 	 */
 	public Artifact search(String initialQuery) {
+		return search(null, initialQuery);
+	}
+
+	public Artifact search(Connection connection, String initialQuery) {
 		if (initialQuery != null && !initialQuery.isEmpty()) {
 			searchInput.setText(initialQuery);
 			searchInput.moveCursorToEnd();
@@ -101,7 +108,19 @@ public class ArtifactSearchWidget {
 			.bind(KeyTrigger.key(KeyCode.TAB), ACTION_SEARCH_CENTRAL)
 			.bind(KeyTrigger.key(KeyCode.F5), ACTION_SEARCH_CENTRAL)
 			.build();
-		try (ToolkitRunner r = ToolkitRunner.builder().bindings(bindings).build()) {
+
+		ToolkitRunner.Builder builder = ToolkitRunner.builder().bindings(bindings);
+		if (connection != null) {
+			try {
+				AeshBackend backend = new AeshBackend(connection);
+				TuiConfig config = TuiConfig.defaults().toBuilder().backend(backend).build();
+				builder.config(config);
+			} catch (Exception e) {
+				Util.verboseMsg("Failed to reuse Aesh connection for TUI, falling back to default: " + e.getMessage());
+			}
+		}
+
+		try (ToolkitRunner r = builder.build()) {
 			this.runner = r;
 			r.run(this::render);
 		} catch (Exception e) {

--- a/src/main/java/dev/jbang/util/NetUtil.java
+++ b/src/main/java/dev/jbang/util/NetUtil.java
@@ -44,21 +44,22 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
-import org.jspecify.annotations.NonNull;
 
 public class NetUtil {
 	public static final String JBANG_AUTH_BASIC_USERNAME = "JBANG_AUTH_BASIC_USERNAME";
 	public static final String JBANG_AUTH_BASIC_PASSWORD = "JBANG_AUTH_BASIC_PASSWORD";
 
 	/**
-	 * Whenever the HTTP(S) resource being downloaded has a known extension,
-	 * the corresponding {@code Accept} header will be additionally sent.
+	 * Whenever the HTTP(S) resource being downloaded has a known extension, the
+	 * corresponding {@code Accept} header will be additionally sent.
 	 * <p>
 	 * This is useful in case a remote server (e.g.: GitHub) may serve different
 	 * content types for the same URL (e.g. both JSON and the HTML view of JSON
@@ -261,13 +262,12 @@ public class NetUtil {
 		}
 
 		/**
-		 * Returns a configurator that sets the {@code Accept} header for an
-		 * HTTP connection based on the file extension of the URL path.
-		 * The header value is determined from a predefined mapping of known
-		 * content types.
+		 * Returns a configurator that sets the {@code Accept} header for an HTTP
+		 * connection based on the file extension of the URL path. The header value is
+		 * determined from a predefined mapping of known content types.
 		 *
-		 * @return a configurator that optionally sets the {@code Accept} header
-		 *   on an HTTP(S) connection.
+		 * @return a configurator that optionally sets the {@code Accept} header on an
+		 *         HTTP(S) connection.
 		 * @see #KNOWN_CONTENT_TYPES
 		 */
 		static @NonNull ConnectionConfigurator accept() {


### PR DESCRIPTION
### Title
`fix: resolve jbang deps search hang on Windows` 

Fixes #2549 

### Description
This PR resolves the issue where `jbang deps search` hangs indefinitely and produces no output when run on Windows.

#### Cause
The terminal backend in JBang for the `deps search` TUI widget is implemented using TamboUI's `tamboui-aesh-backend`. 

By default, the backend's constructor instantiates a new `org.aesh.terminal.tty.TerminalConnection` to connect to the system terminal. However, because JBang is already running within an active Aesh shell session, trying to open a second native system terminal connection to the same console session on Windows results in a conflict/deadlock, causing the process to hang without displaying the UI.

#### Solution
- Modified Deps.java to extract the active `org.aesh.terminal.Connection` instance from Aesh's command invocation context using `commandInvocation.getShell().connection()`.
- Updated ArtifactSearchWidget.java to support an overloaded `search(Connection connection, String initialQuery)` method.
- Reconfigured the TUI initialization to reuse the connection if it's available:
  ```java
  AeshBackend backend = new AeshBackend(connection);
  TuiConfig config = TuiConfig.defaults().toBuilder().backend(backend).build();
  ```
- If no connection is passed (e.g. falls back to default), it defaults back to creating a new terminal connection.