### PR TITLE
feat: support selective verbose categories

### DIFF
--- a/docs/modules/ROOT/pages/configuration.adoc
+++ b/docs/modules/ROOT/pages/configuration.adoc
@@ -247,10 +247,11 @@ As long as `gh auth login --hostname github.mycompany.com` has been run, JBang w
 
 === Debugging authentication
 
-Use `--verbose` to see which credential source JBang selected for each request:
+Use `--verbose=network` to see which credential source JBang selected for each request without unrelated
+diagnostic output:
 
 ```bash
-jbang --verbose run https://gitlab.mycompany.com/group/project/-/raw/main/script.java
+jbang --verbose=network run https://gitlab.mycompany.com/group/project/-/raw/main/script.java
 ```
 
 The output will include lines like `Using .netrc credentials for host: gitlab.mycompany.com` or `Using GITHUB_TOKEN environment variable for host: github.com`.
@@ -306,4 +307,3 @@ Finally JBang uses maven resolver to download dependencies. Maven resolver uses 
     </proxies>
 </settings>
 ```
-

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -358,10 +358,19 @@ jbang cache list
 
 === Enable Verbose Mode
 
+By default, `--verbose` shows all diagnostic output. To investigate a specific area without unrelated details,
+provide one or more comma-separated categories:
+
 [source,bash]
 ----
 # Verbose output
 jbang --verbose script.java
+
+# External commands and network activity only
+jbang --verbose=commands,network script.java
+
+# All verbose output except internal details
+jbang --verbose=-internals script.java
 
 # Debug mode
 jbang --debug script.java
@@ -369,6 +378,24 @@ jbang --debug script.java
 # Show Java command
 jbang --show-java-command script.java
 ----
+
+The available verbose categories are:
+
+`commands`:: External process invocations, such as compiler and run commands.
+`network`:: HTTP requests, downloads, redirects, authentication, and repository access.
+`build`:: Dependency resolution, compilation decisions, classpath assembly, and caching.
+`config`:: Configuration, catalog, trusted-source, and environment lookup.
+`internals`:: Other internal diagnostic details.
+
+Bare `--verbose` and `--verbose=all` enable every category. If only negative categories are specified,
+all categories are enabled first and the named categories are removed. The selection can also be configured:
+
+[source,bash]
+----
+jbang config set verbose commands,network
+----
+
+Use `--no-verbose` to disable verbose output for one invocation when a default is configured.
 
 === Environment Information
 

--- a/src/main/java/dev/jbang/Configuration.java
+++ b/src/main/java/dev/jbang/Configuration.java
@@ -1,5 +1,6 @@
 package dev.jbang;
 
+import static dev.jbang.util.Util.VerboseCategory.CONFIG;
 import static dev.jbang.util.Util.verboseMsg;
 import static dev.jbang.util.Util.warnMsg;
 
@@ -331,7 +332,7 @@ public class Configuration {
 	}
 
 	public static void write(Path configFile, Configuration cfg) throws IOException {
-		verboseMsg(String.format("Writing configuration to %s", configFile));
+		verboseMsg(CONFIG, String.format("Writing configuration to %s", configFile));
 		try (Writer out = Files.newBufferedWriter(configFile)) {
 			cfg.values.store(out);
 		}

--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -72,7 +72,7 @@ public class Main {
 				}
 			} else {
 				Util.errorMsg(null, e);
-				if (Util.isVerbose()) {
+				if (Util.isVerbose(Util.VerboseCategory.INTERNALS)) {
 					Util.infoMsg(
 							"If you believe this a bug in jbang, open an issue at https://github.com/jbangdev/jbang/issues");
 				}

--- a/src/main/java/dev/jbang/catalog/Catalog.java
+++ b/src/main/java/dev/jbang/catalog/Catalog.java
@@ -221,7 +221,7 @@ public class Catalog {
 				throw new ExitException(EXIT_UNEXPECTED_STATE,
 						"Unable to download catalog: " + catalogRef);
 			}
-			Util.verboseMsg(String.format("Obtained catalog from %s", catalogRef));
+			Util.verboseMsg(Util.VerboseCategory.CONFIG, String.format("Obtained catalog from %s", catalogRef));
 			int p = catalogRef.lastIndexOf('/');
 			if (p > 0) {
 				String baseRef = catalog.baseRef;
@@ -327,7 +327,8 @@ public class Catalog {
 					if (result != null)
 						return result;
 				} catch (Exception e) {
-					Util.verboseMsg("Unable to read catalog " + cr.catalogRef + ": " + e.getMessage(), e);
+					Util.verboseMsg(Util.VerboseCategory.CONFIG,
+							"Unable to read catalog " + cr.catalogRef + ": " + e.getMessage(), e);
 				}
 			}
 		}
@@ -376,7 +377,8 @@ public class Catalog {
 	}
 
 	static Catalog read(ResourceRef catalogRef) {
-		Util.verboseMsg(String.format("Reading catalog from %s", catalogRef.getOriginalResource()));
+		Util.verboseMsg(Util.VerboseCategory.CONFIG,
+				String.format("Reading catalog from %s", catalogRef.getOriginalResource()));
 		Catalog catalog = Catalog.empty();
 		if (catalogRef.exists()) {
 			try (InputStream is = catalogRef.getInputStream()) {

--- a/src/main/java/dev/jbang/catalog/CatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/CatalogRef.java
@@ -73,7 +73,8 @@ public class CatalogRef extends CatalogItem {
 		if (Util.isRemoteRef(catalogRefString) && Util.isURL(catalogRefString)) {
 			url = Optional.of(catalogRefString);
 		} else {
-			Util.verboseMsg("Local catalog '" + catalogRefString + "' not found, trying implicit catalogs...");
+			Util.verboseMsg(Util.VerboseCategory.CONFIG,
+					"Local catalog '" + catalogRefString + "' not found, trying implicit catalogs...");
 			url = ImplicitCatalogRef.resolveImplicitCatalogUrl(catalogRefString);
 		}
 		if (url.isPresent()) {

--- a/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
+++ b/src/main/java/dev/jbang/catalog/ImplicitCatalogRef.java
@@ -85,10 +85,10 @@ public class ImplicitCatalogRef {
 	private static Optional<String> tryDownload(String url) {
 		try {
 			Catalog.getByRef(url);
-			Util.verboseMsg("Catalog found at " + url);
+			Util.verboseMsg(Util.VerboseCategory.CONFIG, "Catalog found at " + url);
 			return Optional.of(url);
 		} catch (Exception ex) {
-			Util.verboseMsg("No catalog found at " + url, ex);
+			Util.verboseMsg(Util.VerboseCategory.CONFIG, "No catalog found at " + url, ex);
 			String authMethod = NetUtil.describeAuthMethod(url);
 			if (authMethod != null) {
 				Util.warnMsg("Could not download catalog from " + url

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -49,9 +49,13 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 	@Option(name = "insecure", hasValue = false, description = "Enable insecure trust of all SSL certificates.")
 	boolean insecure;
 
-	@Option(name = "verbose", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
-			"quiet" }, description = "jbang will be verbose on what it does.")
-	Boolean verbose;
+	@Option(name = "verbose", inherited = true, fallbackValue = "all", exclusiveWith = {
+			"quiet", "no-verbose" }, description = "Enable verbose output, optionally filtered by category.")
+	String verbose;
+
+	@Option(name = "no-verbose", hasValue = false, inherited = true, exclusiveWith = {
+			"verbose" }, description = "Disable verbose output.")
+	boolean noVerbose;
 
 	@Option(name = "quiet", hasValue = false, negatable = true, inherited = true, exclusiveWith = {
 			"verbose" }, description = "jbang will be quiet, only print when error occurs.")
@@ -82,7 +86,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 	protected CommandInvocation commandInvocation;
 
 	void debug(String msg) {
-		if (isVerbose()) {
+		if (Util.isVerbose(Util.VerboseCategory.INTERNALS)) {
 			Util.verboseMsg(msg);
 		}
 	}
@@ -179,7 +183,10 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 	@Override
 	public void afterParse() {
 		if (verbose != null) {
-			Util.setVerbose(verbose);
+			Util.setVerboseCategories(verbose);
+		}
+		if (noVerbose) {
+			Util.setVerbose(false);
 		}
 		if (quiet != null) {
 			Util.setQuiet(quiet);

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -513,7 +513,7 @@ public class Export extends BaseCommand {
 				args.addAll(params);
 			}
 
-			Util.verboseMsg("Run: " + String.join(" ", args));
+			Util.verboseMsg(Util.VerboseCategory.COMMANDS, "Run: " + String.join(" ", args));
 			String out = Util.runCommand(args.toArray(new String[] {}));
 			if (out == null) {
 				Util.errorMsg("Unable to export Jdk distribution.");

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -511,7 +511,7 @@ public class Jdk extends BaseCommand {
 							+ " ; $env:PATH, $env:JAVA_HOME=$oldPath, $oldHome }";
 					break;
 				}
-				Util.verboseMsg("Executing in Java environment: " + fullCmd);
+				Util.verboseMsg(Util.VerboseCategory.COMMANDS, "Executing in Java environment: " + fullCmd);
 				System.out.println(fullCmd);
 				return EXIT_EXECUTE;
 			}

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -110,7 +110,7 @@ public class Run extends BaseBuildCommand {
 
 		String cmdline = updateGeneratorForRun(genb).build().generate();
 
-		Util.verboseMsg("run: " + cmdline);
+		Util.verboseMsg(Util.VerboseCategory.COMMANDS, "run: " + cmdline);
 		realOut.println(cmdline);
 
 		return EXIT_EXECUTE;

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -38,7 +38,7 @@ public class Version extends BaseCommand {
 			System.out.println(Util.getJBangVersion());
 		}
 
-		if (isVerbose()) {
+		if (Util.isVerbose(Util.VerboseCategory.INTERNALS)) {
 			System.err.println("Cache: " + Settings.getCacheDir());
 			System.err.println("Config: " + Settings.getConfigDir());
 			System.err.println("Repository: " + ArtifactResolver.getLocalMavenRepo());

--- a/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
+++ b/src/main/java/dev/jbang/dependencies/ArtifactResolver.java
@@ -192,7 +192,7 @@ public class ArtifactResolver implements Closeable {
 					.setRepositories(
 							context.remoteRepositories()));
 		} catch (ArtifactResolutionException e) {
-			Util.verboseMsg("Could not resolve sources for " + artifact.toString());
+			Util.verboseMsg(Util.VerboseCategory.BUILD, "Could not resolve sources for " + artifact.toString());
 		}
 	}
 
@@ -306,7 +306,8 @@ public class ArtifactResolver implements Closeable {
 				if (!printed.contains(id)) {
 					String coord = coord(groupId, artId, version, null, classifier);
 					String pomcoord = coord(groupId, artId, version, "pom", null);
-					if (ids.contains(id) || ids.contains(coord) || ids.contains(pomcoord) || Util.isVerbose()) {
+					if (ids.contains(id) || ids.contains(coord) || ids.contains(pomcoord)
+							|| Util.isVerbose(Util.VerboseCategory.BUILD)) {
 						if (ids.contains(pomcoord)) {
 							infoMsg("   " + pomcoord);
 						} else {
@@ -404,7 +405,8 @@ public class ArtifactResolver implements Closeable {
 				builder.setAuthentication(auth);
 			}
 		} catch (MalformedURLException e) {
-			Util.verboseMsg("Could not parse repository URL for auth lookup: " + repo.getUrl());
+			Util.verboseMsg(Util.VerboseCategory.BUILD,
+					"Could not parse repository URL for auth lookup: " + repo.getUrl());
 		}
 
 		return builder.build();

--- a/src/main/java/dev/jbang/dependencies/DependencyCache.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyCache.java
@@ -122,14 +122,15 @@ public class DependencyCache {
 				return cachedCP;
 			} else {
 				warnMsg("Detected missing or out-of-date dependencies in cache.");
-				if (Util.isVerbose()) {
+				if (Util.isVerbose(Util.VerboseCategory.BUILD)) {
 					cachedCP.stream().filter(ai -> !ai.isUpToDate()).forEach(ai -> {
 						if (Files.isReadable(ai.getFile())) {
-							Util.verboseMsg(
+							Util.verboseMsg(Util.VerboseCategory.BUILD,
 									"   Artifact out of date: " + ai.getFile() + " : " + ai.getTimestamp() + " != "
 											+ ai.getFile().toFile().lastModified());
 						} else {
-							Util.verboseMsg("   Artifact not found in local cache: " + ai.getFile());
+							Util.verboseMsg(Util.VerboseCategory.BUILD,
+									"   Artifact not found in local cache: " + ai.getFile());
 						}
 					});
 				}

--- a/src/main/java/dev/jbang/dependencies/DependencyUtil.java
+++ b/src/main/java/dev/jbang/dependencies/DependencyUtil.java
@@ -2,6 +2,7 @@ package dev.jbang.dependencies;
 
 import static dev.jbang.Settings.CP_SEPARATOR;
 import static dev.jbang.Settings.getJBangLocalMavenRepoOverride;
+import static dev.jbang.util.Util.VerboseCategory.BUILD;
 import static dev.jbang.util.Util.errorMsg;
 import static dev.jbang.util.Util.infoMsg;
 import static dev.jbang.util.Util.isWindows;
@@ -67,7 +68,7 @@ public class DependencyUtil {
 			return new ModularClassPath(Collections.emptyList());
 		}
 
-		verboseMsg(String.format("Resolving artifact(s): %s", String.join(", ", deps)));
+		verboseMsg(BUILD, String.format("Resolving artifact(s): %s", String.join(", ", deps)));
 
 		if (repos.isEmpty()) {
 			repos = new ArrayList<>();
@@ -84,7 +85,7 @@ public class DependencyUtil {
 			repos.add(toMavenRepo(ALIAS_JITPACK));
 		}
 
-		verboseMsg(String.format("Repositories: %s",
+		verboseMsg(BUILD, String.format("Repositories: %s",
 				repos.stream().map(MavenRepo::toString).collect(Collectors.joining(", "))));
 
 		String depsHash = String.join(CP_SEPARATOR, depIds);
@@ -94,7 +95,7 @@ public class DependencyUtil {
 			cachedDeps = DependencyCache.findDependenciesByHash(depsHash);
 			if (cachedDeps != null) {
 				ModularClassPath mcp = new ModularClassPath(cachedDeps);
-				verboseMsg(String.format("Resolved artifact(s) from cache: %s", mcp));
+				verboseMsg(BUILD, String.format("Resolved artifact(s) from cache: %s", mcp));
 				return mcp;
 			}
 		}
@@ -125,7 +126,7 @@ public class DependencyUtil {
 
 			DependencyCache.cache(depsHash, mcp.getArtifacts());
 
-			verboseMsg(String.format("Resolved artifact(s): %s", mcp));
+			verboseMsg(BUILD, String.format("Resolved artifact(s): %s", mcp));
 
 			return mcp;
 		} catch (DependencyException e) { // Probably a wrapped Nullpointer from
@@ -202,7 +203,7 @@ public class DependencyUtil {
 			Path base = Paths.get(".").toAbsolutePath().normalize();
 			Path resolved = base.resolve(reporef).normalize();
 			String resolvedUrl = resolved.toUri().toString();
-			verboseMsg("Maven local path resolved: " + repoReference + " -> " + resolvedUrl);
+			verboseMsg(BUILD, "Maven local path resolved: " + repoReference + " -> " + resolvedUrl);
 			// TODO: should we throw an error if the resolved path is not a child of the
 			// base path?
 			return new MavenRepo(repoid, resolvedUrl);

--- a/src/main/java/dev/jbang/net/EditorManager.java
+++ b/src/main/java/dev/jbang/net/EditorManager.java
@@ -38,7 +38,7 @@ public class EditorManager {
 		Util.infoMsg("Downloading VSCodium " + version
 				+ ". Be patient, this can take several minutes...(Ctrl+C if you want to cancel)");
 		String url = getVSCodiumDownloadURL(version);
-		Util.verboseMsg("Downloading " + url);
+		Util.verboseMsg(Util.VerboseCategory.NETWORK, "Downloading " + url);
 		Path editorDir = getVSCodiumPath();
 		Path editorTmpDir = editorDir.getParent().resolve(editorDir.getFileName().toString() + ".tmp");
 		Path editorOldDir = editorDir.getParent().resolve(editorDir.getFileName().toString() + ".old");
@@ -47,7 +47,7 @@ public class EditorManager {
 		try {
 			Path jdkPkg = NetUtil.downloadAndCacheFile(url);
 			Util.infoMsg("Installing VSCodium " + version + "...");
-			Util.verboseMsg("Unpacking to " + editorDir.toString());
+			Util.verboseMsg(Util.VerboseCategory.NETWORK, "Unpacking to " + editorDir.toString());
 			UnpackUtil.unpackEditor(jdkPkg, editorTmpDir);
 			if (Files.isDirectory(editorDir)) {
 				Files.move(editorDir, editorOldDir);
@@ -95,7 +95,7 @@ public class EditorManager {
 	private static String getLatestVSCodiumVersion() {
 		String version = "1.52.1";
 		try {
-			Util.verboseMsg("Lookup vscodium latest version...");
+			Util.verboseMsg(Util.VerboseCategory.NETWORK, "Lookup vscodium latest version...");
 			try (InputStream is = new URL("https://api.github.com/repos/vscodium/vscodium/releases/latest")
 				.openStream();
 					Scanner sc = new Scanner(is, "UTF-8")) {
@@ -104,7 +104,8 @@ public class EditorManager {
 				if (matcher.find()) {
 					version = matcher.group(1);
 				} else {
-					Util.verboseMsg("Could not find latest version - falling back to " + version);
+					Util.verboseMsg(Util.VerboseCategory.NETWORK,
+							"Could not find latest version - falling back to " + version);
 				}
 			}
 

--- a/src/main/java/dev/jbang/net/GroovyManager.java
+++ b/src/main/java/dev/jbang/net/GroovyManager.java
@@ -37,7 +37,7 @@ public class GroovyManager {
 	public static Path downloadAndInstallGroovy(String version) {
 		Util.infoMsg("Downloading Groovy " + version + ". Be patient, this can take several minutes...");
 		String url = getGroovyDownloadUrl(version);
-		Util.verboseMsg("Downloading " + url);
+		Util.verboseMsg(Util.VerboseCategory.NETWORK, "Downloading " + url);
 		Path groovyDir = getGroovyPath(version);
 		Path groovyTmpDir = groovyDir.getParent().resolve(groovyDir.getFileName().toString() + ".tmp");
 		Path groovyOldDir = groovyDir.getParent().resolve(groovyDir.getFileName().toString() + ".old");
@@ -46,7 +46,7 @@ public class GroovyManager {
 		try {
 			Path groovyPkg = NetUtil.downloadAndCacheFile(url);
 			Util.infoMsg("Installing Groovy " + version + "...");
-			Util.verboseMsg("Unpacking to " + groovyDir);
+			Util.verboseMsg(Util.VerboseCategory.NETWORK, "Unpacking to " + groovyDir);
 			UnpackUtil.unpack(groovyPkg, groovyTmpDir);
 			if (Files.isDirectory(groovyDir)) {
 				Files.move(groovyDir, groovyOldDir);

--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -38,7 +38,7 @@ public class KotlinManager {
 	public static Path downloadAndInstallKotlin(String version) {
 		Util.infoMsg("Downloading Kotlin " + version + ". Be patient, this can take several minutes...");
 		String url = String.format(KOTLIN_DOWNLOAD_URL, version, version);
-		Util.verboseMsg("Downloading " + url);
+		Util.verboseMsg(Util.VerboseCategory.NETWORK, "Downloading " + url);
 		Path kotlinDir = getKotlinPath(version);
 		Path kotlinTmpDir = kotlinDir.getParent().resolve(kotlinDir.getFileName().toString() + ".tmp");
 		Path kotlinOldDir = kotlinDir.getParent().resolve(kotlinDir.getFileName().toString() + ".old");
@@ -47,7 +47,7 @@ public class KotlinManager {
 		try {
 			Path kotlinPkg = NetUtil.downloadAndCacheFile(url);
 			Util.infoMsg("Installing Kotlin " + version + "...");
-			Util.verboseMsg("Unpacking to " + kotlinDir);
+			Util.verboseMsg(Util.VerboseCategory.NETWORK, "Unpacking to " + kotlinDir);
 			UnpackUtil.unpack(kotlinPkg, kotlinTmpDir);
 			if (Files.isDirectory(kotlinDir)) {
 				Files.move(kotlinDir, kotlinOldDir);

--- a/src/main/java/dev/jbang/source/AppBuilder.java
+++ b/src/main/java/dev/jbang/source/AppBuilder.java
@@ -50,22 +50,25 @@ public abstract class AppBuilder implements Builder<CmdGeneratorBuilder> {
 		// it allows integrations the options to produce the native image
 		boolean buildRequired = true;
 		if (project.isExecutableArchive()) {
-			Util.verboseMsg("The resource is an executable archive, no compilation to be done.");
+			Util.verboseMsg(Util.VerboseCategory.BUILD,
+					"The resource is an executable archive, no compilation to be done.");
 			buildRequired = false;
 		} else if (fresh) {
-			Util.verboseMsg("Building as fresh build explicitly requested.");
+			Util.verboseMsg(Util.VerboseCategory.BUILD, "Building as fresh build explicitly requested.");
 		} else if (nativeBuildRequired) {
-			Util.verboseMsg("Building as native build required.");
+			Util.verboseMsg(Util.VerboseCategory.BUILD, "Building as native build required.");
 		} else if (Files.isReadable(outjar)) {
 			Project jarProject = Project.builder().build(outjar);
 			// We already have a Jar, check if we can still use it
 			if (!ctx.isUpToDate()) {
-				Util.verboseMsg("Building as previously built jar found but it or its dependencies not up-to-date.");
+				Util.verboseMsg(Util.VerboseCategory.BUILD,
+						"Building as previously built jar found but it or its dependencies not up-to-date.");
 			} else if (jarProject.getJavaVersion() == null) {
-				Util.verboseMsg("Building as previously built jar found but it has incomplete meta data.");
+				Util.verboseMsg(Util.VerboseCategory.BUILD,
+						"Building as previously built jar found but it has incomplete meta data.");
 			} else if (project.projectJdk().majorVersion() < JavaUtil.minRequestedVersion(
 					jarProject.getJavaVersion())) {
-				Util.verboseMsg(
+				Util.verboseMsg(Util.VerboseCategory.BUILD,
 						String.format(
 								"Building as requested Java version %s < than the java version used during last build %s",
 								requestedJavaVersion, project.getJavaVersion()));
@@ -76,11 +79,11 @@ public abstract class AppBuilder implements Builder<CmdGeneratorBuilder> {
 				if (!project.getModuleName().isPresent()) {
 					project.setModuleName(jarProject.getModuleName().orElse(null));
 				}
-				Util.verboseMsg("No build required. Reusing jar from " + ctx.getJarFile());
+				Util.verboseMsg(Util.VerboseCategory.BUILD, "No build required. Reusing jar from " + ctx.getJarFile());
 				buildRequired = false;
 			}
 		} else {
-			Util.verboseMsg("Build required as " + outjar + " not readable or not found.");
+			Util.verboseMsg(Util.VerboseCategory.BUILD, "Build required as " + outjar + " not readable or not found.");
 		}
 
 		if (buildRequired) {

--- a/src/main/java/dev/jbang/source/ProjectBuilder.java
+++ b/src/main/java/dev/jbang/source/ProjectBuilder.java
@@ -266,7 +266,7 @@ public class ProjectBuilder {
 	}
 
 	private ResourceRef resolveChecked(ResourceResolver resolver, String resource) {
-		Util.verboseMsg("Resolving resource ref: " + resource);
+		Util.verboseMsg(Util.VerboseCategory.BUILD, "Resolving resource ref: " + resource);
 		boolean retryCandidate = catalogFile == null && !Util.isFresh() && Settings.getCacheEvict() > 0
 				&& (Catalog.isValidName(resource) || Catalog.isValidCatalogReference(resource)
 						|| Util.isRemoteRef(resource));
@@ -283,14 +283,14 @@ public class ProjectBuilder {
 			// that could be an alias or a remote URL, so we'll try again
 			// with the cache evict set to 0, forcing Jbang to actually check
 			// if all its cached information is up-to-date.
-			Util.verboseMsg("Retry using cache-evict: " + resource);
+			Util.verboseMsg(Util.VerboseCategory.BUILD, "Retry using cache-evict: " + resource);
 			ref = Util.withCacheEvict(() -> resolver.resolve(resource));
 		}
 		if (ref == null || !Files.isReadable(ref.getFile())) {
 			throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 					"Script or alias could not be found or read: '" + resource + "'");
 		}
-		Util.verboseMsg("Resolved resource ref as: " + ref);
+		Util.verboseMsg(Util.VerboseCategory.BUILD, "Resolved resource ref as: " + ref);
 		return ref;
 	}
 
@@ -493,7 +493,7 @@ public class ProjectBuilder {
 							prj.setGav(gav);
 						}
 					} catch (DomTripException e) {
-						Util.verboseMsg("Unable to read the JAR's pom.xml file", e);
+						Util.verboseMsg(Util.VerboseCategory.BUILD, "Unable to read the JAR's pom.xml file", e);
 					}
 				}
 
@@ -680,7 +680,7 @@ public class ProjectBuilder {
 			SourceSet ss = prj.getMainSourceSet();
 			ss.addSource(srcRef);
 			if (srcRef instanceof ResourceRef.UnresolvableResourceRef) {
-				Util.verboseMsg("Skipping unresolvable source: " + srcRef);
+				Util.verboseMsg(Util.VerboseCategory.BUILD, "Skipping unresolvable source: " + srcRef);
 				return prj;
 			}
 			ResourceResolver sibRes1 = getSiblingResolver(srcRef);

--- a/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/CompileBuildStep.java
@@ -64,7 +64,7 @@ public abstract class CompileBuildStep implements Builder<Project> {
 
 		Util.infoMsg(String.format("Building %s for %s...", project.getMainSource().isAgent() ? "javaagent" : "jar",
 				project.getResourceRef().getFile().getFileName().toString()));
-		Util.verboseMsg("Compile: " + String.join(" ", compileCmd));
+		Util.verboseMsg(Util.VerboseCategory.BUILD, "Compile: " + String.join(" ", compileCmd));
 		runCompiler(compileCmd);
 
 		searchForMain(ctx.getCompileDir());

--- a/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
+++ b/src/main/java/dev/jbang/source/buildsteps/NativeBuildStep.java
@@ -69,7 +69,7 @@ public class NativeBuildStep implements Builder<Project> {
 	}
 
 	protected void runNativeBuilder(List<String> optionList) throws IOException {
-		Util.verboseMsg("native-image: " + String.join(" ", optionList));
+		Util.verboseMsg(Util.VerboseCategory.BUILD, "native-image: " + String.join(" ", optionList));
 
 		ProcessBuilder pb = CommandBuffer.of(optionList)
 			.applyWindowsMaxProcessLimit()

--- a/src/main/java/dev/jbang/spi/IntegrationManager.java
+++ b/src/main/java/dev/jbang/spi/IntegrationManager.java
@@ -96,7 +96,7 @@ public class IntegrationManager {
 						? source.getResourceRef().getFile().toAbsolutePath()
 						: null;
 				IntegrationInput input = new IntegrationInput(className, srcPath, compileDir, pomPath, repos, deps,
-						comments, prj.isNativeImage(), Util.isVerbose());
+						comments, prj.isNativeImage(), Util.isVerbose(Util.VerboseCategory.INTERNALS));
 				boolean embedded = (requestedJavaVersion == null || JavaUtil.satisfiesRequestedVersion(
 						requestedJavaVersion, JavaUtil.getCurrentMajorJavaVersion()) && !JavaUtil.inNativeImage())
 						&& !"true".equals(System.getProperty("jbang.build.integration.forceExternal"));
@@ -182,7 +182,7 @@ public class IntegrationManager {
 		Method method = clazz.getDeclaredMethod("postBuild", Path.class, Path.class, List.class, List.class,
 				List.class, boolean.class);
 
-		if (Util.isVerbose()) {
+		if (Util.isVerbose(Util.VerboseCategory.INTERNALS)) {
 			System.setOut(new PrintStream(new FileOutputStream(FileDescriptor.err)));
 		} else {
 			System.setOut(new PrintStream(new OutputStream() {
@@ -264,10 +264,8 @@ public class IntegrationManager {
 
 		args.add("dev.jbang.spi.IntegrationManager");
 
-		if (Util.isVerbose()) {
-			Util.verboseMsg("Running: " + String.join(" ", args));
-			Util.verboseMsg("Input: " + parser.toJson(input));
-		}
+		Util.verboseMsg(Util.VerboseCategory.COMMANDS, "Running: " + String.join(" ", args));
+		Util.verboseMsg("Input: " + parser.toJson(input));
 
 		Process process = new ProcessBuilder(args)
 			.redirectError(ProcessBuilder.Redirect.INHERIT)

--- a/src/main/java/dev/jbang/util/NetUtil.java
+++ b/src/main/java/dev/jbang/util/NetUtil.java
@@ -1,5 +1,6 @@
 package dev.jbang.util;
 
+import static dev.jbang.util.Util.VerboseCategory.NETWORK;
 import static dev.jbang.util.Util.deletePath;
 import static dev.jbang.util.Util.getAgentString;
 import static dev.jbang.util.Util.getStableID;
@@ -94,7 +95,7 @@ public class NetUtil {
 		if (cachedFile == null || isEvicted(cachedFile)) {
 			return downloadFileAndCache(fileURL, saveDir, metaSaveDir, cachedFile);
 		} else {
-			verboseMsg(String.format("Using cached file %s for remote %s", cachedFile, fileURL));
+			verboseMsg(NETWORK, String.format("Using cached file %s for remote %s", cachedFile, fileURL));
 			return saveDir.resolve(cachedFile);
 		}
 	}
@@ -207,10 +208,10 @@ public class NetUtil {
 
 		if (urlConnection instanceof HttpURLConnection) {
 			HttpURLConnection httpConn = (HttpURLConnection) urlConnection;
-			verboseMsg(String.format("Requesting HTTP %s %s", httpConn.getRequestMethod(), httpConn.getURL()));
-			verboseMsg(String.format("Headers %s", redactAuthHeaders(httpConn.getRequestProperties())));
+			verboseMsg(NETWORK, String.format("Requesting HTTP %s %s", httpConn.getRequestMethod(), httpConn.getURL()));
+			verboseMsg(NETWORK, String.format("Headers %s", redactAuthHeaders(httpConn.getRequestProperties())));
 		} else {
-			verboseMsg(String.format("Requesting %s", urlConnection.getURL()));
+			verboseMsg(NETWORK, String.format("Requesting %s", urlConnection.getURL()));
 		}
 
 		try {
@@ -338,7 +339,7 @@ public class NetUtil {
 									.collect(Collectors.joining("\n"))
 									.trim();
 							}
-							verboseMsg("HTTP: " + responseCode + " - " + err);
+							verboseMsg(NETWORK, "HTTP: " + responseCode + " - " + err);
 							if (err.startsWith("{") && err.endsWith("}")) {
 								// Could be JSON, let's try to parse it
 								try {
@@ -385,7 +386,7 @@ public class NetUtil {
 				if (etag != null) {
 					writeString(etagFile(file, metaSaveDir), etag);
 				}
-				verboseMsg(String.format("Downloaded file %s", conn.getURL().toExternalForm()));
+				verboseMsg(NETWORK, String.format("Downloaded file %s", conn.getURL().toExternalForm()));
 				return file;
 			};
 		}
@@ -451,8 +452,9 @@ public class NetUtil {
 					if (conn instanceof HttpURLConnection) {
 						HttpURLConnection httpConn = (HttpURLConnection) conn;
 						if (httpConn.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
-							verboseMsg(String.format("Not modified, using cached file %s for remote %s", cachedFile,
-									conn.getURL().toExternalForm()));
+							verboseMsg(NETWORK,
+									String.format("Not modified, using cached file %s for remote %s", cachedFile,
+											conn.getURL().toExternalForm()));
 							// Update cached file's last modified time
 							try {
 								Files.setLastModifiedTime(cachedFile, FileTime.from(ZonedDateTime.now().toInstant()));
@@ -464,7 +466,7 @@ public class NetUtil {
 								// that, so we'll just ignore it. It does mean that files affected by this will
 								// be
 								// re-downloaded every time.
-								verboseMsg("Unable to set last-modified time for " + cachedFile, e);
+								verboseMsg(NETWORK, "Unable to set last-modified time for " + cachedFile, e);
 							}
 							return cachedFile;
 						}
@@ -532,7 +534,7 @@ public class NetUtil {
 				// Right now it assumes we're always trying to get Java
 				// source files which just isn't the case (eg //FILES)
 				url = new URL(swizzleURL(url.toString()));
-				verboseMsg("Redirected to: " + url); // Should be debug info
+				verboseMsg(NETWORK, "Redirected to: " + url); // Should be debug info
 				httpConn = (HttpURLConnection) url.openConnection();
 				if (responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
 					// This response code forces the method to GET
@@ -607,7 +609,7 @@ public class NetUtil {
 						password = line.substring(9);
 				}
 				if (!isNullOrBlankString(username) && !isNullOrBlankString(password)) {
-					verboseMsg("Using git credential for host: " + h);
+					verboseMsg(NETWORK, "Using git credential for host: " + h);
 					return new String[] { username, password };
 				}
 			}
@@ -625,7 +627,7 @@ public class NetUtil {
 			String token = Util.runCommandQuietly(null, null, AUTH_HELPER_TIMEOUT_SECONDS,
 					"gh", "auth", "token", "--hostname", host);
 			if (!isNullOrBlankString(token)) {
-				verboseMsg("Using gh auth token for host: " + host);
+				verboseMsg(NETWORK, "Using gh auth token for host: " + host);
 				return new String[] { "", token.trim() };
 			}
 			return null;
@@ -641,7 +643,7 @@ public class NetUtil {
 			String token = Util.runCommandQuietly(null, null, AUTH_HELPER_TIMEOUT_SECONDS,
 					"glab", "config", "get", "token", "--host", host);
 			if (!isNullOrBlankString(token)) {
-				verboseMsg("Using glab auth token for host: " + host);
+				verboseMsg(NETWORK, "Using glab auth token for host: " + host);
 				return new String[] { "", token.trim() };
 			}
 			return null;
@@ -663,9 +665,9 @@ public class NetUtil {
 			if (isNullOrBlankString(username)) {
 				return null;
 			}
-			verboseMsg("Using " + userName + " and " + passName + " environment variables");
+			verboseMsg(NETWORK, "Using " + userName + " and " + passName + " environment variables");
 		} else {
-			verboseMsg("Using " + passName + " environment variable");
+			verboseMsg(NETWORK, "Using " + passName + " environment variable");
 		}
 		return new String[] { username, password };
 	}
@@ -691,7 +693,7 @@ public class NetUtil {
 			String password = credentials.length > 1 ? PropertiesValueResolver.replaceProperties(credentials[1])
 					: "";
 			auth = AuthHeader.authorization(toBasicAuth(username, password));
-			verboseMsg("Using URL credentials for host: " + host);
+			verboseMsg(NETWORK, "Using URL credentials for host: " + host);
 		}
 
 		// 2. .netrc exact host match (more specific than env vars)
@@ -711,10 +713,10 @@ public class NetUtil {
 			String gitlabToken = System.getenv("GITLAB_TOKEN");
 			if (isAGithubUrl(urlConnection) && !isNullOrBlankString(githubToken)) {
 				auth = AuthHeader.authorization("Bearer " + githubToken);
-				verboseMsg("Using GITHUB_TOKEN environment variable for host: " + host);
+				verboseMsg(NETWORK, "Using GITHUB_TOKEN environment variable for host: " + host);
 			} else if (isAGitlabUrl(urlConnection) && !isNullOrBlankString(gitlabToken)) {
 				auth = AuthHeader.authorization("Bearer " + gitlabToken);
-				verboseMsg("Using GITLAB_TOKEN environment variable for host: " + host);
+				verboseMsg(NETWORK, "Using GITLAB_TOKEN environment variable for host: " + host);
 			}
 		}
 
@@ -732,13 +734,13 @@ public class NetUtil {
 			String password = System.getenv(JBANG_AUTH_BASIC_PASSWORD);
 			if (!isNullOrBlankString(username) && !isNullOrBlankString(password)) {
 				auth = AuthHeader.authorization(toBasicAuth(username, password));
-				verboseMsg("Using JBANG_AUTH_BASIC environment variables for host: " + host);
+				verboseMsg(NETWORK, "Using JBANG_AUTH_BASIC environment variables for host: " + host);
 			}
 		}
 
 		if (auth != null) {
 			urlConnection.setRequestProperty(auth.name, auth.value);
-			verboseMsg("Set " + auth.name + " header for host: " + host);
+			verboseMsg(NETWORK, "Set " + auth.name + " header for host: " + host);
 		}
 	}
 
@@ -751,7 +753,7 @@ public class NetUtil {
 		case "bearer":
 			return AuthHeader.authorization("Bearer " + creds[1]);
 		default:
-			verboseMsg("Unknown jbang-auth-scheme: " + scheme + ", using basic");
+			verboseMsg(NETWORK, "Unknown jbang-auth-scheme: " + scheme + ", using basic");
 			return AuthHeader.authorization(toBasicAuth(creds[0], creds[1]));
 		}
 	}
@@ -832,10 +834,10 @@ public class NetUtil {
 		String githubToken = System.getenv("GITHUB_TOKEN");
 		String gitlabToken = System.getenv("GITLAB_TOKEN");
 		if (isAGithubHost(host) && !isNullOrBlankString(githubToken)) {
-			verboseMsg("Using GITHUB_TOKEN for host: " + host);
+			verboseMsg(NETWORK, "Using GITHUB_TOKEN for host: " + host);
 			return new String[] { "", githubToken };
 		} else if (isAGitlabHost(host) && !isNullOrBlankString(gitlabToken)) {
-			verboseMsg("Using GITLAB_TOKEN for host: " + host);
+			verboseMsg(NETWORK, "Using GITLAB_TOKEN for host: " + host);
 			return new String[] { "__token__", gitlabToken };
 		}
 
@@ -851,11 +853,11 @@ public class NetUtil {
 		String envUser = System.getenv(JBANG_AUTH_BASIC_USERNAME);
 		String envPass = System.getenv(JBANG_AUTH_BASIC_PASSWORD);
 		if (!isNullOrBlankString(envUser) && !isNullOrBlankString(envPass)) {
-			verboseMsg("Using JBANG_AUTH_BASIC for host: " + host);
+			verboseMsg(NETWORK, "Using JBANG_AUTH_BASIC for host: " + host);
 			return new String[] { envUser, envPass };
 		}
 
-		verboseMsg("No credentials found for host: " + host);
+		verboseMsg(NETWORK, "No credentials found for host: " + host);
 		return null;
 	}
 
@@ -878,7 +880,7 @@ public class NetUtil {
 			}
 		}
 		if (!isNullOrBlankString(entry.getLogin()) && !isNullOrBlankString(entry.getPassword())) {
-			verboseMsg("Using .netrc credentials for host: " + host);
+			verboseMsg(NETWORK, "Using .netrc credentials for host: " + host);
 			return new String[] { entry.getLogin(), entry.getPassword() };
 		}
 		return null;
@@ -896,7 +898,7 @@ public class NetUtil {
 			if (method.startsWith("env.") && method.length() > 4) {
 				return getEnvCredentials(method.substring(4), login);
 			}
-			verboseMsg("Unknown jbang-auth method: " + method);
+			verboseMsg(NETWORK, "Unknown jbang-auth method: " + method);
 			return null;
 		}
 	}

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -38,8 +38,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -109,6 +111,7 @@ public class Util {
 	public static final String MAIN_JAVA = "main.java";
 
 	private static boolean verbose;
+	private static EnumSet<VerboseCategory> verboseCategories = EnumSet.noneOf(VerboseCategory.class);
 	private static boolean quiet;
 	private static boolean offline;
 	private static boolean fresh;
@@ -123,6 +126,9 @@ public class Util {
 
 	public static void setVerbose(boolean verbose) {
 		Util.verbose = verbose;
+		verboseCategories = verbose
+				? EnumSet.allOf(VerboseCategory.class)
+				: EnumSet.noneOf(VerboseCategory.class);
 		if (verbose) {
 			setQuiet(false);
 		}
@@ -132,6 +138,84 @@ public class Util {
 
 	public static boolean isVerbose() {
 		return verbose;
+	}
+
+	public enum VerboseCategory {
+		COMMANDS,
+		NETWORK,
+		BUILD,
+		CONFIG,
+		INTERNALS
+	}
+
+	public static void setVerboseCategories(String expression) {
+		if (expression == null) {
+			setVerbose(false);
+			return;
+		}
+		String value = expression.trim();
+		if ("true".equalsIgnoreCase(value) || "all".equalsIgnoreCase(value)) {
+			setVerbose(true);
+			return;
+		}
+		if ("false".equalsIgnoreCase(value) || value.isEmpty()) {
+			setVerbose(false);
+			return;
+		}
+
+		String[] parts = value.split(",", -1);
+		boolean hasPositive = Arrays.stream(parts).anyMatch(part -> !part.trim().startsWith("-"));
+		EnumSet<VerboseCategory> categories = hasPositive
+				? EnumSet.noneOf(VerboseCategory.class)
+				: EnumSet.allOf(VerboseCategory.class);
+		for (String part : parts) {
+			String categoryName = part.trim();
+			boolean exclude = categoryName.startsWith("-");
+			if (exclude) {
+				categoryName = categoryName.substring(1).trim();
+			}
+			if (categoryName.isEmpty()) {
+				throw new IllegalArgumentException("Empty verbose category. Valid categories: "
+						+ verboseCategoryNames());
+			}
+			if ("all".equalsIgnoreCase(categoryName)) {
+				if (exclude) {
+					categories.clear();
+				} else {
+					categories.addAll(EnumSet.allOf(VerboseCategory.class));
+				}
+				continue;
+			}
+			VerboseCategory category;
+			try {
+				category = VerboseCategory.valueOf(categoryName.toUpperCase(Locale.ROOT));
+			} catch (IllegalArgumentException e) {
+				throw new IllegalArgumentException("Unknown verbose category '" + categoryName
+						+ "'. Valid categories: " + verboseCategoryNames());
+			}
+			if (exclude) {
+				categories.remove(category);
+			} else {
+				categories.add(category);
+			}
+		}
+		verboseCategories = categories;
+		verbose = !categories.isEmpty();
+		if (verbose) {
+			setQuiet(false);
+		}
+		Logger.getLogger("dev.jbang")
+			.setLevel(verbose ? java.util.logging.Level.FINE : java.util.logging.Level.INFO);
+	}
+
+	private static String verboseCategoryNames() {
+		return Arrays.stream(VerboseCategory.values())
+			.map(category -> category.name().toLowerCase(Locale.ROOT))
+			.collect(Collectors.joining(", ")) + ", all";
+	}
+
+	public static boolean isVerbose(VerboseCategory category) {
+		return verboseCategories.contains(category);
 	}
 
 	public static void setQuiet(boolean quiet) {
@@ -492,17 +576,25 @@ public class Util {
 	}
 
 	static public void verboseMsg(String msg) {
-		if (isVerbose()) {
+		verboseMsg(VerboseCategory.INTERNALS, msg);
+	}
+
+	static public void verboseMsg(VerboseCategory category, String msg) {
+		if (isVerbose(category)) {
 			System.err.print(getMsgHeader());
 			System.err.println(msg);
 		}
 	}
 
 	static public void verboseMsg(String msg, Throwable e) {
-		if (isVerbose()) {
+		verboseMsg(VerboseCategory.INTERNALS, msg, e);
+	}
+
+	static public void verboseMsg(VerboseCategory category, String msg, Throwable e) {
+		if (isVerbose(category)) {
 			System.err.print(getMsgHeader());
 			System.err.println(msg);
-			if (printExceptions() || isVerbose()) {
+			if (printExceptions() || isVerbose(category)) {
 				e.printStackTrace();
 			}
 		}
@@ -550,7 +642,7 @@ public class Util {
 		} else {
 			System.err.println(e.getClass().toGenericString());
 		}
-		if (isVerbose() || printExceptions()) {
+		if (isVerbose(VerboseCategory.INTERNALS) || printExceptions()) {
 			e.printStackTrace();
 		} else {
 			if (msg != null) {
@@ -1005,7 +1097,7 @@ public class Util {
 				boolean finished = p.waitFor(timeoutSeconds, TimeUnit.SECONDS);
 				if (!finished) {
 					p.destroyForcibly();
-					verboseMsg("Command timed out: " + String.join(" ", cmd));
+					verboseMsg(VerboseCategory.COMMANDS, "Command timed out: " + String.join(" ", cmd));
 					return null;
 				}
 				exitCode = p.exitValue();
@@ -1014,17 +1106,18 @@ public class Util {
 			if (exitCode == 0) {
 				return cmdOutput;
 			} else if (logOutput) {
-				verboseMsg(String.format("Command failed: #%d - %s", exitCode, cmdOutput));
+				verboseMsg(VerboseCategory.COMMANDS, String.format("Command failed: #%d - %s", exitCode, cmdOutput));
 			} else {
-				verboseMsg(String.format("Command failed: #%d - %s", exitCode, String.join(" ", cmd)));
+				verboseMsg(VerboseCategory.COMMANDS,
+						String.format("Command failed: #%d - %s", exitCode, String.join(" ", cmd)));
 			}
 		} catch (CompletionException ex) {
-			verboseMsg("Error reading output from: " + String.join(" ", cmd), ex);
+			verboseMsg(VerboseCategory.COMMANDS, "Error reading output from: " + String.join(" ", cmd), ex);
 		} catch (IOException ex) {
-			verboseMsg("Error running: " + String.join(" ", cmd), ex);
+			verboseMsg(VerboseCategory.COMMANDS, "Error running: " + String.join(" ", cmd), ex);
 		} catch (InterruptedException ex) {
 			Thread.currentThread().interrupt();
-			verboseMsg("Interrupted running: " + String.join(" ", cmd), ex);
+			verboseMsg(VerboseCategory.COMMANDS, "Interrupted running: " + String.join(" ", cmd), ex);
 		}
 		return null;
 	}

--- a/src/test/java/dev/jbang/cli/TestAeshParsing.java
+++ b/src/test/java/dev/jbang/cli/TestAeshParsing.java
@@ -37,7 +37,32 @@ class TestAeshParsing extends BaseTest {
 	void testVerboseAloneWorks() {
 		JBang.parseCommand("run", "--verbose", "test.java");
 		assertThat(Util.isVerbose(), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.COMMANDS), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.INTERNALS), is(true));
 		assertThat(Util.isQuiet(), is(false));
+	}
+
+	@Test
+	void testVerboseCategories() {
+		JBang.parseCommand("run", "--verbose=commands,network", "test.java");
+		assertThat(Util.isVerbose(Util.VerboseCategory.COMMANDS), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.NETWORK), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.BUILD), is(false));
+		assertThat(Util.isVerbose(Util.VerboseCategory.INTERNALS), is(false));
+	}
+
+	@Test
+	void testVerboseCategoryExclusion() {
+		JBang.parseCommand("run", "--verbose=-internals", "test.java");
+		assertThat(Util.isVerbose(Util.VerboseCategory.COMMANDS), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.NETWORK), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.INTERNALS), is(false));
+	}
+
+	@Test
+	void testUnknownVerboseCategoryFails() {
+		assertThrows(RuntimeException.class,
+				() -> JBang.parseCommand("run", "--verbose=unknown", "test.java"));
 	}
 
 	@Test
@@ -182,6 +207,18 @@ class TestAeshParsing extends BaseTest {
 	}
 
 	@Test
+	void testVerboseCategoriesFromConfig() throws IOException {
+		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS),
+				"verbose = commands,network\n".getBytes());
+		Configuration.instance(null);
+
+		JBang.parseCommand("run", "test.java");
+		assertThat(Util.isVerbose(Util.VerboseCategory.COMMANDS), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.NETWORK), is(true));
+		assertThat(Util.isVerbose(Util.VerboseCategory.INTERNALS), is(false));
+	}
+
+	@Test
 	void testDefaultValueProviderSkipsDebug() throws IOException {
 		String config = "run.debug = 5005\n";
 		Files.write(jbangTempDir.resolve(Configuration.JBANG_CONFIG_PROPS), config.getBytes());
@@ -257,6 +294,20 @@ class TestAeshParsing extends BaseTest {
 		Util.setVerbose(true);
 		JBang.parseCommand("run", "--verbose=false", "test.java");
 		assertThat(Util.isVerbose(), is(false));
+	}
+
+	@Test
+	void testVerboseCategoryFiltersMessages() throws Exception {
+		JBang.parseCommand("run", "--verbose=commands", "test.java");
+		CaptureResult<Void> result = captureOutput(() -> {
+			Util.verboseMsg(Util.VerboseCategory.COMMANDS, "command message");
+			Util.verboseMsg(Util.VerboseCategory.NETWORK, "network message");
+			Util.verboseMsg("internal message");
+			return null;
+		});
+		assertThat(result.normalizedErr(), containsString("command message"));
+		assertThat(result.normalizedErr(), not(containsString("network message")));
+		assertThat(result.normalizedErr(), not(containsString("internal message")));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Adds category-based verbose filtering so users can inspect specific areas without enabling all internal diagnostic output.

Closes #2601.

## Changes

- Adds verbose categories:
  - `commands`
  - `network`
  - `build`
  - `config`
  - `internals`
- Supports comma-separated categories, for example:
  - `--verbose=commands`
  - `--verbose=commands,network`
- Supports exclusions, for example:
  - `--verbose=-internals`
- Preserves existing behavior for:
  - `--verbose`
  - `--verbose=all`
  - `--verbose=true`
  - `--verbose=false`
  - `--no-verbose`
- Supports configured category defaults:
  - `jbang config set verbose commands,network`
- Categorizes existing command, network, build, dependency, configuration, and catalog diagnostics.
- Treats existing uncategorized verbose messages as `internals`.
- Updates troubleshooting and authentication documentation.

## Testing

- Added tests covering category selection, multiple categories, exclusions, configuration defaults, invalid categories, legacy boolean values, and message filtering.
- Ran `./gradlew test --tests "dev.jbang.cli.TestAeshParsing"`.
- Ran `./gradlew spotlessCheck`.
- Manually verified packaged CLI behavior for selective, bare, and invalid verbose values.