### PR TITLE
feat: prefer relative symbolic links

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -28,6 +28,8 @@ Once you have jbang installed, it is recommended you run `jbang app setup`. This
 [NOTE]
 ====
 By default `jbang` uses `~/.jbang` for configurations and build cache. This can be changed using the environment variable `JBANG_DIR`.
+
+Symbolic links use relative targets when the target is beneath the link's parent directory. This allows linked directory trees, such as the JBang directory, to remain usable when they are moved or mounted into a container. On Windows, JBang prefers symbolic links for directories when they are available and falls back to directory junctions otherwise.
 ====
 
 == Installation Methods

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1062,7 +1062,7 @@ public class Util {
 
 	public static void createLink(Path link, Path target) {
 		if (!Files.exists(link)) {
-			Path linkTarget = getLinkTarget(link, target);
+			Path linkTarget = relativizeLinkTarget(link, target);
 			if (isWindows() && Files.isDirectory(target)) {
 				// Prefer symbolic links when Windows Developer Mode or sufficient
 				// privileges make them available, but retain junctions as a fallback.
@@ -1082,7 +1082,7 @@ public class Util {
 		}
 	}
 
-	static Path getLinkTarget(Path link, Path target) {
+	static Path relativizeLinkTarget(Path link, Path target) {
 		Path linkParent = link.toAbsolutePath().normalize().getParent();
 		Path absoluteTarget = target.toAbsolutePath().normalize();
 		if (linkParent != null && absoluteTarget.startsWith(linkParent)) {

--- a/src/main/java/dev/jbang/util/Util.java
+++ b/src/main/java/dev/jbang/util/Util.java
@@ -1062,14 +1062,18 @@ public class Util {
 
 	public static void createLink(Path link, Path target) {
 		if (!Files.exists(link)) {
-			// On Windows we use junction for directories because their
-			// creation doesn't require any special privileges.
+			Path linkTarget = getLinkTarget(link, target);
 			if (isWindows() && Files.isDirectory(target)) {
+				// Prefer symbolic links when Windows Developer Mode or sufficient
+				// privileges make them available, but retain junctions as a fallback.
+				if (createSymbolicLink(link, linkTarget, false)) {
+					return;
+				}
 				if (createJunction(link, target.toAbsolutePath())) {
 					return;
 				}
 			} else {
-				if (createSymbolicLink(link, target.toAbsolutePath())) {
+				if (createSymbolicLink(link, linkTarget, true)) {
 					return;
 				}
 			}
@@ -1078,12 +1082,22 @@ public class Util {
 		}
 	}
 
-	private static boolean createSymbolicLink(Path link, Path target) {
+	static Path getLinkTarget(Path link, Path target) {
+		Path linkParent = link.toAbsolutePath().normalize().getParent();
+		Path absoluteTarget = target.toAbsolutePath().normalize();
+		if (linkParent != null && absoluteTarget.startsWith(linkParent)) {
+			return linkParent.relativize(absoluteTarget);
+		}
+		return absoluteTarget;
+	}
+
+	private static boolean createSymbolicLink(Path link, Path target, boolean reportWindowsFailure) {
 		try {
 			Files.createSymbolicLink(link, target);
 			return true;
 		} catch (IOException e) {
-			if (isWindows() && e instanceof AccessDeniedException && e.getMessage().contains("privilege")) {
+			if (reportWindowsFailure && isWindows() && e instanceof AccessDeniedException
+					&& e.getMessage().contains("privilege")) {
 				infoMsg(String.format("Creation of symbolic link failed %s -> %s", link, target));
 				infoMsg("This is a known issue with trying to create symbolic links on Windows.");
 				infoMsg("See the information available at the link below for a solution:");

--- a/src/test/java/dev/jbang/util/TestUtil.java
+++ b/src/test/java/dev/jbang/util/TestUtil.java
@@ -26,21 +26,21 @@ public class TestUtil extends BaseTest {
 	}
 
 	@Test
-	void testGetLinkTargetWithinLinkParentIsRelative() throws IOException {
+	void testRelativizeLinkTargetWithinLinkParent() throws IOException {
 		Path root = Files.createTempDirectory("jbang-link");
 		Path link = root.resolve("current");
 		Path target = root.resolve("cache").resolve("jdks").resolve("21");
 
-		assertEquals(root.relativize(target), Util.getLinkTarget(link, target));
+		assertEquals(root.relativize(target), Util.relativizeLinkTarget(link, target));
 	}
 
 	@Test
-	void testGetLinkTargetOutsideLinkParentIsAbsolute() throws IOException {
+	void testRelativizeLinkTargetOutsideLinkParent() throws IOException {
 		Path root = Files.createTempDirectory("jbang-link");
 		Path link = root.resolve("links").resolve("current");
 		Path target = root.resolve("targets").resolve("21");
 
-		assertEquals(target.toAbsolutePath(), Util.getLinkTarget(link, target));
+		assertEquals(target.toAbsolutePath(), Util.relativizeLinkTarget(link, target));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/util/TestUtil.java
+++ b/src/test/java/dev/jbang/util/TestUtil.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -22,6 +23,24 @@ import dev.jbang.catalog.Catalog;
 public class TestUtil extends BaseTest {
 	public static void clearSettingsCaches() {
 		Catalog.clearCache();
+	}
+
+	@Test
+	void testGetLinkTargetWithinLinkParentIsRelative() throws IOException {
+		Path root = Files.createTempDirectory("jbang-link");
+		Path link = root.resolve("current");
+		Path target = root.resolve("cache").resolve("jdks").resolve("21");
+
+		assertEquals(root.relativize(target), Util.getLinkTarget(link, target));
+	}
+
+	@Test
+	void testGetLinkTargetOutsideLinkParentIsAbsolute() throws IOException {
+		Path root = Files.createTempDirectory("jbang-link");
+		Path link = root.resolve("links").resolve("current");
+		Path target = root.resolve("targets").resolve("21");
+
+		assertEquals(target.toAbsolutePath(), Util.getLinkTarget(link, target));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Create relative symbolic links when the target is beneath the link’s parent directory.
- Prefer symbolic links for Windows directories when supported.
- Fall back to directory junctions when Windows symbolic-link creation is unavailable.
- Document the behavior for relocated or container-mounted JBang directories.
- Add unit tests for relative and absolute link-target selection.

Fixes #2573.

## Validation

- `./gradlew test --tests "dev.jbang.util.TestUtil"`
- `./gradlew spotlessCheck`
- Compilation completed successfully.