### PR TITLE
fix: support runtime locales in native image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -845,6 +845,7 @@ task nativeImage(type: Exec) {
 
 				"--enable-https",
 				"--exact-reachability-metadata", // https://www.graalvm.org/latest/reference-manual/native-image/metadata/ & https://github.com/oracle/graal/issues/7962
+				"-H:+IncludeAllLocales", // JBang binaries run with the user's locale, not necessarily the build locale
 				"--enable-url-protocols=jar", // to allow urlclassloader to scan file. https://github.com/oracle/graal/issues/1956 https://www.graalvm.org/jdk25/reference-manual/native-image/dynamic-features/URLProtocols/
 				"-H:-ParseRuntimeOptions" // so -Dkey=value will continue to be passed to jbang
 

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -565,7 +565,14 @@ public class Util {
 			Duration d = Duration.between(startTime, Instant.now());
 			long s = d.getSeconds();
 			long n = d.minus(s, ChronoUnit.SECONDS).toMillis();
-			return String.format("[jbang] [%d:%03d] ", s, n);
+			StringBuilder header = new StringBuilder("[jbang] [").append(s).append(':');
+			if (n < 100) {
+				header.append('0');
+			}
+			if (n < 10) {
+				header.append('0');
+			}
+			return header.append(n).append("] ").toString();
 		} else {
 			return "[jbang] ";
 		}

--- a/src/test/java/dev/jbang/util/TestUtil.java
+++ b/src/test/java/dev/jbang/util/TestUtil.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,6 +23,17 @@ import dev.jbang.catalog.Catalog;
 public class TestUtil extends BaseTest {
 	public static void clearSettingsCaches() {
 		Catalog.clearCache();
+	}
+
+	@Test
+	void testMessageHeaderIsLocaleIndependent() {
+		Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("ar"));
+			assertTrue(Util.getMsgHeader().matches("\\[jbang\\] \\[[0-9]+:[0-9]{3}\\] "));
+		} finally {
+			Locale.setDefault(defaultLocale);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #2610.

Native JBang executables could fail under locales not included at build time. Verbose output used `String.format()` for elapsed-time headers, causing GraalVM to load missing locale-specific CLDR data and throw a `MissingReflectionRegistrationError`.

This PR:

- Includes all locales in distributed native images using `-H:+IncludeAllLocales`.
- Makes verbose message-header formatting locale-independent.
- Adds regression coverage using an Arabic default locale.

Validation:

- `./gradlew test --tests "dev.jbang.util.TestUtil" -x createChecksum`
- `./gradlew spotlessCheck`
- `git diff --check`