### PR TITLE
feat: add support for versions property in aliases

### DIFF
--- a/src/main/java/dev/jbang/catalog/Alias.java
+++ b/src/main/java/dev/jbang/catalog/Alias.java
@@ -16,6 +16,7 @@ import com.google.gson.annotations.SerializedName;
 
 import dev.jbang.cli.ExitException;
 import dev.jbang.dependencies.DependencyUtil;
+import dev.jbang.util.PropertiesValueResolver;
 import dev.jbang.util.Util;
 
 public class Alias extends CatalogItem {
@@ -64,6 +65,7 @@ public class Alias extends CatalogItem {
 	public final List<JavaAgent> javaAgents;
 	@JsonAdapter(Catalog.SkipEmptyListSerializer.class)
 	public final List<String> docs;
+	public final Map<String, String> versions;
 
 	public static class JavaAgent {
 		@SerializedName(value = "agent-ref")
@@ -99,7 +101,7 @@ public class Alias extends CatalogItem {
 
 	public Alias() {
 		this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-				null, null, null, null, null, null, null, null, null, null, null);
+				null, null, null, null, null, null, null, null, null, null, null, null);
 	}
 
 	public Alias(String scriptRef,
@@ -130,6 +132,7 @@ public class Alias extends CatalogItem {
 			Map<String, String> manifestOptions,
 			List<JavaAgent> javaAgents,
 			List<String> docs,
+			Map<String, String> versions,
 			Catalog catalog) {
 		super(catalog);
 		this.scriptRef = scriptRef;
@@ -160,6 +163,7 @@ public class Alias extends CatalogItem {
 		this.manifestOptions = manifestOptions;
 		this.javaAgents = javaAgents;
 		this.docs = docs;
+		this.versions = versions;
 	}
 
 	/**
@@ -167,7 +171,7 @@ public class Alias extends CatalogItem {
 	 * like baseRefs and current working directories applied.
 	 */
 	public String resolve() {
-		return resolve(scriptRef);
+		return scriptRef != null ? resolve(PropertiesValueResolver.replaceProperties(scriptRef)) : null;
 	}
 
 	/**
@@ -209,20 +213,77 @@ public class Alias extends CatalogItem {
 		if (names.contains(name)) {
 			throw new RuntimeException("Encountered alias loop on '" + name + "'");
 		}
-		String[] parts = name.split("@", 2);
-		if (parts[0].isEmpty()) {
-			throw new RuntimeException("Invalid alias name '" + name + "'");
-		}
-		Alias a2;
-		if (parts.length == 1) {
-			a2 = findUnqualifiedAlias.apply(name);
-		} else {
-			if (parts[1].isEmpty()) {
+		String aliasName = name;
+		String catalogName = null;
+		String version = null;
+
+		if (name.contains("@")) {
+			String[] parts = name.split("@");
+			if (parts.length == 2) {
+				String arg = parts[1];
+				if (parts[0].isEmpty() || arg.isEmpty()) {
+					throw new RuntimeException("Invalid alias name '" + name + "'");
+				}
+				Alias a = findUnqualifiedAlias.apply(parts[0]);
+				boolean isCatalog = false;
+				try {
+					Catalog.getByName(arg);
+					isCatalog = true;
+				} catch (Exception e) {
+					// Not a catalog
+				}
+				boolean isVersion = false;
+				if (!isCatalog && a != null) {
+					if (a.versions != null && !a.versions.isEmpty()) {
+						isVersion = a.versions.containsKey(arg) || isVersionLike(arg);
+					} else {
+						isVersion = isVersionLike(arg);
+					}
+				}
+				if (isVersion) {
+					aliasName = parts[0];
+					version = arg;
+				} else {
+					aliasName = parts[0];
+					catalogName = arg;
+				}
+			} else if (parts.length == 3) {
+				aliasName = parts[0];
+				version = parts[1];
+				catalogName = parts[2];
+				if (aliasName.isEmpty() || version.isEmpty() || catalogName.isEmpty()) {
+					throw new RuntimeException("Invalid alias name '" + name + "'");
+				}
+			} else {
 				throw new RuntimeException("Invalid alias name '" + name + "'");
 			}
-			a2 = fromCatalog(parts[1], parts[0]);
 		}
+
+		Alias a2;
+		if (catalogName == null) {
+			a2 = findUnqualifiedAlias.apply(aliasName);
+		} else {
+			a2 = fromCatalog(catalogName, aliasName);
+		}
+
 		if (a2 != null) {
+			if (version != null) {
+				if (a2.versions != null && !a2.versions.isEmpty()) {
+					if (a2.versions.containsKey(version)) {
+						System.setProperty("jbang.app.version", version);
+					} else {
+						throw new ExitException(EXIT_INVALID_INPUT,
+								"Invalid version '" + version + "' for alias '" + aliasName + "'"
+										+ (catalogName != null ? " in catalog '" + catalogName + "'" : "")
+										+ ". Available versions: " + String.join(", ", a2.versions.keySet()));
+					}
+				} else {
+					throw new ExitException(EXIT_INVALID_INPUT,
+							"Alias '" + aliasName + "'"
+									+ (catalogName != null ? " in catalog '" + catalogName + "'" : "")
+									+ " does not support versioning.");
+				}
+			}
 			names.add(name);
 			a2 = merge(a2, a2.scriptRef, findUnqualifiedAlias, names);
 			String desc = a1.description != null ? a1.description : a2.description;
@@ -262,10 +323,11 @@ public class Alias extends CatalogItem {
 					: a2.manifestOptions;
 			List<JavaAgent> jags = a1.javaAgents != null && !a1.javaAgents.isEmpty() ? a1.javaAgents : a2.javaAgents;
 			List<String> docs = a1.docs != null && !a1.docs.isEmpty() ? a1.docs : a2.docs;
+			Map<String, String> versions = a1.versions != null && !a1.versions.isEmpty() ? a1.versions : a2.versions;
 			Catalog catalog = a2.catalog != null ? a2.catalog : a1.catalog;
 			return new Alias(a2.scriptRef, desc, args, jopts, srcs, ress, deps, repos, cpaths, props, javaVersion,
 					mainClass, moduleName, copts, nimg, nopts, forceType, ints, jfr, debug, cds, inter, ep, ea, esa,
-					mopts, jags, docs, catalog);
+					mopts, jags, docs, versions, catalog);
 		} else {
 			return a1;
 		}
@@ -310,20 +372,34 @@ public class Alias extends CatalogItem {
 		return new Alias(scriptRef, description, arguments, runtimeOptions, sources, resources, dependencies,
 				repositories, classpaths, properties, javaVersion, mainClass, moduleName, compileOptions, nativeImage,
 				nativeOptions, forceType, integrations, jfr, debug, cds, interactive, enablePreview, enableAssertions,
-				enableSystemAssertions, manifestOptions, javaAgents, docs, catalog);
+				enableSystemAssertions, manifestOptions, javaAgents, docs, versions, catalog);
 	}
 
 	public Alias withScriptRef(String scriptRef) {
 		return new Alias(scriptRef, description, arguments, runtimeOptions, sources, resources, dependencies,
 				repositories, classpaths, properties, javaVersion, mainClass, moduleName, compileOptions, nativeImage,
 				nativeOptions, forceType, integrations, jfr, debug, cds, interactive, enablePreview, enableAssertions,
-				enableSystemAssertions, manifestOptions, javaAgents, docs, catalog);
+				enableSystemAssertions, manifestOptions, javaAgents, docs, versions, catalog);
 	}
 
 	public Alias withForceType(String forceType) {
 		return new Alias(scriptRef, description, arguments, runtimeOptions, sources, resources, dependencies,
 				repositories, classpaths, properties, javaVersion, mainClass, moduleName, compileOptions, nativeImage,
 				nativeOptions, forceType, integrations, jfr, debug, cds, interactive, enablePreview, enableAssertions,
-				enableSystemAssertions, manifestOptions, javaAgents, docs, catalog);
+				enableSystemAssertions, manifestOptions, javaAgents, docs, versions, catalog);
+	}
+
+	private static boolean isVersionLike(String s) {
+		if (s == null || s.isEmpty()) {
+			return false;
+		}
+		char c = s.charAt(0);
+		if (Character.isDigit(c)) {
+			return true;
+		}
+		if ((c == 'v' || c == 'V') && s.length() > 1 && Character.isDigit(s.charAt(1))) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -110,7 +110,7 @@ public class Alias extends BaseCommand {
 					runMixin.flightRecorderString, runMixin.debugString, runMixin.getCds(), runMixin.interactive,
 					enablePreviewRequested, runMixin.enableAssertions,
 					runMixin.enableSystemAssertions,
-					buildMixin.manifestOptions, createJavaAgents(), docs, null);
+					buildMixin.manifestOptions, createJavaAgents(), docs, null, null);
 			Path catFile = catalogOptions.getCatalogOrDefault();
 			if (force || !CatalogUtil.hasAlias(catFile, name)) {
 				CatalogUtil.addAlias(catFile, name, alias);

--- a/src/main/java/dev/jbang/util/NetUtil.java
+++ b/src/main/java/dev/jbang/util/NetUtil.java
@@ -44,21 +44,22 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NonNull;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 
 import dev.jbang.Cache;
 import dev.jbang.Settings;
-import org.jspecify.annotations.NonNull;
 
 public class NetUtil {
 	public static final String JBANG_AUTH_BASIC_USERNAME = "JBANG_AUTH_BASIC_USERNAME";
 	public static final String JBANG_AUTH_BASIC_PASSWORD = "JBANG_AUTH_BASIC_PASSWORD";
 
 	/**
-	 * Whenever the HTTP(S) resource being downloaded has a known extension,
-	 * the corresponding {@code Accept} header will be additionally sent.
+	 * Whenever the HTTP(S) resource being downloaded has a known extension, the
+	 * corresponding {@code Accept} header will be additionally sent.
 	 * <p>
 	 * This is useful in case a remote server (e.g.: GitHub) may serve different
 	 * content types for the same URL (e.g. both JSON and the HTML view of JSON
@@ -261,13 +262,12 @@ public class NetUtil {
 		}
 
 		/**
-		 * Returns a configurator that sets the {@code Accept} header for an
-		 * HTTP connection based on the file extension of the URL path.
-		 * The header value is determined from a predefined mapping of known
-		 * content types.
+		 * Returns a configurator that sets the {@code Accept} header for an HTTP
+		 * connection based on the file extension of the URL path. The header value is
+		 * determined from a predefined mapping of known content types.
 		 *
-		 * @return a configurator that optionally sets the {@code Accept} header
-		 *   on an HTTP(S) connection.
+		 * @return a configurator that optionally sets the {@code Accept} header on an
+		 *         HTTP(S) connection.
 		 * @see #KNOWN_CONTENT_TYPES
 		 */
 		static @NonNull ConnectionConfigurator accept() {

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -108,12 +108,24 @@ public class TestAlias extends BaseTest {
 			"    },\n" +
 			"    \"gav\": {\n" +
 			"      \"script-ref\": \"org.example:artifact:version\"\n" +
+			"    },\n" +
+			"    \"camel\": {\n" +
+			"      \"script-ref\": \"./camel/${jbang.app.version:4.18.1}/CamelJBang.java\",\n" +
+			"      \"versions\": {\n" +
+			"        \"4.18.1\": \"Recommended stable version\",\n" +
+			"        \"4.17.0\": \"Previous stable version\",\n" +
+			"        \"4.9.0\": \"Legacy version\"\n" +
+			"      }\n" +
+			"    },\n" +
+			"    \"no-version-alias\": {\n" +
+			"      \"script-ref\": \"./no-version.java\"\n" +
 			"    }\n" +
 			"  }\n" +
 			"}";
 
 	@BeforeEach
 	void initCatalog() throws IOException {
+		System.clearProperty("jbang.app.version");
 		Files.write(jbangTempDir.resolve(Catalog.JBANG_CATALOG_JSON), aliases.getBytes());
 		Util.setCwd(Files.createDirectory(cwdDir.resolve("test")));
 	}
@@ -551,6 +563,39 @@ public class TestAlias extends BaseTest {
 			assertThat(ex.getMessage(), containsString("seven"));
 		}
 
+	}
+
+	@Test
+	void testGetAliasWithDefaultVersion() throws IOException {
+		Alias alias = Alias.get("camel");
+		assertThat(alias, notNullValue());
+		assertThat(alias.versions, notNullValue());
+		assertThat(alias.versions, aMapWithSize(3));
+		assertThat(alias.versions, hasEntry("4.18.1", "Recommended stable version"));
+		// without specifying a version, resolve should fall back to default
+		assertThat(alias.resolve().replace('\\', '/'), containsString("camel/4.18.1/CamelJBang.java"));
+	}
+
+	@Test
+	void testGetAliasWithSpecifiedValidVersion() throws IOException {
+		Alias alias = Alias.get("camel@4.17.0");
+		assertThat(alias, notNullValue());
+		assertThat(alias.resolve().replace('\\', '/'), containsString("camel/4.17.0/CamelJBang.java"));
+		assertThat(System.getProperty("jbang.app.version"), equalTo("4.17.0"));
+	}
+
+	@Test
+	void testGetAliasWithInvalidVersion() {
+		ExitException e = assertThrows(ExitException.class, () -> Alias.get("camel@4.17.9"));
+		assertThat(e.getMessage(), containsString("Invalid version '4.17.9' for alias 'camel'"));
+		assertThat(e.getMessage(), containsString("Available versions:"));
+		assertThat(e.getMessage(), containsString("4.18.1"));
+	}
+
+	@Test
+	void testGetAliasVersionWhenVersioningNotSupported() {
+		ExitException e = assertThrows(ExitException.class, () -> Alias.get("no-version-alias@1.0"));
+		assertThat(e.getMessage(), containsString("Alias 'no-version-alias' does not support versioning."));
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -2440,7 +2440,7 @@ public class TestRun extends BaseTest {
 		File f = examplesTestFolder.resolve("echo.java").toFile();
 		List<String> args = Arrays.asList("foo", "bar");
 		Alias alias = new Alias(f.toString(), null, args, null, null, null, null, null, null, null, null, null, null,
-				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+				null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		CatalogUtil.addNearestAlias("echo", alias);
 
 		Run run = JBang.parseCommand("run", "echo", "baz");


### PR DESCRIPTION
## Description

This PR adds support for a new `versions` property in JBang alias configurations within catalogs, addressing the feature request in #2443. 

### Key Changes:
- **`versions` Field**: Added a `versions` map (`Map<String, String>`) to the Alias.java configuration to store available versions and their description/info.
- **Placeholder Resolution**: Updated alias path resolution to evaluate property replacements dynamically on the script reference (e.g. resolving `${jbang.app.version:default_version}` in the `script-ref`).
- **Versioned Alias Invocation & Validation**:
  - Implemented parsing to recognize versioned alias references with syntaxes like `<alias>@<version>` and `<alias>@<version>@<catalog>`.
  - Validates that the requested version is present in the alias's `versions` property map. If it is invalid, an error is thrown listing the available versions.
  - If the alias does not support versioning but a version is specified, it raises an exception.
  - Sets the `jbang.app.version` system property dynamically to the requested version to enable proper property substitution.
- **Unit Tests**: Added comprehensive test coverage in TestAlias.java verifying default resolution, valid specified versions, invalid version handling, and cases where versioning is not supported.

Fixes #2443