### PR TITLE
docs: Removed Duplicate Sentences from Document

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -15,9 +15,7 @@ endif::[]
 toc::[]
 
 To use `jbang` Java 8 is the minimum required version, however Java 17 or higher is recommended.
-To use `jbang` Java 8 is the minimum required version, however Java 17 or higher is recommended.
 
-Note: `jbang` will download and install `java` from Eclipse Temurin if no `java` is available.
 Note: `jbang` will download and install `java` from Eclipse Temurin if no `java` is available.
 
 There are multiple ways to install jbang. See below for all available options.


### PR DESCRIPTION
### Summary

While reading through the documentation, I noticed that the exact same sentence was included twice in immediate succession. This PR removes the duplicate sentence

### Changes
File modified: docs/modules/ROOT/pages/installation.adoc
Removed the redundant second instance of the sentence.

Fixes #2581
