### PR TITLE
chore: upgrade jandex from 2.2.3 to 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ dependencies {
 
 	implementation "org.slf4j:slf4j-nop:1.7.36"
 	implementation "org.slf4j:jcl-over-slf4j:1.7.36"
-	implementation "org.jboss:jandex:2.2.3.Final"
+	implementation "io.smallrye:jandex:3.6.0"
 
 	implementation "eu.maveniverse.maven.mima:context:2.4.36"
 	runtimeOnly    "eu.maveniverse.maven.mima.runtime:standalone-static:2.4.36"


### PR DESCRIPTION
Upgrades Jandex from `org.jboss:jandex:2.2.3.Final` to `io.smallrye:jandex:3.6.0`.

- Maven coordinates changed from `org.jboss:jandex` to `io.smallrye:jandex`
- Java package (`org.jboss.jandex`) is unchanged — no source changes needed
- Jandex 3.x still targets Java 8 (`maven.compiler.source=1.8`)
- All tests pass (840 tests, 1 pre-existing unrelated failure)

Replaces #2498 (Renovate bumped version but kept old coordinates).