### PR TITLE
build: remove unused task-tree plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
 	id 'org.gradle.crypto.checksum' version '1.4.0'
 	id "com.diffplug.spotless" version "8.6.0"
 	id 'com.github.gmazzo.buildconfig' version "3.1.0"
-	id "com.dorongold.task-tree" version "2.1.1"
 	id "com.geoffgranum.gradle-conventional-changelog" version "0.3.1"
 	id "org.asciidoctor.jvm.convert" version "3.3.2"
 	id "org.ajoberstar.grgit" version "4.1.1"


### PR DESCRIPTION
The `com.dorongold.task-tree` plugin was added as a drive-by in a 2020 commit and has never been referenced in CI, build scripts, or documentation. It's a dev convenience for `gradle taskTree` that nobody uses.

Removes it instead of upgrading it two major versions (2.1.1 → 4.0.1).

Closes #2493