### PR TITLE
fix: select default init template by extension

### DIFF
--- a/docs/modules/ROOT/pages/multiple-languages.adoc
+++ b/docs/modules/ROOT/pages/multiple-languages.adoc
@@ -101,7 +101,14 @@ JBang supports Kotlin scripts using the Kotlin compiler.
 
 === Basic Kotlin Usage
 
-Create a file called `hello.kt`:
+Initialize a Kotlin script:
+
+[source,bash]
+----
+jbang init hello.kt
+----
+
+This creates `hello.kt` using the built-in Kotlin Hello World template. You can also create the file manually:
 
 [source,kotlin]
 ----

--- a/docs/modules/ROOT/pages/templates.adoc
+++ b/docs/modules/ROOT/pages/templates.adoc
@@ -16,6 +16,8 @@ toc::[]
 
 To get started you can run `jbang init helloworld.java` and a simple java class with a static main is generated.
 
+When no template is specified, JBang uses a `hello.<extension>` template matching the requested file extension when available. For example, `jbang init hello.kt` uses the built-in `hello.kt` template. Otherwise, it uses the Java `hello` template, which supports `.java` and extensionless file names.
+
 Using `jbang init --template=cli helloworld.java` you get a more complete Hello World CLI using https://picocli.info/[picocli] as dependency.
 
 Run `jbang template list` to see the full list of templates that are available.

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -81,7 +81,8 @@ public class Init extends BaseCommand {
 		requireScriptArgument();
 
 		if (initTemplate == null) {
-			initTemplate = "hello";
+			String extensionTemplate = "hello." + Util.extension(scriptOrFile);
+			initTemplate = dev.jbang.catalog.Template.get(extensionTemplate) != null ? extensionTemplate : "hello";
 		}
 
 		Map<String, Object> propsMap = new HashMap<>();

--- a/src/main/resources/jbang.properties
+++ b/src/main/resources/jbang.properties
@@ -1,5 +1,4 @@
 format=text
-init.template=hello
 run.debug=4004
 run.jfr=filename={baseName}.jfr
 wrapper.install.dir=.

--- a/src/test/java/dev/jbang/TestConfiguration.java
+++ b/src/test/java/dev/jbang/TestConfiguration.java
@@ -92,7 +92,7 @@ public class TestConfiguration extends BaseTest {
 	@Test
 	public void testDefaults() {
 		Configuration cfg = Configuration.defaults();
-		assertThat(cfg.get("init.template"), equalTo("hello"));
+		assertThat(cfg.get("init.template"), nullValue());
 		assertThat(cfg.get("run.debug"), equalTo("4004"));
 	}
 

--- a/src/test/java/dev/jbang/cli/TestConfig.java
+++ b/src/test/java/dev/jbang/cli/TestConfig.java
@@ -49,7 +49,6 @@ public class TestConfig extends BaseTest {
 		assertThat(result.result, equalTo(SUCCESS_EXIT));
 		assertThat(result.normalizedOut(),
 				equalTo("format = text\n" +
-						"init.template = hello\n" +
 						"one = footop\n" +
 						"run.debug = 4004\n" +
 						"run.jfr = filename={baseName}.jfr\n" +

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import dev.jbang.BaseTest;
@@ -147,6 +148,16 @@ public class TestInit extends BaseTest {
 		assertThat(result, is(0));
 		assertThat(new File(s).exists(), is(true));
 		assertThat(Util.readString(x), Matchers.containsString("class edit"));
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "kt, public fun main()", "groovy, println" })
+	void testDefaultLanguageInit(String extension, String expectedContent, @TempDir Path outputDir) throws IOException {
+		Path out = outputDir.resolve("edit." + extension);
+		int result = JBang.execute("init", out.toString());
+		assertThat(result, is(0));
+		assertThat(out.toFile().exists(), is(true));
+		assertThat(Util.readString(out), Matchers.containsString(expectedContent));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Fixes #2635.

When `jbang init` is used without an explicit template, JBang now selects an available `hello.<extension>` template matching the requested file extension.

For example:

```
jbang init hello.kt
```

now uses the built-in `hello.kt` template instead of selecting the Java `hello` template and failing with:

```
Template expects java extension, not kt
```

The existing Java template remains the fallback for `.java` and extensionless filenames. Explicit template selection and extension validation remain unchanged.

## Changes

- Select the default initialization template based on the requested extension.
- Add regression tests for Kotlin and Groovy initialization.
- Document extension-based default template selection.
- Document Kotlin script creation using `jbang init hello.kt`.

## Verification

```
./gradlew test --tests "dev.jbang.cli.TestInit"
```