### PR TITLE
fix: avoid misleading messages during update

### DIFF
--- a/src/main/java/dev/jbang/util/VersionChecker.java
+++ b/src/main/java/dev/jbang/util/VersionChecker.java
@@ -39,10 +39,10 @@ public class VersionChecker {
 
 	/**
 	 * Very specialized function used to check if jbang can be updated. It returns
-	 * `true` when we're running a managed jbang and either there is a newer version
-	 * or `checkForUpdate` was disabled. In all other cases it will return `false`
-	 * and informing the user that either jbang is already up-to-date or telling
-	 * them how to update jbang themselves (if `checkForUpdate` was disabled).
+	 * `true` when we're running a managed jbang and there is a newer version
+	 * available. In all other cases it will return `false` and inform the user
+	 * that either jbang is already up-to-date or tell them how to update jbang
+	 * themselves (if not a managed install).
 	 * 
 	 * @param checkForUpdate do we check for a new version or not?
 	 * @return do we update jbang or not?
@@ -51,9 +51,10 @@ public class VersionChecker {
 		try {
 			if (Util.runningManagedJBang()) {
 				String latestVersion = retrieveLatestVersionAsync().get();
-				if (!checkForUpdate || isNewer(latestVersion)) {
+				if (isNewer(latestVersion)) {
+					informed = true;
 					return true;
-				} else if (checkForUpdate) {
+				} else {
 					inform(latestVersion, false);
 				}
 			} else {


### PR DESCRIPTION
This fixes issue #2609.

### Problem

When `jbang version --update` is executed, the update flow bypasses the normal version comparison and later triggers the standard version notification. As a result, users are told to run `jbang version --update` even though they just did.

Additionally, when JBang is already on the latest version, the command unnecessarily attempts an update instead of informing the user that it is already up to date.

### Fix

This change always compares the installed version with the latest version, reports when the installation is already up to date, and suppresses the redundant notification after a successful update.

### Result

- No misleading "Run `jbang version --update`" message after an update.
- Users are informed when they already have the latest version.
- Existing version-check behavior remains unchanged.

Fixes #2609