### PR TITLE
fix: rename native binaries to avoid plugin discovery collision

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,7 +308,7 @@ def commonSpec = project.copySpec {
 		include 'jbang.ps1'
 		into 'bin'
 	}
-	// Include native image binary renamed to platform-specific name (e.g. jbang-linux-x64.bin)
+	// Include native image binary renamed to platform-specific name (e.g. jbang.bin-linux-x64)
 	// Scripts look for the platform-named binary first, then fall back to jbang.bin
 	def nativeExecName = getNativeExecutableName()
 	def platformNativeExecName = getPlatformNativeExecutableName()
@@ -749,9 +749,9 @@ String getPlatformNativeExecutableName() {
 	def os = getNativeBundleOs()
 	def arch = getNativeBundleArch()
 	if (os == 'windows') {
-		return "jbang-${os}-${arch}.bin.exe"
+		return "jbang.bin-${os}-${arch}.exe"
 	} else {
-		return "jbang-${os}-${arch}.bin"
+		return "jbang.bin-${os}-${arch}"
 	}
 }
 

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -236,8 +236,8 @@ public class App extends BaseCommand {
 				} else {
 					Path jar = Util.getJarLocation();
 					// TODO: this is duplicated in Wrapper.java - should be more shared.
-					if (!jar.toString().endsWith(".jar") && !jar.toString().endsWith(".bin")
-							&& !jar.toString().endsWith(".bin.exe")) {
+					String jarName = jar.getFileName().toString();
+					if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
 						throw new ExitException(EXIT_GENERIC_ERROR, "Could not determine jbang location from " + jar);
 					}
 					Path fromDir = jar.getParent();

--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -49,8 +49,8 @@ public class Wrapper extends BaseCommand {
 			}
 			try {
 				Path jar = Util.getJarLocation();
-				String binSuffix = Util.isWindows() ? ".bin.exe" : ".bin";
-				if (!jar.toString().endsWith(".jar") && !jar.toString().endsWith(binSuffix)) {
+				String jarName = jar.getFileName().toString();
+				if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
 					throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't find JBang install location via " + jar);
 				}
 				Path parent = jar.getParent();

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -251,23 +251,23 @@ if [[ -z "$JBANG_USE_NATIVE" ]]; then JBANG_USE_NATIVE="false"; fi
 binaryPath=""
 jarPath=""
 if [[ "$JBANG_USE_NATIVE" == "true" ]]; then
-  # Look for platform-specific native binary first (e.g. jbang-linux-x64.bin),
+  # Look for platform-specific native binary first (e.g. jbang.bin-linux-x64),
   # then fall back to generic jbang.bin for manually placed binaries
   if [[ "$os" == "windows" ]]; then
-    if [ -f "$abs_jbang_dir/jbang-${os}-${arch}.bin.exe" ] && [ -x "$abs_jbang_dir/jbang-${os}-${arch}.bin.exe" ]; then
-      binaryPath="$abs_jbang_dir/jbang-${os}-${arch}.bin.exe"
+    if [ -f "$abs_jbang_dir/jbang.bin-${os}-${arch}.exe" ] && [ -x "$abs_jbang_dir/jbang.bin-${os}-${arch}.exe" ]; then
+      binaryPath="$abs_jbang_dir/jbang.bin-${os}-${arch}.exe"
     elif [ -f "$abs_jbang_dir/jbang.bin.exe" ] && [ -x "$abs_jbang_dir/jbang.bin.exe" ]; then
       binaryPath="$abs_jbang_dir/jbang.bin.exe"
     else
-      echo "WARNING: JBang native binary (jbang-${os}-${arch}.bin.exe or jbang.bin.exe) not found in $abs_jbang_dir" 1>&2
+      echo "WARNING: JBang native binary (jbang.bin-${os}-${arch}.exe or jbang.bin.exe) not found in $abs_jbang_dir" 1>&2
     fi
   else
-    if [ -f "$abs_jbang_dir/jbang-${os}-${arch}.bin" ] && [ -x "$abs_jbang_dir/jbang-${os}-${arch}.bin" ]; then
-      binaryPath="$abs_jbang_dir/jbang-${os}-${arch}.bin"
+    if [ -f "$abs_jbang_dir/jbang.bin-${os}-${arch}" ] && [ -x "$abs_jbang_dir/jbang.bin-${os}-${arch}" ]; then
+      binaryPath="$abs_jbang_dir/jbang.bin-${os}-${arch}"
     elif [ -f "$abs_jbang_dir/jbang.bin" ] && [ -x "$abs_jbang_dir/jbang.bin" ]; then
       binaryPath="$abs_jbang_dir/jbang.bin"
     else
-      echo "WARNING: JBang native binary (jbang-${os}-${arch}.bin or jbang.bin) not found or not executable in $abs_jbang_dir" 1>&2
+      echo "WARNING: JBang native binary (jbang.bin-${os}-${arch} or jbang.bin) not found or not executable in $abs_jbang_dir" 1>&2
     fi
   fi
 fi

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -17,12 +17,12 @@ set binaryPath=
 set jarPath=
 if "%JBANG_USE_NATIVE%"=="true" (
   rem Look for platform-specific native binary first, then fall back to jbang.bin.exe
-  if exist "%~dp0jbang-windows-%jbang_arch%.bin.exe" (
-    set binaryPath=%~dp0jbang-windows-%jbang_arch%.bin.exe
+  if exist "%~dp0jbang.bin-windows-%jbang_arch%.exe" (
+    set binaryPath=%~dp0jbang.bin-windows-%jbang_arch%.exe
   ) else if exist "%~dp0jbang.bin.exe" (
     set binaryPath=%~dp0jbang.bin.exe
   ) else (
-    echo WARNING: JBang native binary (jbang-windows-%jbang_arch%.bin.exe or jbang.bin.exe^) not found in %~dp0 1>&2
+    echo WARNING: JBang native binary (jbang.bin-windows-%jbang_arch%.exe or jbang.bin.exe^) not found in %~dp0 1>&2
   )
 )
 if "!binaryPath!"=="" (

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -133,12 +133,12 @@ $binaryPath=""
 $jarPath=""
 if ($env:JBANG_USE_NATIVE -eq "true") {
   # Look for platform-specific native binary first, then fall back to jbang.bin.exe
-  if (Test-Path "$PSScriptRoot\jbang-windows-${jbang_arch}.bin.exe") {
-    $binaryPath="$PSScriptRoot\jbang-windows-${jbang_arch}.bin.exe"
+  if (Test-Path "$PSScriptRoot\jbang.bin-windows-${jbang_arch}.exe") {
+    $binaryPath="$PSScriptRoot\jbang.bin-windows-${jbang_arch}.exe"
   } elseif (Test-Path "$PSScriptRoot\jbang.bin.exe") {
     $binaryPath="$PSScriptRoot\jbang.bin.exe"
   } else {
-    [Console]::Error.WriteLine("WARNING: JBang native binary (jbang-windows-${jbang_arch}.bin.exe or jbang.bin.exe) not found in $PSScriptRoot")
+    [Console]::Error.WriteLine("WARNING: JBang native binary (jbang.bin-windows-${jbang_arch}.exe or jbang.bin.exe) not found in $PSScriptRoot")
   }
 }
 if (-not $binaryPath) {


### PR DESCRIPTION
The plugin discovery mechanism scans PATH for executables starting with `jbang-` and lists them as external commands. Platform-specific native binaries like `jbang-mac-aarch64.bin` match this pattern, so they show up in `jbang --help` output:

```
External:
    mac-aarch64  
    one          plugin one
    two          plugin two
```

They also leak into clidoc-generated docs (`jbang.adoc`, `jbang-completion.adoc`), producing machine-specific artifacts.

This renames the binaries from `jbang-<os>-<arch>.bin` to `jbang.bin-<os>-<arch>`, extending the existing `jbang.bin` naming convention. The new names don't start with `jbang-`, so plugin discovery ignores them.

**Changes:**
- `build.gradle`: `getPlatformNativeExecutableName()` produces the new name
- `src/main/scripts/jbang`: updated binary lookup
- `src/main/scripts/jbang.cmd`: updated binary lookup
- `src/main/scripts/jbang.ps1`: updated binary lookup

Download bundle names (`jbang-<os>-<arch>.tar`/`.zip`) are unchanged since those are archive filenames, not executables on PATH.

Fixes #2576