### PR TITLE
build: upgrade aesh to 3.16.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ plugins {
 def allureVersion = '2.29.1'
 def aspectJVersion = '1.9.25'
 def assertjVersion = '3.27.7'
-def aeshVersion = '3.16.5'
+def aeshVersion = '3.16.6'
 def devkitmanVersion = '0.4.9'
 def junitBomVersion = '5.14.4'
 def testcontainersVersion = '2.0.2'


### PR DESCRIPTION
Picks up aesh fixes:
- #557: command-not-found message now suggests --help instead of non-existent help subcommand
- #558: group command --help no longer prints spurious 'unknown option'
