### PR TITLE
fix: upgrade Quarkus version to resolve JBoss Threads library warning…

### DIFF
--- a/src/main/resources/init-qcli.java.qute
+++ b/src/main/resources/init-qcli.java.qute
@@ -1,8 +1,8 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//JAVA 17+
+//JAVA 21+
 // Update the Quarkus version to what you want here or run jbang with
 // `-Dquarkus.version=<version>` to override it.
-//DEPS io.quarkus:quarkus-bom:$\{quarkus.version:3.15.1\}@pom
+//DEPS io.quarkus:quarkus-bom:$\{quarkus.version:3.37.2\}@pom
 //DEPS io.quarkus:quarkus-picocli
 {#for dep in dependencies.orEmpty}
 //DEPS {dep}

--- a/src/main/resources/init-qcli.java.qute
+++ b/src/main/resources/init-qcli.java.qute
@@ -1,5 +1,5 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//JAVA 21+
+//JAVA 17+
 // Update the Quarkus version to what you want here or run jbang with
 // `-Dquarkus.version=<version>` to override it.
 //DEPS io.quarkus:quarkus-bom:$\{quarkus.version:3.37.2\}@pom


### PR DESCRIPTION
When creating Quarkus test program using command `jbang init -t qcli test.java`, a test program is created that uses an older version of Quarkus that when used with Java 26 produces JBoss Threads library warning:

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by org.jboss.threads.JBossExecutors (file:/home/wfouche/.m2/repository/org/jboss/threads/jboss-threads/3.6.1.Final/jboss-threads-3.6.1.Final.jar)
WARNING: Please consider reporting this to the maintainers of class org.jboss.threads.JBossExecutors
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

The issue is resolved by this PR by using the latest released version of Quarkus.
