### PR TITLE
fix: avoid replacing active Windows command launcher

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -74,6 +74,17 @@ For example `iex "& { $(iwr -useb https://ps.jbang.dev) } properties@jbangdev"`
 
 Unzip the https://github.com/jbangdev/jbang/releases/latest[latest binary release], add the `jbang-<version>/bin` folder to your `$PATH` and you are set.
 
+=== Updating a JBang-managed installation
+
+If JBang was installed using the universal installation script, update it with:
+
+[source,shell]
+----
+jbang version --update
+----
+
+When JBang was installed using a package manager such as SDKMAN, Homebrew, Chocolatey, or Scoop, use that package manager's upgrade command instead.
+
 === Wrapper install
 
 If you would like to have `jbang` available in a local directory and committed into a source code repository (akin to Maven and Gradle wrappers) you can use the `jbang wrapper` command.

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -74,20 +74,6 @@ For example `iex "& { $(iwr -useb https://ps.jbang.dev) } properties@jbangdev"`
 
 Unzip the https://github.com/jbangdev/jbang/releases/latest[latest binary release], add the `jbang-<version>/bin` folder to your `$PATH` and you are set.
 
-=== Updating a JBang-managed installation
-
-If JBang was installed using the universal installation script, update it with:
-
-[source,shell]
-----
-jbang version --update
-----
-
-When JBang was installed using a package manager such as SDKMAN, Homebrew, Chocolatey, or Scoop, use that package manager's upgrade command instead.
-
-On Windows, updates to `jbang.cmd` are staged as `jbang.cmd.new` before being moved into place.
-When an update is started from Command Prompt, the move happens after the Java process completes so the batch file is not replaced while Command Prompt is still reading it.
-
 === Wrapper install
 
 If you would like to have `jbang` available in a local directory and committed into a source code repository (akin to Maven and Gradle wrappers) you can use the `jbang wrapper` command.

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -85,8 +85,8 @@ jbang version --update
 
 When JBang was installed using a package manager such as SDKMAN, Homebrew, Chocolatey, or Scoop, use that package manager's upgrade command instead.
 
-On Windows, an update started from Command Prompt stages the new `jbang.cmd` launcher and installs it after the Java process completes.
-This avoids replacing a batch file while it is still being read by Command Prompt.
+On Windows, updates to `jbang.cmd` are staged as `jbang.cmd.new` before being moved into place.
+When an update is started from Command Prompt, the move happens after the Java process completes so the batch file is not replaced while Command Prompt is still reading it.
 
 === Wrapper install
 

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -74,6 +74,20 @@ For example `iex "& { $(iwr -useb https://ps.jbang.dev) } properties@jbangdev"`
 
 Unzip the https://github.com/jbangdev/jbang/releases/latest[latest binary release], add the `jbang-<version>/bin` folder to your `$PATH` and you are set.
 
+=== Updating a JBang-managed installation
+
+If JBang was installed using the universal installation script, update it with:
+
+[source,shell]
+----
+jbang version --update
+----
+
+When JBang was installed using a package manager such as SDKMAN, Homebrew, Chocolatey, or Scoop, use that package manager's upgrade command instead.
+
+On Windows, an update started from Command Prompt keeps the currently running `jbang.cmd` launcher to avoid replacing a batch file while it is being executed.
+The JBang JAR and the other startup scripts are still updated.
+
 === Wrapper install
 
 If you would like to have `jbang` available in a local directory and committed into a source code repository (akin to Maven and Gradle wrappers) you can use the `jbang wrapper` command.

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -85,8 +85,8 @@ jbang version --update
 
 When JBang was installed using a package manager such as SDKMAN, Homebrew, Chocolatey, or Scoop, use that package manager's upgrade command instead.
 
