### PR TITLE
fix: honor //JAVA version in edit --sandbox gradle

### DIFF
--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -30,6 +30,7 @@ import dev.jbang.net.EditorManager;
 import dev.jbang.resources.ResourceRef;
 import dev.jbang.source.*;
 import dev.jbang.util.CommandBuffer;
+import dev.jbang.util.JavaUtil;
 import dev.jbang.util.TemplateEngine;
 import dev.jbang.util.Util;
 import dev.jbang.util.Util.Shell;
@@ -474,7 +475,10 @@ public class Edit extends BaseCommand {
 			prj.addRepository(DependencyUtil.toMavenRepo(DependencyUtil.ALIAS_JITPACK));
 		}
 
+		String javaVersion = getJavaVersion(prj);
+
 		renderTemplate(engine, depIds, fullClassName, baseName, resolvedDependencies, repositories,
+				javaVersion,
 				templateRef,
 				arguments,
 				destination);
@@ -483,6 +487,7 @@ public class Edit extends BaseCommand {
 		templateRef = ResourceRef.forResource("classpath:/.qute.classpath");
 		destination = tmpProjectDir.resolve(".classpath");
 		renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+				javaVersion,
 				templateRef,
 				arguments,
 				destination);
@@ -490,6 +495,7 @@ public class Edit extends BaseCommand {
 		templateRef = ResourceRef.forResource("classpath:/.qute.project");
 		destination = tmpProjectDir.resolve(".project");
 		renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+				javaVersion,
 				templateRef,
 				arguments,
 				destination);
@@ -498,6 +504,7 @@ public class Edit extends BaseCommand {
 		destination = tmpProjectDir.resolve(".eclipse/" + baseName + ".launch");
 		destination.toFile().getParentFile().mkdirs();
 		renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+				javaVersion,
 				templateRef,
 				arguments,
 				destination);
@@ -505,6 +512,7 @@ public class Edit extends BaseCommand {
 		templateRef = ResourceRef.forResource("classpath:/main-port-4004.qute.launch");
 		destination = tmpProjectDir.resolve(".eclipse/" + baseName + "-port-4004.launch");
 		renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+				javaVersion,
 				templateRef,
 				arguments,
 				destination);
