### PR TITLE
Sharing JBang installation 

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -234,17 +234,8 @@ public class App extends BaseCommand {
 						return 0;
 					});
 				} else {
-					Path jar = Util.getJarLocation();
-					// TODO: this is duplicated in Wrapper.java - should be more shared.
-					String jarName = jar.getFileName().toString();
-					if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
-						throw new ExitException(EXIT_GENERIC_ERROR, "Could not determine jbang location from " + jar);
-					}
-					Path fromDir = jar.getParent();
-					if (fromDir.endsWith(".jbang")) {
-						fromDir = fromDir.getParent();
-					}
-					copyJBangFiles(fromDir, binDir);
+					JBangInstallation installation = JBangInstallation.find(Util.getJarLocation());
+					copyJBangFiles(installation.getScriptsDir(), installation.getJarDir(), binDir);
 				}
 			} else {
 				Util.infoMsg("jbang is already installed.");
@@ -253,16 +244,21 @@ public class App extends BaseCommand {
 		}
 
 		private static void copyJBangFiles(Path from, Path to) throws IOException {
+			copyJBangFiles(from, from, to);
+		}
+
+		private static void copyJBangFiles(Path scriptsFrom, Path jarFrom, Path to) throws IOException {
 			to.toFile().mkdirs();
 			Stream.of("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar")
 				.map(Paths::get)
 				.forEach(f -> {
 					try {
-						Path fromp = from.resolve(f);
+						Path fromp = f.endsWith("jbang.jar") ? jarFrom.resolve(f) : scriptsFrom.resolve(f);
 						Path top = to.resolve(f);
 						if (f.endsWith("jbang.jar")) {
 							if (!Files.isReadable(fromp)) {
-								fromp = from.resolve(".jbang/jbang.jar");
+								fromp = scriptsFrom.resolve(JBangInstallation.DIR_NAME)
+									.resolve(JBangInstallation.JAR_NAME);
 							}
 							if (Util.isWindows() && Files.isRegularFile(top)) {
 								top = to.resolve("jbang.jar.new");

--- a/src/main/java/dev/jbang/cli/JBangInstallation.java
+++ b/src/main/java/dev/jbang/cli/JBangInstallation.java
@@ -1,0 +1,70 @@
+package dev.jbang.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/** Locates the files belonging to the JBang installation currently running. */
+final class JBangInstallation {
+	static final String DIR_NAME = ".jbang";
+	static final String JAR_NAME = "jbang.jar";
+	static final List<String> SCRIPT_NAMES = Arrays.asList("jbang", "jbang.cmd", "jbang.ps1");
+
+	private final Path scriptsDir;
+	private final Path jarDir;
+
+	private JBangInstallation(Path scriptsDir, Path jarDir) {
+		this.scriptsDir = scriptsDir;
+		this.jarDir = jarDir;
+	}
+
+	static JBangInstallation find(Path location) {
+		if (!isJBangArtifact(location)) {
+			throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR,
+					"Could not determine JBang installation from " + location);
+		}
+
+		Path parent = location.getParent();
+		if (hasScripts(parent) && hasJar(parent)) {
+			return new JBangInstallation(parent, parent);
+		}
+		if (parent != null && DIR_NAME.equals(fileName(parent))) {
+			Path scriptsDir = parent.getParent();
+			if (hasScripts(scriptsDir) && hasJar(parent)) {
+				return new JBangInstallation(scriptsDir, parent);
+			}
+		}
+
+		throw new ExitException(BaseCommand.EXIT_GENERIC_ERROR,
+				"Could not find JBang installation files relative to " + location);
+	}
+
+	Path getScriptsDir() {
+		return scriptsDir;
+	}
+
+	Path getJarDir() {
+		return jarDir;
+	}
+
+	private static boolean isJBangArtifact(Path location) {
+		if (location == null || location.getFileName() == null) {
+			return false;
+		}
+		String name = location.getFileName().toString();
+		return name.endsWith(".jar") || name.contains("jbang.bin");
+	}
+
+	private static boolean hasScripts(Path dir) {
+		return dir != null && SCRIPT_NAMES.stream().map(dir::resolve).allMatch(Files::isRegularFile);
+	}
+
+	private static boolean hasJar(Path dir) {
+		return dir != null && Files.isRegularFile(dir.resolve(JAR_NAME));
+	}
+
+	private static String fileName(Path path) {
+		return path.getFileName() != null ? path.getFileName().toString() : "";
+	}
+}

--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 
 import org.aesh.command.CommandDefinition;
@@ -19,9 +18,9 @@ import dev.jbang.util.Util;
 @CommandDefinition(name = "wrapper", description = "Manage jbang wrapper for a folder.", groupCommands = {
 		Wrapper.WrapperInstall.class }, generateHelp = true)
 public class Wrapper extends BaseCommand {
-	public static final String DIR_NAME = ".jbang";
-	public static final String JAR_NAME = "jbang.jar";
-	public static final List<String> SCRIPT_NAMES = Arrays.asList("jbang", "jbang.cmd", "jbang.ps1");
+	public static final String DIR_NAME = JBangInstallation.DIR_NAME;
+	public static final String JAR_NAME = JBangInstallation.JAR_NAME;
+	public static final List<String> SCRIPT_NAMES = JBangInstallation.SCRIPT_NAMES;
 
 	@Override
 	public Integer doCall() {
@@ -48,23 +47,9 @@ public class Wrapper extends BaseCommand {
 				return EXIT_OK;
 			}
 			try {
-				Path jar = Util.getJarLocation();
-				String jarName = jar.getFileName().toString();
-				if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
-					throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't find JBang install location via " + jar);
-				}
-				Path parent = jar.getParent();
-				if (checkScripts(parent) && checkJar(parent)) {
-					copyScripts(parent, destPath);
-					copyJar(parent, destPath);
-				} else if (parent.getFileName().toString().equals(DIR_NAME)
-						&& checkScripts(parent.getParent())
-						&& checkJar(parent)) {
-					copyScripts(parent.getParent(), destPath);
-					copyJar(parent, destPath);
-				} else {
-					throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't find JBang wrapper files");
-				}
+				JBangInstallation installation = JBangInstallation.find(Util.getJarLocation());
+				copyScripts(installation.getScriptsDir(), destPath);
+				copyJar(installation.getJarDir(), destPath);
 				return EXIT_OK;
 			} catch (IOException e) {
 				throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't copy JBang wrapper scripts", e);

--- a/src/test/java/dev/jbang/cli/TestJBangInstallation.java
+++ b/src/test/java/dev/jbang/cli/TestJBangInstallation.java
@@ -1,0 +1,71 @@
+package dev.jbang.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestJBangInstallation {
+	@Test
+	void findsFlatInstallation(@TempDir Path dir) throws IOException {
+		createScripts(dir);
+		Path jar = Files.createFile(dir.resolve(Wrapper.JAR_NAME));
+
+		JBangInstallation installation = JBangInstallation.find(jar);
+
+		assertThat(installation.getScriptsDir(), equalTo(dir));
+		assertThat(installation.getJarDir(), equalTo(dir));
+	}
+
+	@Test
+	void findsWrapperInstallation(@TempDir Path dir) throws IOException {
+		createScripts(dir);
+		Path jarDir = Files.createDirectory(dir.resolve(Wrapper.DIR_NAME));
+		Path jar = Files.createFile(jarDir.resolve(Wrapper.JAR_NAME));
+
+		JBangInstallation installation = JBangInstallation.find(jar);
+
+		assertThat(installation.getScriptsDir(), equalTo(dir));
+		assertThat(installation.getJarDir(), equalTo(jarDir));
+	}
+
+	@Test
+	void acceptsNativeArtifacts(@TempDir Path dir) throws IOException {
+		createScripts(dir);
+		Files.createFile(dir.resolve(Wrapper.JAR_NAME));
+
+		for (String name : Arrays.asList("jbang.bin", "jbang.bin.exe", "jbang.bin-linux-x64",
+				"jbang.bin-windows-x64.exe")) {
+			JBangInstallation installation = JBangInstallation.find(Files.createFile(dir.resolve(name)));
+			assertThat(installation.getScriptsDir(), equalTo(dir));
+			assertThat(installation.getJarDir(), equalTo(dir));
+		}
+	}
+
+	@Test
+	void rejectsUnsupportedArtifact(@TempDir Path dir) throws IOException {
+		Path location = Files.createFile(dir.resolve("classes"));
+
+		assertThrows(ExitException.class, () -> JBangInstallation.find(location));
+	}
+
+	@Test
+	void rejectsIncompleteInstallation(@TempDir Path dir) throws IOException {
+		Path jar = Files.createFile(dir.resolve(Wrapper.JAR_NAME));
+
+		assertThrows(ExitException.class, () -> JBangInstallation.find(jar));
+	}
+
+	private static void createScripts(Path dir) throws IOException {
+		for (String name : Wrapper.SCRIPT_NAMES) {
+			Files.createFile(dir.resolve(name));
+		}
+	}
+}


### PR DESCRIPTION
  ## Summary

  `cli/App.java` contained a TODO noting duplicated JBang installation discovery logic in `Wrapper.java`.

  This PR introduces a shared `JBangInstallation` helper that:

  - locates the current JBang installation
  - supports flat and `.jbang` wrapper layouts
  - handles `.jar`, `.bin`, and `.bin.exe` artifacts
  - validates the required scripts and JAR
  - provides separate script and JAR directories

  `App` and `Wrapper` now use this helper while retaining their command-specific copy behavior.

  ## Testing

  ```shell
  ./gradlew test --tests "dev.jbang.cli.TestApp"
  ./gradlew test
  ./gradlew spotlessCheck
  ./gradlew build

  All tests and formatting checks pass.