-On Windows, an update started from Command Prompt keeps the currently running `jbang.cmd` launcher to avoid replacing a batch file while it is being executed.
-The JBang JAR and the other startup scripts are still updated.
+On Windows, an update started from Command Prompt stages the new `jbang.cmd` launcher and installs it after the Java process completes.
+This avoids replacing a batch file while it is still being read by Command Prompt.
 
 === Wrapper install
 

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -261,9 +261,9 @@ public class App extends BaseCommand {
 					try {
 						Path fromp = from.resolve(f);
 						Path top = to.resolve(f);
-						if (isActiveCmdLauncher(top)) {
+						if (Util.isWindows() && f.endsWith("jbang.cmd") && Files.isRegularFile(top)) {
 							top = top.resolveSibling(top.getFileName() + ".new");
-							Util.verboseMsg("Staging the active Windows command launcher update: " + top);
+							Util.verboseMsg("Staging the Windows command launcher update: " + top);
 						}
 						if (f.endsWith("jbang.jar")) {
 							if (!Files.isReadable(fromp)) {
@@ -279,25 +279,16 @@ public class App extends BaseCommand {
 						throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);
 					}
 				});
-		}
-
-		static boolean isActiveCmdLauncher(Path target) {
-			if (!Util.isWindows() || Util.getShell() != Util.Shell.cmd) {
-				return false;
+			if (Util.isWindows() && Util.getShell() != Util.Shell.cmd) {
+				replaceStagedCmdLauncher(to);
 			}
-			String launchCmd = System.getenv(Util.JBANG_LAUNCH_CMD);
-			if (launchCmd == null || launchCmd.isEmpty()) {
-				return false;
-			}
-			return target.toAbsolutePath().normalize().equals(Paths.get(launchCmd).toAbsolutePath().normalize());
 		}
 
 		static String cmdLauncherUpdateCommand() {
-			String launchCmd = System.getenv(Util.JBANG_LAUNCH_CMD);
-			if (!Util.isWindows() || Util.getShell() != Util.Shell.cmd || launchCmd == null || launchCmd.isEmpty()) {
+			if (!Util.isWindows() || Util.getShell() != Util.Shell.cmd) {
 				return null;
 			}
-			Path launcher = Paths.get(launchCmd).toAbsolutePath().normalize();
+			Path launcher = Settings.getConfigBinDir().resolve("jbang.cmd");
 			Path launcherUpdate = launcher.resolveSibling(launcher.getFileName() + ".new");
 			if (!Files.isRegularFile(launcherUpdate)) {
 				return null;
@@ -306,6 +297,14 @@ public class App extends BaseCommand {
 				.shell(Util.Shell.cmd)
 				.asCommandLine();
 			return moveCommand + " > nul 2>&1 && exit /b 0 || exit /b 1";
+		}
+
+		private static void replaceStagedCmdLauncher(Path binDir) throws IOException {
+			Path launcher = binDir.resolve("jbang.cmd");
+			Path launcherUpdate = launcher.resolveSibling(launcher.getFileName() + ".new");
+			if (Files.isRegularFile(launcherUpdate)) {
+				Files.move(launcherUpdate, launcher, StandardCopyOption.REPLACE_EXISTING);
+			}
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -262,8 +262,8 @@ public class App extends BaseCommand {
 						Path fromp = from.resolve(f);
 						Path top = to.resolve(f);
 						if (isActiveCmdLauncher(top)) {
-							Util.verboseMsg("Keeping the active Windows command launcher during the update: " + top);
-							return;
+							top = top.resolveSibling(top.getFileName() + ".new");
+							Util.verboseMsg("Staging the active Windows command launcher update: " + top);
 						}
 						if (f.endsWith("jbang.jar")) {
 							if (!Files.isReadable(fromp)) {
@@ -290,6 +290,22 @@ public class App extends BaseCommand {
 				return false;
 			}
 			return target.toAbsolutePath().normalize().equals(Paths.get(launchCmd).toAbsolutePath().normalize());
+		}
+
+		static String cmdLauncherUpdateCommand() {
+			String launchCmd = System.getenv(Util.JBANG_LAUNCH_CMD);
+			if (!Util.isWindows() || Util.getShell() != Util.Shell.cmd || launchCmd == null || launchCmd.isEmpty()) {
+				return null;
+			}
+			Path launcher = Paths.get(launchCmd).toAbsolutePath().normalize();
+			Path launcherUpdate = launcher.resolveSibling(launcher.getFileName() + ".new");
+			if (!Files.isRegularFile(launcherUpdate)) {
+				return null;
+			}
+			String moveCommand = CommandBuffer.of("move", "/y", launcherUpdate.toString(), launcher.toString())
+				.shell(Util.Shell.cmd)
+				.asCommandLine();
+			return moveCommand + " > nul 2>&1 && exit /b 0 || exit /b 1";
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -253,7 +253,7 @@ public class App extends BaseCommand {
 			return true;
 		}
 
-		private static void copyJBangFiles(Path from, Path to) throws IOException {
+		static void copyJBangFiles(Path from, Path to) throws IOException {
 			to.toFile().mkdirs();
 			Stream.of("jbang", "jbang.cmd", "jbang.ps1", "jbang.jar")
 				.map(Paths::get)
@@ -261,6 +261,10 @@ public class App extends BaseCommand {
 					try {
 						Path fromp = from.resolve(f);
 						Path top = to.resolve(f);
+						if (isActiveCmdLauncher(top)) {
+							Util.verboseMsg("Keeping the active Windows command launcher during the update: " + top);
+							return;
+						}
 						if (f.endsWith("jbang.jar")) {
 							if (!Files.isReadable(fromp)) {
 								fromp = from.resolve(".jbang/jbang.jar");
@@ -275,6 +279,17 @@ public class App extends BaseCommand {
 						throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);
 					}
 				});
+		}
+
+		static boolean isActiveCmdLauncher(Path target) {
+			if (!Util.isWindows() || Util.getShell() != Util.Shell.cmd) {
+				return false;
+			}
+			String launchCmd = System.getenv(Util.JBANG_LAUNCH_CMD);
+			if (launchCmd == null || launchCmd.isEmpty()) {
+				return false;
+			}
+			return target.toAbsolutePath().normalize().equals(Paths.get(launchCmd).toAbsolutePath().normalize());
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -50,6 +50,14 @@ public class Version extends BaseCommand {
 			System.err.println("Native Image: " + JavaUtil.inNativeImage());
 		}
 
+		if (update) {
+			String cmdLauncherUpdate = App.AppInstall.cmdLauncherUpdateCommand();
+			if (cmdLauncherUpdate != null) {
+				System.out.println(cmdLauncherUpdate);
+				return EXIT_EXECUTE;
+			}
+		}
+
 		return EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -84,6 +84,7 @@ public class Util {
 
 	public static final String JBANG_JDK_VENDOR = "JBANG_JDK_VENDOR";
 	public static final String JBANG_RUNTIME_SHELL = "JBANG_RUNTIME_SHELL";
+	public static final String JBANG_LAUNCH_CMD = "JBANG_LAUNCH_CMD";
 	public static final String JBANG_STDIN_NOTTY = "JBANG_STDIN_NOTTY";
 	public static final String JBANG_PREFER_GUI = "JBANG_PREFER_GUI";
 	private static final String JBANG_DOWNLOAD_SOURCES = "JBANG_DOWNLOAD_SOURCES";

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -83,7 +83,7 @@ public class TestApp extends BaseTest {
 	}
 
 	@Test
-	void testUpdateKeepsActiveWindowsCmdLauncher(@TempDir Path tempDir) throws IOException {
+	void testUpdateStagesActiveWindowsCmdLauncher(@TempDir Path tempDir) throws IOException, InterruptedException {
 		Assumptions.assumeTrue(Util.isWindows());
 		Path source = Files.createDirectory(tempDir.resolve("source"));
 		Path target = Files.createDirectory(tempDir.resolve("target"));
@@ -99,10 +99,18 @@ public class TestApp extends BaseTest {
 		App.AppInstall.copyJBangFiles(source, target);
 
 		assertThat(Files.readString(target.resolve("jbang.cmd")), is("running cmd"));
+		assertThat(Files.readString(target.resolve("jbang.cmd.new")), is("new cmd"));
 		assertThat(Files.readString(target.resolve("jbang")), is("new sh"));
 		assertThat(Files.readString(target.resolve("jbang.ps1")), is("new ps1"));
 		assertThat(Files.readString(target.resolve("jbang.jar")), is("running jar"));
 		assertThat(Files.readString(target.resolve("jbang.jar.new")), is("new jar"));
+
+		String updateCommand = App.AppInstall.cmdLauncherUpdateCommand();
+		assertThat(updateCommand, notNullValue());
+		Process process = new ProcessBuilder("cmd", "/d", "/c", updateCommand).start();
+		assertThat(process.waitFor(), is(0));
+		assertThat(Files.readString(target.resolve("jbang.cmd")), is("new cmd"));
+		assertThat(target.resolve("jbang.cmd.new").toFile(), not(anExistingFile()));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -14,9 +14,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import dev.jbang.BaseTest;
@@ -62,31 +63,11 @@ public class TestApp extends BaseTest {
 	}
 
 	@Test
-	void testActiveWindowsCmdLauncher() {
-		Assumptions.assumeTrue(Util.isWindows());
-		Path launcher = jbangTempDir.resolve("bin").resolve("jbang.cmd");
-		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "cmd");
-		environmentVariables.set(Util.JBANG_LAUNCH_CMD, launcher.toString());
-
-		assertThat(App.AppInstall.isActiveCmdLauncher(launcher), is(true));
-		assertThat(App.AppInstall.isActiveCmdLauncher(launcher.resolveSibling("jbang.ps1")), is(false));
-	}
-
-	@Test
-	void testInactiveWindowsCmdLauncher() {
-		Assumptions.assumeTrue(Util.isWindows());
-		Path launcher = jbangTempDir.resolve("bin").resolve("jbang.cmd");
-		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "powershell");
-		environmentVariables.set(Util.JBANG_LAUNCH_CMD, launcher.toString());
-
-		assertThat(App.AppInstall.isActiveCmdLauncher(launcher), is(false));
-	}
-
-	@Test
-	void testUpdateStagesActiveWindowsCmdLauncher(@TempDir Path tempDir) throws IOException, InterruptedException {
-		Assumptions.assumeTrue(Util.isWindows());
+	@EnabledOnOs(OS.WINDOWS)
+	void testUpdateStagesWindowsCmdLauncher(@TempDir Path tempDir) throws IOException, InterruptedException {
 		Path source = Files.createDirectory(tempDir.resolve("source"));
-		Path target = Files.createDirectory(tempDir.resolve("target"));
+		Path target = Settings.getConfigBinDir();
+		Files.createDirectories(target);
 		Files.writeString(source.resolve("jbang"), "new sh");
 		Files.writeString(source.resolve("jbang.cmd"), "new cmd");
 		Files.writeString(source.resolve("jbang.ps1"), "new ps1");
@@ -94,7 +75,6 @@ public class TestApp extends BaseTest {
 		Files.writeString(target.resolve("jbang.cmd"), "running cmd");
 		Files.writeString(target.resolve("jbang.jar"), "running jar");
 		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "cmd");
-		environmentVariables.set(Util.JBANG_LAUNCH_CMD, target.resolve("jbang.cmd").toString());
 
 		App.AppInstall.copyJBangFiles(source, target);
 
@@ -109,6 +89,24 @@ public class TestApp extends BaseTest {
 		assertThat(updateCommand, notNullValue());
 		Process process = new ProcessBuilder("cmd", "/d", "/c", updateCommand).start();
 		assertThat(process.waitFor(), is(0));
+		assertThat(Files.readString(target.resolve("jbang.cmd")), is("new cmd"));
+		assertThat(target.resolve("jbang.cmd.new").toFile(), not(anExistingFile()));
+	}
+
+	@Test
+	@EnabledOnOs(OS.WINDOWS)
+	void testUpdateReplacesStagedCmdLauncherOutsideCmd(@TempDir Path tempDir) throws IOException {
+		Path source = Files.createDirectory(tempDir.resolve("source"));
+		Path target = Files.createDirectory(tempDir.resolve("target"));
+		Files.writeString(source.resolve("jbang"), "new sh");
+		Files.writeString(source.resolve("jbang.cmd"), "new cmd");
+		Files.writeString(source.resolve("jbang.ps1"), "new ps1");
+		Files.writeString(source.resolve("jbang.jar"), "new jar");
+		Files.writeString(target.resolve("jbang.cmd"), "old cmd");
+		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "powershell");
+
+		App.AppInstall.copyJBangFiles(source, target);
+
 		assertThat(Files.readString(target.resolve("jbang.cmd")), is("new cmd"));
 		assertThat(target.resolve("jbang.cmd.new").toFile(), not(anExistingFile()));
 	}

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
@@ -58,6 +59,50 @@ public class TestApp extends BaseTest {
 
 		Files.write(rcFile, Collections.singletonList("# Add JBang to environment"));
 		assertThat(App.AppSetup.hasJBangSetup(rcFile), is(true));
+	}
+
+	@Test
+	void testActiveWindowsCmdLauncher() {
+		Assumptions.assumeTrue(Util.isWindows());
+		Path launcher = jbangTempDir.resolve("bin").resolve("jbang.cmd");
+		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "cmd");
+		environmentVariables.set(Util.JBANG_LAUNCH_CMD, launcher.toString());
+
+		assertThat(App.AppInstall.isActiveCmdLauncher(launcher), is(true));
+		assertThat(App.AppInstall.isActiveCmdLauncher(launcher.resolveSibling("jbang.ps1")), is(false));
+	}
+
+	@Test
+	void testInactiveWindowsCmdLauncher() {
+		Assumptions.assumeTrue(Util.isWindows());
+		Path launcher = jbangTempDir.resolve("bin").resolve("jbang.cmd");
+		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "powershell");
+		environmentVariables.set(Util.JBANG_LAUNCH_CMD, launcher.toString());
+
+		assertThat(App.AppInstall.isActiveCmdLauncher(launcher), is(false));
+	}
+
+	@Test
+	void testUpdateKeepsActiveWindowsCmdLauncher(@TempDir Path tempDir) throws IOException {
+		Assumptions.assumeTrue(Util.isWindows());
+		Path source = Files.createDirectory(tempDir.resolve("source"));
+		Path target = Files.createDirectory(tempDir.resolve("target"));
+		Files.writeString(source.resolve("jbang"), "new sh");
+		Files.writeString(source.resolve("jbang.cmd"), "new cmd");
+		Files.writeString(source.resolve("jbang.ps1"), "new ps1");
+		Files.writeString(source.resolve("jbang.jar"), "new jar");
+		Files.writeString(target.resolve("jbang.cmd"), "running cmd");
+		Files.writeString(target.resolve("jbang.jar"), "running jar");
+		environmentVariables.set(Util.JBANG_RUNTIME_SHELL, "cmd");
+		environmentVariables.set(Util.JBANG_LAUNCH_CMD, target.resolve("jbang.cmd").toString());
+
+		App.AppInstall.copyJBangFiles(source, target);
+
+		assertThat(Files.readString(target.resolve("jbang.cmd")), is("running cmd"));
+		assertThat(Files.readString(target.resolve("jbang")), is("new sh"));
+		assertThat(Files.readString(target.resolve("jbang.ps1")), is("new ps1"));
+		assertThat(Files.readString(target.resolve("jbang.jar")), is("running jar"));
+		assertThat(Files.readString(target.resolve("jbang.jar.new")), is("new jar"));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/cli/TestPowerShellSelfUpdate.java
+++ b/src/test/java/dev/jbang/cli/TestPowerShellSelfUpdate.java
@@ -1,0 +1,83 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+@EnabledOnOs(OS.WINDOWS)
+class TestPowerShellSelfUpdate extends AbstractScriptTest {
+
+	@BeforeEach
+	void checkPowerShell() {
+		requirePowerShell();
+	}
+
+	@Test
+	void replacesRunningPowerShellLauncher() throws Exception {
+		Path binDir = Files.createDirectories(tempDir.resolve("bin"));
+		Path launcher = binDir.resolve("jbang.ps1");
+		Files.copy(PS1_SCRIPT, launcher);
+		createUpdaterJar(binDir.resolve("jbang.jar"));
+
+		Map<String, String> env = new HashMap<>(System.getenv());
+		env.put("JAVA_HOME", System.getProperty("java.home"));
+		env.put("JBANG_DIR", tempDir.resolve("jbang-home").toString());
+		env.put("JBANG_CACHE_DIR", tempDir.resolve("cache").toString());
+		env.put("JBANG_NO_VERSION_CHECK", "true");
+
+		List<String> command = new ArrayList<>();
+		command.add(psCommand);
+		command.add("-NoProfile");
+		command.add("-ExecutionPolicy");
+		command.add("Bypass");
+		command.add("-File");
+		command.add(launcher.toString());
+		RunResult result = runProcess(command, env);
+
+		assertEquals(0, result.exitCode, result.stderr);
+		assertEquals("# updated while running\n", Files.readString(launcher).replace("\r\n", "\n"));
+		assertFalse(Files.exists(launcher.resolveSibling("jbang.ps1.new")));
+	}
+
+	private static void createUpdaterJar(Path jar) throws IOException {
+		Manifest manifest = new Manifest();
+		manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+		manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, PowerShellUpdater.class.getName());
+		String classResource = PowerShellUpdater.class.getName().replace('.', '/') + ".class";
+		try (InputStream input = PowerShellUpdater.class.getClassLoader().getResourceAsStream(classResource);
+				JarOutputStream output = new JarOutputStream(Files.newOutputStream(jar), manifest)) {
+			if (input == null) {
+				throw new IOException("Could not find test updater class: " + classResource);
+			}
+			output.putNextEntry(new JarEntry(classResource));
+			input.transferTo(output);
+			output.closeEntry();
+		}
+	}
+
+	public static class PowerShellUpdater {
+		public static void main(String[] args) throws IOException {
+			Path launcher = Paths.get(System.getenv("JBANG_LAUNCH_CMD"));
+			Files.write(launcher, "# updated while running\n".getBytes(StandardCharsets.UTF_8));
+		}
+	}
+}


### PR DESCRIPTION
Fixes #2608.

## What changed

- Prevent the updater from overwriting the currently executing `jbang.cmd` launcher on Windows.
- Continue updating the JBang JAR and other startup scripts normally.
- Add regression tests covering active and inactive Windows command launchers.
- Document `jbang version --update` and package-manager upgrade behavior.

## Root cause

`cmd.exe` reads batch files incrementally. During `jbang version --update`, JBang replaced the active `jbang.cmd` file. CMD then continued reading the new file from its previous byte offset, causing fragments such as `_with_cli` and `""` to be interpreted as commands.

## Verification

- `./gradlew test --tests "dev.jbang.cli.TestApp"`
- `./gradlew spotlessCheck`
- `git diff --check`