### PR TITLE
fix: migrate remaining EXIT_EXECUTE references to ExitException

### DIFF
--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -483,7 +483,7 @@ public class App extends BaseCommand {
 			}
 			if (!cmd.isEmpty()) {
 				System.out.println(cmd);
-				return EXIT_EXECUTE;
+				return ExitException.EXIT_EXECUTE;
 			} else {
 				return EXIT_OK;
 			}

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -513,7 +513,7 @@ public class Jdk extends BaseCommand {
 				}
 				Util.verboseMsg("Executing in Java environment: " + fullCmd);
 				System.out.println(fullCmd);
-				return EXIT_EXECUTE;
+				return ExitException.EXIT_EXECUTE;
 			}
 			return EXIT_OK;
 		}

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -113,7 +113,7 @@ public class Run extends BaseBuildCommand {
 		Util.verboseMsg("run: " + cmdline);
 		realOut.println(cmdline);
 
-		return EXIT_EXECUTE;
+		return ExitException.EXIT_EXECUTE;
 	}
 
 	void buildAgents(BuildContext ctx) throws IOException {

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -66,7 +66,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -90,7 +90,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "--native", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -103,7 +103,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: kubectl-example"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -117,7 +117,7 @@ public class TestApp extends BaseTest {
 				"https://github.com/jbangdev/k8s-cli-java/blob/jbang/kubectl-example");
 		assertThat(result.err, containsString("Command installed: kubectl-example"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -130,7 +130,7 @@ public class TestApp extends BaseTest {
 				"com.h2database:h2:1.4.200");
 		assertThat(result.err, containsString("Command installed: h2"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -178,7 +178,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -193,7 +193,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -239,7 +239,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 			assertThat(Settings.getConfigBinDir().resolve("hello.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("hello.ps1").toFile(), anExistingFile());
 		} else {
@@ -254,7 +254,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -269,7 +269,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
 			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
 		}
@@ -284,7 +284,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "apptest");
 		assertThat(result.err, containsString("Command installed: apptest"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {
@@ -302,7 +302,7 @@ public class TestApp extends BaseTest {
 		CaptureResult<Integer> result = checkedRun("app", "install", "--no-build", "apptest@testrepo");
 		assertThat(result.err, containsString("Command installed: apptest"));
 		if (Util.isWindows()) {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import dev.jbang.BaseTest;
 import dev.jbang.Cache;
+import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.util.JavaUtil;
 import dev.jbang.util.Util;
@@ -319,7 +320,7 @@ public class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(withProviders("jdk", "exec", "java", "-version"));
 
-		assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+		assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		assertThat(result.normalizedOut(),
 				equalTo(expectedExecCommand(Util.getShell(), Settings.getDefaultJdkDir(), "java", "-version") + "\n"));
 	}
@@ -331,7 +332,7 @@ public class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(withProviders("jdk", "exec", "java", "-version"));
 
-		assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+		assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		assertThat(result.normalizedOut(),
 				equalTo(expectedExecCommand(Util.Shell.bash, Settings.getDefaultJdkDir(), "java", "-version") + "\n"));
 	}
@@ -343,7 +344,7 @@ public class TestJdk extends BaseTest {
 
 		CaptureResult<Integer> result = checkedRun(withProviders("jdk", "exec", "java", "-version"));
 
-		assertThat(result.result, equalTo(BaseCommand.EXIT_EXECUTE));
+		assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		assertThat(result.normalizedOut(),
 				equalTo(expectedExecCommand(Util.Shell.powershell, Settings.getDefaultJdkDir(), "java", "-version")
 						+ "\n"));

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -3,7 +3,7 @@ package dev.jbang.cli;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static dev.jbang.cli.BaseCommand.EXIT_EXECUTE;
+import static dev.jbang.ExitException.EXIT_EXECUTE;
 import static dev.jbang.source.Project.ATTR_AGENT_CLASS;
 import static dev.jbang.source.Project.ATTR_PREMAIN_CLASS;
 import static dev.jbang.util.JavaUtil.defaultJdkManager;


### PR DESCRIPTION
BaseCommand.EXIT_EXECUTE was deprecated in #2602 in favor of ExitException.EXIT_EXECUTE but the existing usages were not updated, causing deprecation warnings during compilation.

This migrates all remaining references in source and test code:
- App.java, Jdk.java, Run.java — `return EXIT_EXECUTE` → `return ExitException.EXIT_EXECUTE`
- TestApp.java, TestJdk.java, TestRun.java — assertions and imports updated