### PR TITLE
fix: update aesh to 3.16.5 to fix #2587 and #2589

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 def allureVersion = '2.29.1'
 def aspectJVersion = '1.9.25'
 def assertjVersion = '3.27.7'
-def aeshVersion = '3.16.4'
+def aeshVersion = '3.16.5'
 def devkitmanVersion = '0.4.9'
 def junitBomVersion = '5.14.4'
 def testcontainersVersion = '2.0.2'

--- a/src/test/java/dev/jbang/cli/TestAeshParsing.java
+++ b/src/test/java/dev/jbang/cli/TestAeshParsing.java
@@ -341,6 +341,76 @@ class TestAeshParsing extends BaseTest {
 		assertThat(run.runMixin.debugString, is(nullValue()));
 	}
 
+	// --- #2587: --runtime-option with space separator ---
+
+	@Test
+	void testRuntimeOptionWithSpaceSeparator() {
+		// --runtime-option -Dstdout.encoding=UTF-8 should work (space between option
+		// and value)
+		Run run = JBang.parseCommand("run", "--runtime-option", "-Dstdout.encoding=UTF-8", "test.java");
+		assertThat(run.runMixin.javaRuntimeOptions, hasSize(1));
+		assertThat(run.runMixin.javaRuntimeOptions, contains("-Dstdout.encoding=UTF-8"));
+	}
+
+	@Test
+	void testMultipleRuntimeOptionsWithSpaceSeparator() {
+		// Multiple --runtime-option with space should all be parsed
+		Run run = JBang.parseCommand("run",
+				"--runtime-option", "-Dstdout.encoding=UTF-8",
+				"--runtime-option", "-Dpython.console.encoding=UTF-8",
+				"test.java");
+		assertThat(run.runMixin.javaRuntimeOptions, hasSize(2));
+		assertThat(run.runMixin.javaRuntimeOptions,
+				contains("-Dstdout.encoding=UTF-8", "-Dpython.console.encoding=UTF-8"));
+	}
+
+	@Test
+	void testRuntimeOptionShortWithSpaceSeparator() {
+		// -R -Dkey=value (space between -R and value) should work
+		Run run = JBang.parseCommand("run", "-R", "-Dstdout.encoding=UTF-8", "test.java");
+		assertThat(run.runMixin.javaRuntimeOptions, hasSize(1));
+		assertThat(run.runMixin.javaRuntimeOptions, contains("-Dstdout.encoding=UTF-8"));
+	}
+
+	// --- #2589: --deps comma-separated via DefaultValueProvider ---
+
+	@Test
+	void testDepsDefaultValueProviderCommaSeparated() throws IOException {
+		// When run.deps is set in config with comma-delimited deps,
+		// they should be split into separate list items (not treated as one GAV)
+		String config = "run.deps = org.foo:bar:1.0,org.baz:qux:2.0\n";
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
+		Configuration.instance(null);
+
+		Run run = JBang.parseCommand("run", "test.java");
+		assertThat(run.dependencyInfoMixin.dependencies, hasSize(2));
+		assertThat(run.dependencyInfoMixin.dependencies,
+				contains("org.foo:bar:1.0", "org.baz:qux:2.0"));
+	}
+
+	@Test
+	void testDepsDefaultValueProviderSingleDep() throws IOException {
+		// Single dep from config should still work
+		String config = "run.deps = org.foo:bar:1.0\n";
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
+		Configuration.instance(null);
+
+		Run run = JBang.parseCommand("run", "test.java");
+		assertThat(run.dependencyInfoMixin.dependencies, hasSize(1));
+		assertThat(run.dependencyInfoMixin.dependencies, contains("org.foo:bar:1.0"));
+	}
+
+	@Test
+	void testDepsExplicitOverridesDefaultValueProvider() throws IOException {
+		// Explicit --deps should override config defaults
+		String config = "run.deps = org.foo:bar:1.0,org.baz:qux:2.0\n";
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
+		Configuration.instance(null);
+
+		Run run = JBang.parseCommand("run", "--deps", "org.other:lib:3.0", "test.java");
+		assertThat(run.dependencyInfoMixin.dependencies, hasItem("org.other:lib:3.0"));
+	}
+
 	// --- Subcommand list consistency ---
 
 	@Test


### PR DESCRIPTION
## Summary

Update aesh from 3.16.4 to 3.16.5 to fix two regressions introduced with the aesh migration.

### Fixes #2587: `--runtime-option` with space separator
`--runtime-option -Dfoo=bar` (space between option and value) was rejected with *"no value was given"* since 0.139.3. The `=` syntax (`-R=-Dfoo=bar`) still worked.

### Fixes #2589: comma-delimited deps from config
`run.deps=org.foo:bar:1.0,org.baz:qux:2.0` in jbang.properties was passed as a single GAV string instead of being split by `valueSeparator` when coming through `DefaultValueProvider`. CLI `--deps a,b` was unaffected.

Both fixed upstream in aesh 3.16.5 (aeshell/aesh#551).

## Tests added
- `testRuntimeOptionWithSpaceSeparator`
- `testMultipleRuntimeOptionsWithSpaceSeparator`
- `testRuntimeOptionShortWithSpaceSeparator`
- `testDepsDefaultValueProviderCommaSeparated`
- `testDepsDefaultValueProviderSingleDep`
- `testDepsExplicitOverridesDefaultValueProvider`

All 6 fail with aesh 3.16.4, all pass with 3.16.5. Full test suite (846 tests) passes with no regressions.