### PR TITLE
fix: honor JBANG_USE_NATIVE when updating

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -600,7 +600,7 @@ These are read by the scripts themselves before Java or JBang's Java code is inv
 
 | `JBANG_USE_NATIVE`
 | `false`
-| When set to `true`, use the native binary (`jbang.bin` / `jbang.bin.exe`) instead of the JAR. The `jbang version --update` command also downloads and installs the native package matching the current platform.
+| When set to `true`, use the native binary (`jbang.bin` / `jbang.bin.exe`) instead of the JAR. The `jbang version --update` command downloads and installs the native package matching the current platform when this variable is `true` or JBang is already running as a native executable.
 
 | `JBANG_NO_VERSION_CHECK`
 | _(unset)_

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -600,7 +600,7 @@ These are read by the scripts themselves before Java or JBang's Java code is inv
 
 | `JBANG_USE_NATIVE`
 | `false`
-| When set to `true`, use the native binary (`jbang.bin` / `jbang.bin.exe`) instead of the JAR.
+| When set to `true`, use the native binary (`jbang.bin` / `jbang.bin.exe`) instead of the JAR. The `jbang version --update` command also downloads and installs the native package matching the current platform.
 
 | `JBANG_NO_VERSION_CHECK`
 | _(unset)_

--- a/src/main/java/dev/jbang/Settings.java
+++ b/src/main/java/dev/jbang/Settings.java
@@ -25,6 +25,7 @@ public class Settings {
 
 	public static final String ENV_DEFAULT_JAVA_VERSION = "JBANG_DEFAULT_JAVA_VERSION";
 	public static final String ENV_NO_VERSION_CHECK = "JBANG_NO_VERSION_CHECK";
+	public static final String ENV_USE_NATIVE = "JBANG_USE_NATIVE";
 
 	public static final int DEFAULT_JAVA_VERSION = 17;
 	public static final int DEFAULT_ALPINE_JAVA_VERSION = 16;

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -63,7 +63,7 @@ public class App extends BaseCommand {
 
 	@CommandDefinition(name = "install", description = "Install a script as a command.", generateHelp = true)
 	public static class AppInstall extends BaseBuildCommand {
-		private static final String jbangUrl = "https://www.jbang.dev/releases/latest/download/jbang.zip";
+		private static final String jbangDownloadBaseUrl = "https://www.jbang.dev/releases/latest/download/";
 
 		@Mixin
 		RunMixin runMixin;
@@ -214,6 +214,7 @@ public class App extends BaseCommand {
 		public static boolean installJBang(boolean force) throws IOException {
 			Path binDir = Settings.getConfigBinDir();
 			boolean managedJBang = Files.exists(binDir.resolve("jbang.jar"));
+			boolean useNative = Boolean.parseBoolean(System.getenv(Settings.ENV_USE_NATIVE));
 
 			if (!force && (managedJBang || Util.searchPath("jbang") != null)) {
 				Util.infoMsg("jbang is already available, re-run with --force to install anyway.");
@@ -225,13 +226,13 @@ public class App extends BaseCommand {
 					Util.withCacheEvict(() -> {
 						// Download JBang and unzip to ~/.jbang/bin/
 						Util.infoMsg("Downloading and installing jbang...");
-						Path zipFile = NetUtil.downloadAndCacheFile(jbangUrl);
+						Path zipFile = NetUtil.downloadAndCacheFile(getJBangUrl(useNative));
 						Path urlsDir = Settings.getCacheDir(Cache.CacheClass.urls);
 						Util.deletePath(urlsDir.resolve("jbang"), true);
 						UnpackUtil.unpack(zipFile, urlsDir);
 						App.deleteCommandFiles("jbang");
 						Path fromDir = urlsDir.resolve("jbang").resolve("bin");
-						copyJBangFiles(fromDir, binDir);
+						copyJBangFiles(fromDir, binDir, useNative);
 						return 0;
 					});
 				} else {
@@ -245,7 +246,7 @@ public class App extends BaseCommand {
 					if (fromDir.endsWith(".jbang")) {
 						fromDir = fromDir.getParent();
 					}
-					copyJBangFiles(fromDir, binDir);
+					copyJBangFiles(fromDir, binDir, useNative);
 				}
 			} else {
 				Util.infoMsg("jbang is already installed.");
@@ -253,9 +254,34 @@ public class App extends BaseCommand {
 			return true;
 		}
 
-		private static void copyJBangFiles(Path from, Path to) throws IOException {
+		static String getJBangUrl(boolean useNative) {
+			return jbangDownloadBaseUrl + (useNative ? "jbang-" + getNativePlatform() + ".zip" : "jbang.zip");
+		}
+
+		static String getNativeBinaryName() {
+			String name = "jbang.bin-" + getNativePlatform();
+			return Util.isWindows() ? name + ".exe" : name;
+		}
+
+		private static String getNativePlatform() {
+			String os = Util.getOS().name();
+			if (os.equals("alpine_linux")) {
+				os = "linux";
+			}
+			String arch = Util.getArch().name();
+			if (arch.equals("arm64")) {
+				arch = "aarch64";
+			}
+			return os + "-" + arch;
+		}
+
+		static void copyJBangFiles(Path from, Path to, boolean useNative) throws IOException {
 			to.toFile().mkdirs();
-			Stream.of("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar")
+			Stream<String> files = Stream.of("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar");
+			if (useNative) {
+				files = Stream.concat(files, Stream.of(getNativeBinaryName()));
+			}
+			files
 				.map(Paths::get)
 				.forEach(f -> {
 					try {
@@ -268,6 +294,9 @@ public class App extends BaseCommand {
 							if (Util.isWindows() && Files.isRegularFile(top)) {
 								top = to.resolve("jbang.jar.new");
 							}
+						} else if (Util.isWindows() && f.toString().equals(getNativeBinaryName())
+								&& Files.isRegularFile(top)) {
+							top = to.resolve(f.toString() + ".new");
 						}
 						Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
 								StandardCopyOption.COPY_ATTRIBUTES);

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -37,6 +37,7 @@ import dev.jbang.devkitman.Jdk;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
 import dev.jbang.util.CommandBuffer;
+import dev.jbang.util.JavaUtil;
 import dev.jbang.util.NetUtil;
 import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
@@ -214,7 +215,7 @@ public class App extends BaseCommand {
 		public static boolean installJBang(boolean force) throws IOException {
 			Path binDir = Settings.getConfigBinDir();
 			boolean managedJBang = Files.exists(binDir.resolve("jbang.jar"));
-			boolean useNative = Boolean.parseBoolean(System.getenv(Settings.ENV_USE_NATIVE));
+			boolean useNative = shouldUseNative(JavaUtil.inNativeImage());
 
 			if (!force && (managedJBang || Util.searchPath("jbang") != null)) {
 				Util.infoMsg("jbang is already available, re-run with --force to install anyway.");
@@ -252,6 +253,10 @@ public class App extends BaseCommand {
 				Util.infoMsg("jbang is already installed.");
 			}
 			return true;
+		}
+
+		static boolean shouldUseNative(boolean runningNative) {
+			return runningNative || Boolean.parseBoolean(System.getenv(Settings.ENV_USE_NATIVE));
 		}
 
 		static String getJBangUrl(boolean useNative) {

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -215,7 +215,7 @@ public class App extends BaseCommand {
 		public static boolean installJBang(boolean force) throws IOException {
 			Path binDir = Settings.getConfigBinDir();
 			boolean managedJBang = Files.exists(binDir.resolve("jbang.jar"));
-			boolean useNative = shouldUseNative(JavaUtil.inNativeImage());
+			boolean useNative = shouldUseNative();
 
 			if (!force && (managedJBang || Util.searchPath("jbang") != null)) {
 				Util.infoMsg("jbang is already available, re-run with --force to install anyway.");
@@ -255,8 +255,8 @@ public class App extends BaseCommand {
 			return true;
 		}
 
-		static boolean shouldUseNative(boolean runningNative) {
-			return runningNative || Boolean.parseBoolean(System.getenv(Settings.ENV_USE_NATIVE));
+		static boolean shouldUseNative() {
+			return JavaUtil.inNativeImage() || Boolean.parseBoolean(System.getenv(Settings.ENV_USE_NATIVE));
 		}
 
 		static String getJBangUrl(boolean useNative) {

--- a/src/main/scripts/jbang.cmd
+++ b/src/main/scripts/jbang.cmd
@@ -12,6 +12,11 @@ rem detect architecture for platform-specific binary lookup
 set "jbang_arch=x64"
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" set "jbang_arch=aarch64"
 
+if exist "%~dp0jbang.bin-windows-%jbang_arch%.exe.new" (
+  copy /y "%~dp0jbang.bin-windows-%jbang_arch%.exe.new" "%~dp0jbang.bin-windows-%jbang_arch%.exe" > nul 2>&1
+  del /f /q "%~dp0jbang.bin-windows-%jbang_arch%.exe.new"
+)
+
 rem resolve native binary or jar path from script location
 set binaryPath=
 set jarPath=

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -128,6 +128,11 @@ function Invoke-JBang {
 # detect architecture for platform-specific binary lookup
 $jbang_arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::Arm64) { "aarch64" } else { "x64" }
 
+$nativeUpdatePath = "$PSScriptRoot\jbang.bin-windows-${jbang_arch}.exe.new"
+if (Test-Path $nativeUpdatePath) {
+  Move-Item -Path $nativeUpdatePath -Destination "$PSScriptRoot\jbang.bin-windows-${jbang_arch}.exe" -Force
+}
+
 # resolve native binary or jar path from script location
 $binaryPath=""
 $jarPath=""

--- a/src/test/java/dev/jbang/cli/AbstractScriptTest.java
+++ b/src/test/java/dev/jbang/cli/AbstractScriptTest.java
@@ -196,8 +196,8 @@ abstract class AbstractScriptTest {
 
 	/**
 	 * Returns a base environment map for bash tests with JBANG_DIR,
-	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. JAVA_HOME is removed.
-	 * Subclasses should add their specific env vars on top.
+	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. Native mode is disabled and
+	 * JAVA_HOME is removed. Subclasses should add their specific env vars on top.
 	 */
 	protected Map<String, String> baseBashEnv(String suffix) {
 		Path jbdir = tempSubDir("jbdir-" + suffix);
@@ -206,14 +206,15 @@ abstract class AbstractScriptTest {
 		env.put("JBANG_DIR", jbdir.toString());
 		env.put("JBANG_CACHE_DIR", tdir.toString());
 		env.put("JBANG_NO_VERSION_CHECK", "true");
+		env.put("JBANG_USE_NATIVE", "false");
 		env.remove("JAVA_HOME");
 		return env;
 	}
 
 	/**
 	 * Returns a base environment map for PowerShell tests with JBANG_DIR,
-	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. JAVA_HOME is removed.
-	 * Subclasses should add their specific env vars on top.
+	 * JBANG_CACHE_DIR, and JBANG_NO_VERSION_CHECK set. Native mode is disabled and
+	 * JAVA_HOME is removed. Subclasses should add their specific env vars on top.
 	 */
 	protected Map<String, String> basePsEnv(String suffix) {
 		Path jbdir = tempSubDir("jbdir-" + suffix);
@@ -222,6 +223,7 @@ abstract class AbstractScriptTest {
 		env.put("JBANG_DIR", jbdir.toString());
 		env.put("JBANG_CACHE_DIR", tdir.toString());
 		env.put("JBANG_NO_VERSION_CHECK", "true");
+		env.put("JBANG_USE_NATIVE", "false");
 		env.remove("JAVA_HOME");
 		return env;
 	}

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -49,6 +49,16 @@ public class TestApp extends BaseTest {
 			"jbang run 'com.h2database:h2:1.4.200' @args");
 
 	@Test
+	void testNativeUpdateSelection() {
+		environmentVariables.clear(Settings.ENV_USE_NATIVE);
+		assertThat(App.AppInstall.shouldUseNative(false), is(false));
+		assertThat(App.AppInstall.shouldUseNative(true), is(true));
+
+		environmentVariables.set(Settings.ENV_USE_NATIVE, "true");
+		assertThat(App.AppInstall.shouldUseNative(false), is(true));
+	}
+
+	@Test
 	void testJBangUpdateUrlMatchesRuntime() {
 		assertThat(App.AppInstall.getJBangUrl(false),
 				equalTo("https://www.jbang.dev/releases/latest/download/jbang.zip"));

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -51,11 +51,10 @@ public class TestApp extends BaseTest {
 	@Test
 	void testNativeUpdateSelection() {
 		environmentVariables.clear(Settings.ENV_USE_NATIVE);
-		assertThat(App.AppInstall.shouldUseNative(false), is(false));
-		assertThat(App.AppInstall.shouldUseNative(true), is(true));
+		assertThat(App.AppInstall.shouldUseNative(), is(false));
 
 		environmentVariables.set(Settings.ENV_USE_NATIVE, "true");
-		assertThat(App.AppInstall.shouldUseNative(false), is(true));
+		assertThat(App.AppInstall.shouldUseNative(), is(true));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -49,6 +49,35 @@ public class TestApp extends BaseTest {
 			"jbang run 'com.h2database:h2:1.4.200' @args");
 
 	@Test
+	void testJBangUpdateUrlMatchesRuntime() {
+		assertThat(App.AppInstall.getJBangUrl(false),
+				equalTo("https://www.jbang.dev/releases/latest/download/jbang.zip"));
+		assertThat(App.AppInstall.getJBangUrl(true),
+				equalTo("https://www.jbang.dev/releases/latest/download/jbang-"
+						+ App.AppInstall.getNativeBinaryName().replace("jbang.bin-", "").replace(".exe", "") + ".zip"));
+	}
+
+	@Test
+	void testCopyNativeJBangFiles(@TempDir Path tempDir) throws IOException {
+		Path from = Files.createDirectory(tempDir.resolve("from"));
+		Path to = tempDir.resolve("to");
+		for (String file : Arrays.asList("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar",
+				App.AppInstall.getNativeBinaryName())) {
+			Files.write(from.resolve(file), Collections.singletonList(file));
+		}
+
+		App.AppInstall.copyJBangFiles(from, to, true);
+
+		assertThat(to.resolve("jbang.jar").toFile(), anExistingFile());
+		assertThat(to.resolve(App.AppInstall.getNativeBinaryName()).toFile(), anExistingFile());
+		if (Util.isWindows()) {
+			Files.write(from.resolve(App.AppInstall.getNativeBinaryName()), Collections.singletonList("updated"));
+			App.AppInstall.copyJBangFiles(from, to, true);
+			assertThat(to.resolve(App.AppInstall.getNativeBinaryName() + ".new").toFile(), anExistingFile());
+		}
+	}
+
+	@Test
 	void testHasJBangSetup(@TempDir Path tempDir) throws IOException {
 		Path rcFile = tempDir.resolve(".bashrc");
 		assertThat(App.AppSetup.hasJBangSetup(rcFile), is(false));


### PR DESCRIPTION
## Summary

Fixes #2611.

`jbang version --update` now respects `JBANG_USE_NATIVE`. When native mode is enabled, JBang downloads and installs the release bundle matching the current operating system and architecture instead of always downloading the generic JAR-based package.

On Windows, an in-use native executable is staged as `.exe.new` and replaced by the launcher on the next invocation.

The `JBANG_USE_NATIVE` installation documentation and relevant tests have also been updated.

## Validation

- `./gradlew spotlessCheck compileTestJava`
- `./gradlew test --tests "dev.jbang.cli.TestApp"`
- PowerShell tests in `TestScriptNativeDownload`