### PR TITLE
fix: build markdown scripts with main methods

### DIFF
--- a/src/main/java/dev/jbang/source/sources/MarkdownSource.java
+++ b/src/main/java/dev/jbang/source/sources/MarkdownSource.java
@@ -12,6 +12,9 @@ import dev.jbang.cli.BaseCommand;
 import dev.jbang.cli.ExitException;
 import dev.jbang.resources.ResourceRef;
 import dev.jbang.resources.resolvers.LiteralScriptResourceResolver;
+import dev.jbang.source.BuildContext;
+import dev.jbang.source.Builder;
+import dev.jbang.source.CmdGeneratorBuilder;
 import dev.jbang.source.Source;
 import dev.jbang.util.Util;
 
@@ -24,6 +27,11 @@ public class MarkdownSource extends JshSource {
 	@Override
 	public @NonNull Type getType() {
 		return Type.markdown;
+	}
+
+	@Override
+	public Builder<CmdGeneratorBuilder> getBuilder(BuildContext ctx) {
+		return ctx.getProject().isJShell() ? super.getBuilder(ctx) : new JavaAppBuilder(ctx);
 	}
 
 	public static Source create(ResourceRef resourceRef, Function<String, String> replaceProperties) {

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -241,6 +241,34 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testMarkdownWithMainMethod() throws IOException {
+		Path readme = jbangTempDir.resolve("readme.md");
+		writeString(readme,
+				"```java\nclass Readme {\n    public static void main(String... args) {\n        System.out.println(\"Hello\");\n    }\n}\n```\n");
+
+		Run run = JBang.parseCommand("run", readme.toString());
+		Project prj = run.createProjectBuilderForRun().build(readme.toString());
+		CmdGeneratorBuilder genb = Project.codeBuilder(BuildContext.forProject(prj)).build();
+
+		String result = run.updateGeneratorForRun(genb).build().generate();
+
+		assertThat(result, matchesPattern("^.*java(.exe(\\^\\\")?)? .*$"));
+		assertThat(result, containsString("Readme"));
+	}
+
+	@Test
+	void testMarkdownWithUnnamedMainMethod() throws Exception {
+		assumeTrue(JavaUtil.getCurrentMajorJavaVersion() >= 25);
+		Path readme = jbangTempDir.resolve("readme.md");
+		writeString(readme,
+				"```java\nvoid main() {\n    System.out.println(\"Hello unnamed\");\n}\n```\n");
+
+		CaptureResult<Integer> result = checkedRun(readme.toString());
+
+		assertThat(result.out, containsString("Hello unnamed"));
+	}
+
+	@Test
 	void testMarkdownWindows() throws IOException {
 		Path readmeFileOrg = examplesTestFolder.resolve("readme.md");
 		String readmeText = Util.readString(readmeFileOrg);


### PR DESCRIPTION
Fixes #2575.\n\nMarkdown sources already transform to a cached .java file when a main method is detected. This makes MarkdownSource use the Java build pipeline for those transformed .java sources while preserving JShell behavior for normal markdown snippets.\n\nTests:\n- ./gradlew test --tests "dev.jbang.cli.TestRun.testMarkdownWithMainMethod" --tests "dev.jbang.cli.TestRun.testMarkdownWithUnnamedMainMethod" --tests "dev.jbang.cli.TestRun.testMarkdown"\n- ./gradlew spotlessApply spotlessCheck