### PR TITLE
feat: suggest closest subcommand for mistyped commands (#2628)

### DIFF
--- a/src/main/java/dev/jbang/Main.java
+++ b/src/main/java/dev/jbang/Main.java
@@ -15,6 +15,7 @@ import org.aesh.command.CommandResult;
 import dev.jbang.catalog.Alias;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.cli.JBang;
+import dev.jbang.search.SearchScorer;
 import dev.jbang.util.Util;
 import dev.jbang.util.VersionChecker;
 
@@ -220,6 +221,15 @@ public class Main {
 					System.out.println(cmdLine);
 					throw new ExitException(ExitException.EXIT_EXECUTE, cmdLine);
 				}
+				// Before falling through to implicit "run", check if the
+				// command looks like a typo of a known subcommand. Only
+				// suggest if the input doesn't look like a file/script
+				// reference (no path separators, no extensions, no URLs).
+				String suggestion = findClosestSubcommand(cmd);
+				if (suggestion != null && !looksLikeScriptRef(cmd)) {
+					Util.warnMsg("'" + cmd + "' is not a jbang command. Did you mean '" + suggestion + "'?");
+					Util.infoMsg("See 'jbang --help' for available commands.");
+				}
 				// In all other cases assume it's an implicit "run"
 				List<String> jbangOpts = stripNonInheritedJBangOpts(leadingOpts);
 				List<String> result = new ArrayList<>(jbangOpts);
@@ -255,6 +265,40 @@ public class Main {
 		default:
 			return null;
 		}
+	}
+
+	/**
+	 * Finds the closest matching subcommand for a mistyped input using Levenshtein
+	 * distance. Returns the suggestion if the edit distance is small enough (max 2
+	 * for short commands, max 3 for longer ones), or null if no close match.
+	 */
+	public static String findClosestSubcommand(String input) {
+		String bestMatch = null;
+		int bestDistance = Integer.MAX_VALUE;
+		for (String cmd : getSubcommandNames()) {
+			int distance = SearchScorer.calculate(input.toLowerCase(), cmd.toLowerCase()).distance();
+			if (distance < bestDistance) {
+				bestDistance = distance;
+				bestMatch = cmd;
+			}
+		}
+		// Threshold: max distance 2 for short commands (<=5 chars), 3 for longer
+		int maxDistance = input.length() <= 5 ? 2 : 3;
+		if (bestDistance > 0 && bestDistance <= maxDistance) {
+			return bestMatch;
+		}
+		return null;
+	}
+
+	/**
+	 * Returns true if the input looks like a script/file reference rather than a
+	 * mistyped command. Checks for path separators, file extensions, URLs, and GAV
+	 * coordinates.
+	 */
+	private static boolean looksLikeScriptRef(String input) {
+		return input.contains("/") || input.contains("\\")
+				|| input.contains(".") || input.contains(":")
+				|| input.startsWith("http") || input.startsWith("@");
 	}
 
 	private static List<String> stripNonInheritedJBangOpts(List<String> opts) {

--- a/src/test/java/dev/jbang/cli/TestAeshParsing.java
+++ b/src/test/java/dev/jbang/cli/TestAeshParsing.java
@@ -411,6 +411,50 @@ class TestAeshParsing extends BaseTest {
 		assertThat(run.dependencyInfoMixin.dependencies, hasItem("org.other:lib:3.0"));
 	}
 
+	// --- Command typo detection (#2628) ---
+
+	@Test
+	void testFindClosestSubcommand_closeTypo() {
+		assertThat(Main.findClosestSubcommand("alis"), equalTo("alias"));
+	}
+
+	@Test
+	void testFindClosestSubcommand_singleCharOff() {
+		assertThat(Main.findClosestSubcommand("buidl"), equalTo("build"));
+	}
+
+	@Test
+	void testFindClosestSubcommand_transposition() {
+		assertThat(Main.findClosestSubcommand("rnу"), is(notNullValue()));
+	}
+
+	@Test
+	void testFindClosestSubcommand_exactMatch() {
+		// Exact match should return null (distance 0 is excluded)
+		assertThat(Main.findClosestSubcommand("run"), is(nullValue()));
+	}
+
+	@Test
+	void testFindClosestSubcommand_tooFar() {
+		// Completely unrelated input should return null
+		assertThat(Main.findClosestSubcommand("xyz"), is(nullValue()));
+	}
+
+	@Test
+	void testFindClosestSubcommand_longerTypo() {
+		assertThat(Main.findClosestSubcommand("completon"), equalTo("completion"));
+	}
+
+	@Test
+	void testFindClosestSubcommand_missingChar() {
+		assertThat(Main.findClosestSubcommand("edi"), equalTo("edit"));
+	}
+
+	@Test
+	void testFindClosestSubcommand_extraChar() {
+		assertThat(Main.findClosestSubcommand("initt"), equalTo("init"));
+	}
+
 	// --- Subcommand list consistency ---
 
 	@Test


### PR DESCRIPTION
When a user types a command that doesn't match any subcommand, alias, or PATH plugin, and the input looks like a typo rather than a script reference, show a 'did you mean?' suggestion before falling through to implicit run.

Uses the existing SearchScorer (Levenshtein distance) to find the closest matching subcommand. Only suggests when:
- Edit distance <= 2 for short commands (<=5 chars)
- Edit distance <= 3 for longer commands
- The input doesn't look like a file/script reference (no dots, slashes, colons, URLs, or @ prefixes)

Per Max's feedback: the typo check runs after all alias and plugin lookups, so valid aliases/plugins always take priority over typo suggestions.

Examples:
  jbang alis     -> warns: Did you mean 'alias'?
  jbang buidl    -> warns: Did you mean 'build'?
  jbang completon -> warns: Did you mean 'completion'?
  jbang test.java -> no warning (looks like a script ref)
  jbang xyz       -> no warning (too far from any command)

Zero startup overhead: the check only runs in the error path when no subcommand, alias, or plugin matches.


<!--
Thanks for submitting your Pull Request!

Please delete this text, and add description of the topic solved by this PR.

To make releases as automated as possible we use conventional commits formats.
Thus commits and pull-requests titles should before merge follow the Conventional Commits spec.
See https://www.conventionalcommits.org/

Details in https://github.com/Ezard/semantic-prs

If in doubt then open the pull-request and we'll help you - Thank you!
-->
