### PR TITLE
fix: PowerShell quoting for special chars and -D property spacing in app install

### DIFF
--- a/src/it/java/dev/jbang/it/AppIT.java
+++ b/src/it/java/dev/jbang/it/AppIT.java
@@ -41,6 +41,34 @@ public class AppIT extends AbstractHelpBaseIT {
 					+ lineSeparator());
 	}
 
+	// Scenario: app install with -D should keep -D attached to property name
+	// Regression test for https://github.com/jbangdev/jbang/issues/2564
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	@Description("app install with -D should produce -Dkey=value (no space) in wrapper script")
+	public void shouldKeepSystemPropertyAttached() {
+		assertThat(shell("jbang app install --force --name jbang-itest-app-sysprop"
+				+ " -Djavafx.preview=true -Dcamel.jbang.version=4.21.0 printjvmargs.java"))
+			.succeeded();
+		assertThat(shell("$JBANG_DIR/bin/jbang-itest-app-sysprop"))
+			.succeeded()
+			.outContains("JVMARG:-Djavafx.preview=true")
+			.outContains("JVMARG:-Dcamel.jbang.version=4.21.0");
+	}
+
+	@Test
+	@EnabledOnOs(OS.WINDOWS)
+	@Description("app install with -D should produce -Dkey=value (no space) in wrapper scripts on Windows")
+	public void shouldKeepSystemPropertyAttachedWindows() {
+		assertThat(shell("jbang app install --force --name jbang-itest-app-sysprop"
+				+ " -Djavafx.preview=true -Dcamel.jbang.version=4.21.0 printjvmargs.java"))
+			.succeeded();
+		assertThat(shell("%JBANG_DIR%\\bin\\jbang-itest-app-sysprop.cmd"))
+			.succeeded()
+			.outContains("JVMARG:-Djavafx.preview=true")
+			.outContains("JVMARG:-Dcamel.jbang.version=4.21.0");
+	}
+
 	@Override
 	protected String commandName() {
 		return "app";

--- a/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
+++ b/src/main/java/dev/jbang/cli/DependencyInfoMixin.java
@@ -54,8 +54,7 @@ public class DependencyInfoMixin {
 		List<String> opts = new ArrayList<>();
 		if (properties != null) {
 			for (Map.Entry<String, String> e : properties.entrySet()) {
-				opts.add("-D");
-				opts.add(e.getKey() + "=" + e.getValue());
+				opts.add("-D" + e.getKey() + "=" + e.getValue());
 			}
 		}
 		if (dependencies != null) {

--- a/src/main/java/dev/jbang/util/CommandBuffer.java
+++ b/src/main/java/dev/jbang/util/CommandBuffer.java
@@ -24,7 +24,7 @@ public class CommandBuffer {
 	// cmdSafeChars = Pattern.compile("[^\\Q&()[]{}^=;!'+,`~<>|\\E]*");
 	static Pattern cmdSafeChars = Pattern.compile("[a-zA-Z0-9.,_+=:;@()-\\\\]*");
 	// TODO: Figure out what the real list of safe characters is for PowerShell
-	static Pattern pwrSafeChars = Pattern.compile("[a-zA-Z0-9.,_+=:@()\\\\-]*");
+	static Pattern pwrSafeChars = Pattern.compile("[a-zA-Z0-9_+=@\\\\-]*");
 	static Pattern shellSafeChars = Pattern.compile("[a-zA-Z0-9._+=:@%/-]*");
 
 	static Pattern cmdNeedQuotesChars = Pattern.compile("[\\Q&()[]{}^=;!'+,`~\\E]");

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -45,7 +45,7 @@ public class TestApp extends BaseTest {
 	private static final List<String> h2cmdContents = Arrays.asList("@echo off",
 			"jbang run com.h2database:h2:1.4.200 %*");
 	private static final List<String> h2ps1Contents = Collections.singletonList(
-			"jbang run com.h2database:h2:1.4.200 @args");
+			"jbang run 'com.h2database:h2:1.4.200' @args");
 
 	@Test
 	void testHasJBangSetup(@TempDir Path tempDir) throws IOException {

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -145,6 +145,33 @@ public class TestApp extends BaseTest {
 	}
 
 	@Test
+	void testAppInstallWithSystemProperty() throws Exception {
+		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
+		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "--force",
+				"--name=helloprops", "-Djavafx.preview=true", "-Dcamel.jbang.version=4.21.0-SNAPSHOT", src);
+		assertThat(result.err, containsString("Command installed: helloprops"));
+
+		String cwd = examplesTestFolder.getParent().toString();
+		Path shFile = Settings.getConfigBinDir().resolve(Util.isWindows() ? "helloprops.cmd" : "helloprops");
+		String content = String.join("\n", Files.readAllLines(shFile));
+		// -D must be joined with the property key (no space)
+		assertThat(content, containsString("-Djavafx.preview=true"));
+		assertThat(content, containsString("-Dcamel.jbang.version=4.21.0-SNAPSHOT"));
+		assertThat(content, not(containsString("-D javafx.preview")));
+		assertThat(content, not(containsString("-D camel.jbang.version")));
+
+		if (Util.isWindows()) {
+			// Also check ps1 script
+			Path ps1File = Settings.getConfigBinDir().resolve("helloprops.ps1");
+			String ps1Content = String.join("\n", Files.readAllLines(ps1File));
+			assertThat(ps1Content, containsString("-Djavafx.preview=true"));
+			assertThat(ps1Content, containsString("-Dcamel.jbang.version=4.21.0-SNAPSHOT"));
+			assertThat(ps1Content, not(containsString("-D javafx.preview")));
+			assertThat(ps1Content, not(containsString("-D camel.jbang.version")));
+		}
+	}
+
+	@Test
 	void testAppInstallFileExists() throws Exception {
 		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", src);

--- a/src/test/java/dev/jbang/util/TestCommandBuffer.java
+++ b/src/test/java/dev/jbang/util/TestCommandBuffer.java
@@ -39,6 +39,28 @@ public class TestCommandBuffer extends BaseTest {
 	}
 
 	@Test
+	void testCmdDoesNotEscapeDotAndComma() {
+		assertThat(CommandBuffer.escapeShellArgument("-Djavafx.preview=true", Util.Shell.cmd),
+				equalTo("-Djavafx.preview=true"));
+		assertThat(CommandBuffer.escapeShellArgument("abc,def", Util.Shell.cmd),
+				equalTo("abc,def"));
+	}
+
+	@Test
+	void testPowershellEscapesUnsafeChars() {
+		assertThat(CommandBuffer.escapeShellArgument("-Djavafx.preview=true", Util.Shell.powershell),
+				equalTo("'-Djavafx.preview=true'"));
+		assertThat(CommandBuffer.escapeShellArgument("abc,def", Util.Shell.powershell),
+				equalTo("'abc,def'"));
+		assertThat(CommandBuffer.escapeShellArgument("foo:bar", Util.Shell.powershell),
+				equalTo("'foo:bar'"));
+		assertThat(CommandBuffer.escapeShellArgument("foo;bar", Util.Shell.powershell),
+				equalTo("'foo;bar'"));
+		assertThat(CommandBuffer.escapeShellArgument("foo(bar)", Util.Shell.powershell),
+				equalTo("'foo(bar)'"));
+	}
+
+	@Test
 	@EnabledOnOs(OS.WINDOWS)
 	void testRunWinPS1() {
 		String out = CommandBuffer.of("abc def", "abc;def").shell(Util.Shell.powershell).asCommandLine();


### PR DESCRIPTION
turns out we had "bad" quoting rules on windows since 2020 :)

-Dwhatever.period=true breaks on powershell, works on cmd.exe 

and since 2024 our install scripts generated `-D x=y` instead of `-Dx=y` causing issues too.

This fixes both.


### 1. PowerShell safe chars too permissive (#2584)

`pwrSafeChars` included `.,;:()` as safe characters, inherited from original best-guess allowlist (47b9f342, 2020). These characters cause issues in PowerShell — args like `-Djavafx.preview=true` were passed through unquoted and got mangled.

**Fix:** Remove `.,;:()` from `pwrSafeChars`. Args containing these chars now get single-quoted in PowerShell (e.g. `'-Djavafx.preview=true'`). CMD is unchanged — these chars are safe there.

### 2. `app install -Dkey=value` splits `-D` from property (#2564)

`DependencyInfoMixin.opts()` emitted `-D` and `key=value` as two separate list elements. The generated wrapper script ended up with `-D camel.jbang.version=4.21.0` (space-separated), which `jbang run` then rejects with *"Option -D, must be part of a property"*.

**Fix:** Join them: `opts.add("-D" + key + "=" + value)`.

## Tests added

- **Unit:** `TestCommandBuffer` — PowerShell escapes `.,;:()`, CMD does not
- **Unit:** `TestApp.testAppInstallWithSystemProperty` — verifies generated scripts contain `-Dkey=value` (no space)
- **Integration:** `AppIT.shouldKeepSystemPropertyAttached` — end-to-end: `app install -Djavafx.preview=true` runs and JVM receives the property intact

Fixes #2584
Fixes #2564