### PR TITLE
feat: add gradle versions plugin to settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ resolutionStrategy {
 plugins {
 	id "com.gradle.develocity" version "4.3.2"
 	id "org.gradle.toolchains.foojay-resolver-convention" version "1.0.0"
+	id "io.github.ben-manes.versions.settings" version "0.56.0"
 }
 
 develocity {


### PR DESCRIPTION
I've submited a PR for this plugin in the past, and proposed that it be added to the main build.gradle file. The plugin should rather be  added to the settings.gradle file, as implemented by this PR,  and then available dependency updates can be viewed from the command-line by running:

`./gradlew dependencyUpdates`

This is really useful functionality, if you want to quickly check if any dependencies can be updated.