@@ -515,6 +523,7 @@ public class Edit extends BaseCommand {
 		if (isNeeded(reload, destination)) {
 			destination.toFile().getParentFile().mkdirs();
 			renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+					javaVersion,
 					templateRef,
 					arguments,
 					destination);
@@ -526,6 +535,7 @@ public class Edit extends BaseCommand {
 		if (isNeeded(reload, destination)) {
 			destination.toFile().getParentFile().mkdirs();
 			renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+					javaVersion,
 					templateRef,
 					arguments,
 					destination);
@@ -536,6 +546,7 @@ public class Edit extends BaseCommand {
 		if (isNeeded(reload, destination)) {
 			destination.toFile().getParentFile().mkdirs();
 			renderTemplate(engine, dependencies, fullClassName, baseName, resolvedDependencies, repositories,
+					javaVersion,
 					templateRef,
 					arguments,
 					destination);
@@ -548,9 +559,20 @@ public class Edit extends BaseCommand {
 		return !file.toFile().exists() && !reload;
 	}
 
+	/**
+	 * Numeric Java major version for Gradle toolchain languageVersion, matching
+	 * export gradle behavior (//JAVA 21 / 21+ → "21").
+	 */
+	private String getJavaVersion(Project prj) {
+		if (prj.getJavaVersion() == null) {
+			return null;
+		}
+		return Integer.toString(JavaUtil.minRequestedVersion(prj.getJavaVersion()));
+	}
+
 	private void renderTemplate(TemplateEngine engine, List<String> collectDependencies, String fullclassName,
-			String baseName, List<String> resolvedDependencies, List<MavenRepo> repositories, ResourceRef templateRef,
-			List<String> userParams, Path destination)
+			String baseName, List<String> resolvedDependencies, List<MavenRepo> repositories, String javaVersion,
+			ResourceRef templateRef, List<String> userParams, Path destination)
 			throws IOException {
 		Template template = engine.getTemplate(templateRef);
 		if (template == null)
@@ -564,6 +586,7 @@ public class Edit extends BaseCommand {
 			.data("gradledependencies", gradleify(collectDependencies))
 			.data("baseName", baseName)
 			.data("fullClassName", fullclassName)
+			.data("javaVersion", javaVersion)
 			.data("classpath",
 					resolvedDependencies.stream()
 						.filter(t -> !t.isEmpty())

--- a/src/main/resources/build.qute.gradle
+++ b/src/main/resources/build.qute.gradle
@@ -12,6 +12,14 @@ repositories {
 {/for}
 }
 
+{#if javaVersion}
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of({javaVersion})
+	}
+}
+{/if}
+
 dependencies {
 {#for item in gradledependencies}
 	{item}

--- a/src/test/java/dev/jbang/cli/TestEdit.java
+++ b/src/test/java/dev/jbang/cli/TestEdit.java
@@ -99,6 +99,8 @@ public class TestEdit extends BaseTest {
 		assertThat(buildGradle, containsString("mainClass = 'edit'"));
 		assertThat(buildGradle, containsString("repo1.maven.org")); // auto-added maven
 		assertThat(buildGradle, not(containsString("jitpack.io"))); // auto-added jitpack repo
+		// no //JAVA directive → sandbox build.gradle must not force a toolchain
+		assertThat(buildGradle, not(containsString("JavaLanguageVersion")));
 
 		Path java = project.resolve("src/edit.java");
 
@@ -107,6 +109,50 @@ public class TestEdit extends BaseTest {
 		assert (Files.isSymbolicLink(java) || Files.exists(java));
 
 		assertThat(Files.isSameFile(java, p), equalTo(true));
+	}
+
+	@Test
+	void testEditJavaVersionToolchain(@TempDir Path outputDir) throws IOException {
+		// //JAVA must surface as a Gradle toolchain in edit --sandbox build.gradle
+		// (#2023)
+		Path p = outputDir.resolve("edit.java");
+		String s = p.toString();
+		JBang.execute("init", s);
+		assertThat(new File(s).exists(), is(true));
+
+		Util.writeString(p, "//JAVA 21\n" + Util.readString(p));
+
+		ProjectBuilder pb = Project.builder();
+		Project prj = pb.build(s);
+		assertThat(prj.getJavaVersion(), equalTo("21"));
+
+		Path project = new Edit().createProjectForLinkedEdit(prj, Collections.emptyList(), false);
+
+		Path gradle = project.resolve("build.gradle");
+		assert (Files.exists(gradle));
+		String buildGradle = Util.readString(gradle);
+		assertThat(buildGradle, containsString("JavaLanguageVersion.of(21)"));
+		assertThat(buildGradle, containsString("toolchain"));
+	}
+
+	@Test
+	void testEditJavaVersionPlusToolchain(@TempDir Path outputDir) throws IOException {
+		// //JAVA 17+ should use min major version 17 for the toolchain
+		Path p = outputDir.resolve("edit.java");
+		String s = p.toString();
+		JBang.execute("init", s);
+		assertThat(new File(s).exists(), is(true));
+
+		Util.writeString(p, "//JAVA 17+\n" + Util.readString(p));
+
+		ProjectBuilder pb = Project.builder();
+		Project prj = pb.build(s);
+		assertThat(prj.getJavaVersion(), equalTo("17+"));
+
+		Path project = new Edit().createProjectForLinkedEdit(prj, Collections.emptyList(), false);
+
+		String buildGradle = Util.readString(project.resolve("build.gradle"));
+		assertThat(buildGradle, containsString("JavaLanguageVersion.of(17)"));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #2023

`jbang edit --sandbox` ignored `//JAVA` (e.g. `//JAVA 21`) because the sandbox template `build.qute.gradle` had no toolchain block and `Edit.renderTemplate()` never passed `javaVersion`. Export already did this correctly via `export-build.qute.gradle`.

### Root cause
1. Sandbox edit uses `classpath:/build.qute.gradle` (no `java { toolchain { ... } }`).
2. `Edit.renderTemplate()` did not set template data `javaVersion` (unlike `ExportGradleProject.renderBuildFile`).

### Fix
- Thread numeric major version from `Project` into `createProjectForLinkedEdit` → `renderTemplate` (same `JavaUtil.minRequestedVersion` mapping as export: `21` / `21+` → `21`).
- Port the toolchain block from export into `build.qute.gradle`.
- Scope kept to `//JAVA` toolchain only (no enable-preview / compiler-args parity).

### Test plan
- [x] `./gradlew spotlessApply` + `spotlessCheck`
- [x] `./gradlew test --tests "dev.jbang.cli.TestEdit"` → **11 tests, 0 failures** (JDK Temurin 21, macOS arm64)
  - New: `testEditJavaVersionToolchain` (`//JAVA 21` → `JavaLanguageVersion.of(21)`)
  - New: `testEditJavaVersionPlusToolchain` (`//JAVA 17+` → `JavaLanguageVersion.of(17)`)
  - Existing tests still pass; no-`//JAVA` path asserts no toolchain forced

**Platform:** macOS arm64, Temurin 21.0.12