### PR TITLE
fix: jbang build --native from existing/pre-built jar

### DIFF
--- a/src/main/java/dev/jbang/source/AppBuilder.java
+++ b/src/main/java/dev/jbang/source/AppBuilder.java
@@ -109,6 +109,8 @@ public abstract class AppBuilder implements Builder<CmdGeneratorBuilder> {
 		}
 
 		if (nativeBuildRequired) {
+			Path outputDir = ctx.getNativeImageFile().getParent();
+			outputDir.toFile().mkdirs();
 			if (integrationResult.nativeImagePath != null) {
 				Files.move(integrationResult.nativeImagePath, ctx.getNativeImageFile());
 			} else {

--- a/src/test/java/dev/jbang/source/TestBuilder.java
+++ b/src/test/java/dev/jbang/source/TestBuilder.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -416,6 +417,30 @@ public class TestBuilder extends BaseTest {
 		runBuild(ctx, (ctxx, optionList) -> {
 		}, null, null, (ctxx, optionList) -> callCount.incrementAndGet());
 		assertThat(callCount.get(), equalTo(2));
+	}
+
+	@Test
+	void testNativeFromExecutableArchive() throws IOException {
+		// A native build from a pre-built jar skips the jar step that creates the
+		// output dir.
+		Path jar = examplesTestFolder.resolve("hellojar.jar");
+
+		ProjectBuilder pb = Project.builder().nativeImage(true);
+		Project prj = pb.build(jar.toString());
+		assertThat(prj.isExecutableArchive(), is(true));
+		BuildContext ctx = BuildContext.forProject(prj);
+
+		runBuild(ctx, null, null, null, (ctxx, optionList) -> {
+			try {
+				// Copy the input .jar into the executable output file to simulate something was
+				// "built", note that native-image is not executed here.
+				Files.copy(jar, ctxx.getNativeImageFile());
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+
+		assertThat(Files.exists(ctx.getNativeImageFile()), is(true));
 	}
 
 	@Test


### PR DESCRIPTION
Huge fan of jbang! I also maintain the AUR [jbang](https://aur.archlinux.org/packages/jbang) for Arch.

### Issue description
When installing a native image from an existing/pre-built jar e.g. `jbang app install --native myapp.jar`,  
the `native-image` invocation fails with the following error:

```
Error: Writing image to non-existent directory /home/mukel/.jbang/cache/jars/myapp.jar.e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 is not allowed.  
Create the missing directory if you want the image to be written to that location.
```

Note that this works when building from sources because the folder is created by jbang's when building from sources.

### Implemented fix
Always create the output folder for `native-image` explicitly.  
Regression test included.