### PR TITLE
feat: make `app install` fetch fresh resources by default

### DIFF
--- a/docs/modules/ROOT/pages/app-installation.adoc
+++ b/docs/modules/ROOT/pages/app-installation.adoc
@@ -118,8 +118,11 @@ jbang app uninstall mytool
 
 [source,bash]
 ----
-# Reinstall to update
+# Reinstall to update (always fetches fresh sources and dependencies)
 jbang app install --force gavsearch@jbangdev
+
+# Reuse cached resources instead
+jbang app install --force --no-fresh gavsearch@jbangdev
 ----
 
 == Installation Options

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -82,6 +82,11 @@ public class App extends BaseCommand {
 
 		@Override
 		public Integer doCall() throws IOException {
+			// Installing is a rare, explicit act: fetch the latest sources and
+			// dependencies unless the user asked for cached or offline behaviour.
+			if (fresh == null && !Util.isOffline()) {
+				Util.setFresh(true);
+			}
 			scriptMixin.validate();
 			boolean installed = false;
 			try {

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -125,6 +125,19 @@ public class TestApp extends BaseTest {
 	}
 
 	@Test
+	void testAppInstallDefaultsToFresh() throws Exception {
+		String src = examplesTestFolder.resolve("with space/helloworld.java").toString();
+		checkedRun("app", "install", "--no-build", "--force", src);
+		assertThat(Util.isFresh(), is(true));
+
+		checkedRun("app", "install", "--no-build", "--force", "--no-fresh", src);
+		assertThat(Util.isFresh(), is(false));
+
+		checkedRun("app", "install", "--no-build", "--force", "--offline", src);
+		assertThat(Util.isFresh(), is(false));
+	}
+
+	@Test
 	void testAppInstallWithRepos() throws Exception {
 		String src = examplesTestFolder.resolve("repos.java").toString();
 		App.AppInstall app = JBang.parseCommand("app", "install", "--no-build", "--fresh", "--force",


### PR DESCRIPTION
🤖 Copy-pasting `jbang app install --force <app>` did not pick up updated -SNAPSHOT dependencies, because installs reused cached resources. Following the suggestion in the review, `app install` now defaults to fresh resolution while runs stay lazy; `--no-fresh` or `--offline` opts back out.

Test: `jbang app install --force gavsearch@jbangdev` picks up a new snapshot; `--no-fresh` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)