### PR TITLE
feat: verify SHA-256 checksum of downloaded JBang archive

### DIFF
--- a/.github/workflows/publish-pr-build.yml
+++ b/.github/workflows/publish-pr-build.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Download jbang artifact from CI run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: '*-shared-build-jbang'
           path: jbang-artifact
           run-id: ${{ github.event.workflow_run.id }}

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -457,7 +457,12 @@ export JBANG_DOWNLOAD_URL=https://internal-mirror.example.com/jbang/jbang.tar
 
 JBang automatically verifies the SHA-256 checksum of the downloaded archive against the `.sha256` file published alongside each release.
 If the checksum does not match, the download is rejected.
-If the `.sha256` file cannot be downloaded (e.g. a corporate mirror that does not publish it), or if no hash tool is available (`sha256sum`/`shasum` on Linux/macOS), a warning is printed and installation continues.
+If the `.sha256` file cannot be downloaded (e.g. a corporate mirror that does not publish it), a warning is printed and installation continues.
+
+On Linux/macOS the bash script requires `sha256sum` or `shasum` to compute hashes.
+If neither is available and `JBANG_DOWNLOAD_CHECKSUM` is set, the script exits with an error (verification was explicitly requested but cannot be performed).
+If neither is available and no explicit checksum was requested, a warning is printed and installation continues without verification.
+On Windows, PowerShell's built-in `Get-FileHash` cmdlet is always available.
 
 You can override the expected checksum by setting the `JBANG_DOWNLOAD_CHECKSUM` environment variable.
 When set, the server-side `.sha256` file is not downloaded and the provided value is used instead:
@@ -469,14 +474,18 @@ export JBANG_DOWNLOAD_CHECKSUM=0305dab682909378fa71eb590eb199dffba8d2ea8f6293c4b
 
 This is useful in locked-down CI environments or air-gapped setups where you want to pin an exact artifact hash.
 
-To verify the JBang JAR (or native binary) before every execution — even when no download occurs — set `JBANG_JAR_CHECKSUM`:
+To verify the JBang JAR or native binary before every execution — even when no download occurs — set `JBANG_JAR_CHECKSUM` (for the JAR) or `JBANG_BIN_CHECKSUM` (for the native binary):
 
 [source,bash]
 ----
-export JBANG_JAR_CHECKSUM=abc123...  # SHA-256 of jbang.jar or the native binary
+export JBANG_JAR_CHECKSUM=abc123...  # SHA-256 of jbang.jar
+export JBANG_BIN_CHECKSUM=def456...  # SHA-256 of the native binary (when JBANG_USE_NATIVE=true)
 ----
 
-Unlike `JBANG_DOWNLOAD_CHECKSUM`, this check runs on every invocation and is always mandatory when set.
+`JBANG_JAR_CHECKSUM` verifies whichever artifact is about to be executed — the JAR or the native binary.
+`JBANG_BIN_CHECKSUM` is an optional override that takes precedence when running a native binary (`JBANG_USE_NATIVE=true`).
+Most users only need `JBANG_JAR_CHECKSUM`; set `JBANG_BIN_CHECKSUM` only when you need different checksums for the JAR and the native binary.
+Unlike `JBANG_DOWNLOAD_CHECKSUM`, these checks run on every invocation and are always mandatory when set.
 
 === Downloading a specific version or the early-access build
 
@@ -632,7 +641,11 @@ These are read by the scripts themselves before Java or JBang's Java code is inv
 
 | `JBANG_JAR_CHECKSUM`
 | _(unset)_
-| Expected SHA-256 of the JBang JAR or native binary. Verified before every execution. Fails if the checksum does not match or no hash tool is available.
+| Expected SHA-256 of the JBang JAR. Verified before every execution. Fails if the checksum does not match or no hash tool is available.
+
+| `JBANG_BIN_CHECKSUM`
+| _(unset)_
+| Expected SHA-256 of the native binary. Only used when `JBANG_USE_NATIVE=true`. Takes precedence over `JBANG_JAR_CHECKSUM` for native binary verification. Most users only need `JBANG_JAR_CHECKSUM`.
 
 | `JBANG_DOWNLOAD_VERSION`
 | _(latest)_

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -469,6 +469,15 @@ export JBANG_DOWNLOAD_CHECKSUM=0305dab682909378fa71eb590eb199dffba8d2ea8f6293c4b
 
 This is useful in locked-down CI environments or air-gapped setups where you want to pin an exact artifact hash.
 
+To verify the JBang JAR (or native binary) before every execution — even when no download occurs — set `JBANG_JAR_CHECKSUM`:
+
+[source,bash]
+----
+export JBANG_JAR_CHECKSUM=abc123...  # SHA-256 of jbang.jar or the native binary
+----
+
+Unlike `JBANG_DOWNLOAD_CHECKSUM`, this check runs on every invocation and is always mandatory when set.
+
 === Downloading a specific version or the early-access build
 
 Set `JBANG_DOWNLOAD_VERSION` to pick a specific release. Numeric values are resolved to the matching `vX.Y.Z` GitHub release; any other value is used as a release tag name as-is. This means you can opt-in to the perpetual early-access build with a simple:
@@ -620,6 +629,10 @@ These are read by the scripts themselves before Java or JBang's Java code is inv
 | `JBANG_DOWNLOAD_CHECKSUM`
 | _(from server)_
 | Expected SHA-256 checksum of the JBang archive. When set, verification uses this value instead of downloading the `.sha256` file from the server.
+
+| `JBANG_JAR_CHECKSUM`
+| _(unset)_
+| Expected SHA-256 of the JBang JAR or native binary. Verified before every execution. Fails if the checksum does not match or no hash tool is available.
 
 | `JBANG_DOWNLOAD_VERSION`
 | _(latest)_

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -457,7 +457,7 @@ export JBANG_DOWNLOAD_URL=https://internal-mirror.example.com/jbang/jbang.tar
 
 JBang automatically verifies the SHA-256 checksum of the downloaded archive against the `.sha256` file published alongside each release.
 If the checksum does not match, the download is rejected.
-If the `.sha256` file cannot be downloaded (e.g. a corporate mirror that does not publish it), a warning is printed and installation continues.
+If the `.sha256` file cannot be downloaded (e.g. a corporate mirror that does not publish it), or if no hash tool is available (`sha256sum`/`shasum` on Linux/macOS), a warning is printed and installation continues.
 
 You can override the expected checksum by setting the `JBANG_DOWNLOAD_CHECKSUM` environment variable.
 When set, the server-side `.sha256` file is not downloaded and the provided value is used instead:

--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -453,6 +453,22 @@ By default JBang downloads itself from GitHub. You can override the download URL
 export JBANG_DOWNLOAD_URL=https://internal-mirror.example.com/jbang/jbang.tar
 ----
 
+=== Download checksum verification
+
+JBang automatically verifies the SHA-256 checksum of the downloaded archive against the `.sha256` file published alongside each release.
+If the checksum does not match, the download is rejected.
+If the `.sha256` file cannot be downloaded (e.g. a corporate mirror that does not publish it), a warning is printed and installation continues.
+
+You can override the expected checksum by setting the `JBANG_DOWNLOAD_CHECKSUM` environment variable.
+When set, the server-side `.sha256` file is not downloaded and the provided value is used instead:
+
+[source,bash]
+----
+export JBANG_DOWNLOAD_CHECKSUM=0305dab682909378fa71eb590eb199dffba8d2ea8f6293c4bd7dcc671daabaca
+----
+
+This is useful in locked-down CI environments or air-gapped setups where you want to pin an exact artifact hash.
+
 === Downloading a specific version or the early-access build
 
 Set `JBANG_DOWNLOAD_VERSION` to pick a specific release. Numeric values are resolved to the matching `vX.Y.Z` GitHub release; any other value is used as a release tag name as-is. This means you can opt-in to the perpetual early-access build with a simple:
@@ -600,6 +616,10 @@ These are read by the scripts themselves before Java or JBang's Java code is inv
 | `JBANG_DOWNLOAD_URL`
 | _(GitHub releases)_
 | Override the URL used to download JBang itself. Useful for corporate mirrors or air-gapped environments.
+
+| `JBANG_DOWNLOAD_CHECKSUM`
+| _(from server)_
+| Expected SHA-256 checksum of the JBang archive. When set, verification uses this value instead of downloading the `.sha256` file from the server.
 
 | `JBANG_DOWNLOAD_VERSION`
 | _(latest)_

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -303,6 +303,35 @@ if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
     echo "Downloading JBang ${JBANG_DOWNLOAD_VERSION:-latest} from $jburl..." 1>&2
     download "$jburl" "$TDIR/urls/jbang.tar"
     if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual=$(sha256sum "$TDIR/urls/jbang.tar" | cut -d' ' -f1)
+    elif command -v shasum >/dev/null 2>&1; then
+      actual=$(shasum -a 256 "$TDIR/urls/jbang.tar" | cut -d' ' -f1)
+    else
+      if [ -n "$JBANG_DOWNLOAD_CHECKSUM" ]; then
+        echo "Error: JBANG_DOWNLOAD_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
+        exit 1
+      fi
+      echo "Warning: sha256sum/shasum not found, skipping download checksum verification" 1>&2
+      actual=""
+    fi
+    if [ -n "$actual" ]; then
+      if [ -n "$JBANG_DOWNLOAD_CHECKSUM" ]; then
+        expected="$JBANG_DOWNLOAD_CHECKSUM"
+      else
+        download "${jburl}.sha256" "$TDIR/urls/jbang.tar.sha256"
+        if [ $retval -eq 0 ]; then
+          expected=$(tr -d '[:space:]' < "$TDIR/urls/jbang.tar.sha256")
+        else
+          expected=""
+          echo "Warning: could not download checksum file, skipping verification" 1>&2
+        fi
+      fi
+      if [ -n "$expected" ] && [ "$actual" != "$expected" ]; then
+        echo "Error: checksum mismatch for jbang.tar (expected $expected, got $actual)" 1>&2
+        exit 1
+      fi
+    fi
     echo "Installing JBang..." 1>&2
     rm -rf "$TDIR/urls/jbang"
     tar xf "$TDIR/urls/jbang.tar" -C "$TDIR/urls"

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -305,26 +305,34 @@ if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
     if [ $retval -ne 0 ]; then echo "Error downloading JBang from $jburl" 1>&2; exit $retval; fi
     if command -v sha256sum >/dev/null 2>&1; then
       actual=$(sha256sum "$TDIR/urls/jbang.tar" | cut -d' ' -f1)
+      hashret=$?
     elif command -v shasum >/dev/null 2>&1; then
       actual=$(shasum -a 256 "$TDIR/urls/jbang.tar" | cut -d' ' -f1)
+      hashret=$?
     else
+      hashret=1
+      actual=""
+    fi
+    if [ $hashret -ne 0 ] || [ -z "$actual" ]; then
       if [ -n "$JBANG_DOWNLOAD_CHECKSUM" ]; then
-        echo "Error: JBANG_DOWNLOAD_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
+        echo "Error: JBANG_DOWNLOAD_CHECKSUM is set but could not compute SHA-256 hash" 1>&2
         exit 1
       fi
-      echo "Warning: sha256sum/shasum not found, skipping download checksum verification" 1>&2
+      echo "Warning: could not compute SHA-256 hash, skipping download checksum verification" 1>&2
       actual=""
     fi
     if [ -n "$actual" ]; then
       if [ -n "$JBANG_DOWNLOAD_CHECKSUM" ]; then
-        expected="$JBANG_DOWNLOAD_CHECKSUM"
+        expected=$(echo "$JBANG_DOWNLOAD_CHECKSUM" | tr '[:upper:]' '[:lower:]')
       else
         download "${jburl}.sha256" "$TDIR/urls/jbang.tar.sha256"
         if [ $retval -eq 0 ]; then
-          expected=$(tr -d '[:space:]' < "$TDIR/urls/jbang.tar.sha256")
+          expected=$(tr -d '[:space:]' < "$TDIR/urls/jbang.tar.sha256" | tr '[:upper:]' '[:lower:]')
         else
           expected=""
-          echo "Warning: could not download checksum file, skipping verification" 1>&2
+        fi
+        if [ -z "$expected" ]; then
+          echo "Warning: could not obtain checksum from server, skipping verification" 1>&2
         fi
       fi
       if [ -n "$expected" ] && [ "$actual" != "$expected" ]; then
@@ -364,8 +372,9 @@ if [ -n "$JBANG_JAR_CHECKSUM" ]; then
     echo "Error: JBANG_JAR_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
     exit 1
   fi
-  if [ "$actual" != "$JBANG_JAR_CHECKSUM" ]; then
-    echo "Error: checksum mismatch for $checkFile (expected $JBANG_JAR_CHECKSUM, got $actual)" 1>&2
+  expected=$(echo "$JBANG_JAR_CHECKSUM" | tr '[:upper:]' '[:lower:]')
+  if [ "$actual" != "$expected" ]; then
+    echo "Error: checksum mismatch for $checkFile (expected $expected, got $actual)" 1>&2
     exit 1
   fi
 fi

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -82,6 +82,27 @@ javacInPath() {
   [[ -x "$(command -v javac)" ]] && ( [[ $os != "mac" ]] || /usr/libexec/java_home &> /dev/null )
 }
 
+# Verifies SHA-256 checksum of a file against an expected value.
+# Usage: _jbang_verify_checksum <file> <expected_checksum> <var_name>
+_jbang_verify_checksum() {
+  local checkFile="$1" expectedRaw="$2" varName="$3"
+  local actual=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$checkFile" | cut -d' ' -f1)
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$checkFile" | cut -d' ' -f1)
+  else
+    echo "Error: $varName is set but neither sha256sum nor shasum is available" 1>&2
+    exit 1
+  fi
+  local expected
+  expected=$(echo "$expectedRaw" | tr '[:upper:]' '[:lower:]')
+  if [ "$actual" != "$expected" ]; then
+    echo "Error: checksum mismatch for $checkFile (expected $expected, got $actual)" 1>&2
+    exit 1
+  fi
+}
+
 # Determines the JDK/JAVA_EXEC to use
 setup_java_exec() {
   unset JAVA_EXEC
@@ -348,21 +369,15 @@ if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
     rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
     cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
   fi
-  if [ -n "$JBANG_JAR_CHECKSUM" ]; then
-    checkFile="$JBDIR/bin/jbang.jar"
-    if command -v sha256sum >/dev/null 2>&1; then
-      actual=$(sha256sum "$checkFile" | cut -d' ' -f1)
-    elif command -v shasum >/dev/null 2>&1; then
-      actual=$(shasum -a 256 "$checkFile" | cut -d' ' -f1)
-    else
-      echo "Error: JBANG_JAR_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
-      exit 1
+  # Verify the artifact we are about to execute
+  if [ "$JBANG_USE_NATIVE" == "true" ]; then
+    if [ -n "$JBANG_BIN_CHECKSUM" ]; then
+      _jbang_verify_checksum "$JBDIR/bin/jbang.bin" "$JBANG_BIN_CHECKSUM" "JBANG_BIN_CHECKSUM"
+    elif [ -n "$JBANG_JAR_CHECKSUM" ]; then
+      _jbang_verify_checksum "$JBDIR/bin/jbang.bin" "$JBANG_JAR_CHECKSUM" "JBANG_JAR_CHECKSUM"
     fi
-    expected=$(echo "$JBANG_JAR_CHECKSUM" | tr '[:upper:]' '[:lower:]')
-    if [ "$actual" != "$expected" ]; then
-      echo "Error: checksum mismatch for $checkFile (expected $expected, got $actual)" 1>&2
-      exit 1
-    fi
+  elif [ -n "$JBANG_JAR_CHECKSUM" ]; then
+    _jbang_verify_checksum "$JBDIR/bin/jbang.jar" "$JBANG_JAR_CHECKSUM" "JBANG_JAR_CHECKSUM"
   fi
   "$JBDIR"/bin/jbang "$@"
   exit $?
@@ -378,21 +393,10 @@ if [[ -z "$binaryPath" ]]; then
   setup_java_exec
 fi
 
-if [ -n "$JBANG_JAR_CHECKSUM" ]; then
-  checkFile="${binaryPath:-$jarPath}"
-  if command -v sha256sum >/dev/null 2>&1; then
-    actual=$(sha256sum "$checkFile" | cut -d' ' -f1)
-  elif command -v shasum >/dev/null 2>&1; then
-    actual=$(shasum -a 256 "$checkFile" | cut -d' ' -f1)
-  else
-    echo "Error: JBANG_JAR_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
-    exit 1
-  fi
-  expected=$(echo "$JBANG_JAR_CHECKSUM" | tr '[:upper:]' '[:lower:]')
-  if [ "$actual" != "$expected" ]; then
-    echo "Error: checksum mismatch for $checkFile (expected $expected, got $actual)" 1>&2
-    exit 1
-  fi
+if [ -n "$binaryPath" ] && [ -n "$JBANG_BIN_CHECKSUM" ]; then
+  _jbang_verify_checksum "$binaryPath" "$JBANG_BIN_CHECKSUM" "JBANG_BIN_CHECKSUM"
+elif [ -n "$JBANG_JAR_CHECKSUM" ]; then
+  _jbang_verify_checksum "${binaryPath:-$jarPath}" "$JBANG_JAR_CHECKSUM" "JBANG_JAR_CHECKSUM"
 fi
 
 execute_jbang "$@"

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -348,6 +348,22 @@ if [[ -z "$binaryPath" && -z "$jarPath" ]]; then
     rm -f "$JBDIR/bin/jbang" "$JBDIR/bin"/jbang.*
     cp -f "$TDIR/urls/jbang/bin"/* "$JBDIR/bin"
   fi
+  if [ -n "$JBANG_JAR_CHECKSUM" ]; then
+    checkFile="$JBDIR/bin/jbang.jar"
+    if command -v sha256sum >/dev/null 2>&1; then
+      actual=$(sha256sum "$checkFile" | cut -d' ' -f1)
+    elif command -v shasum >/dev/null 2>&1; then
+      actual=$(shasum -a 256 "$checkFile" | cut -d' ' -f1)
+    else
+      echo "Error: JBANG_JAR_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
+      exit 1
+    fi
+    expected=$(echo "$JBANG_JAR_CHECKSUM" | tr '[:upper:]' '[:lower:]')
+    if [ "$actual" != "$expected" ]; then
+      echo "Error: checksum mismatch for $checkFile (expected $expected, got $actual)" 1>&2
+      exit 1
+    fi
+  fi
   "$JBDIR"/bin/jbang "$@"
   exit $?
 fi

--- a/src/main/scripts/jbang
+++ b/src/main/scripts/jbang
@@ -354,4 +354,20 @@ if [[ -z "$binaryPath" ]]; then
   setup_java_exec
 fi
 
+if [ -n "$JBANG_JAR_CHECKSUM" ]; then
+  checkFile="${binaryPath:-$jarPath}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$checkFile" | cut -d' ' -f1)
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$checkFile" | cut -d' ' -f1)
+  else
+    echo "Error: JBANG_JAR_CHECKSUM is set but neither sha256sum nor shasum is available" 1>&2
+    exit 1
+  fi
+  if [ "$actual" != "$JBANG_JAR_CHECKSUM" ]; then
+    echo "Error: checksum mismatch for $checkFile (expected $JBANG_JAR_CHECKSUM, got $actual)" 1>&2
+    exit 1
+  fi
+fi
+
 execute_jbang "$@"

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -272,4 +272,13 @@ if (-not $binaryPath) {
 }
 
 # Execute jbang
+if (Test-Path env:JBANG_JAR_CHECKSUM) {
+  $checkFile = if ($binaryPath) { $binaryPath } else { $jarPath }
+  $actual = (Get-FileHash "$checkFile" -Algorithm SHA256).Hash.ToLower()
+  if ($actual -ne $env:JBANG_JAR_CHECKSUM) {
+    [Console]::Error.WriteLine("Error: checksum mismatch for $checkFile (expected $env:JBANG_JAR_CHECKSUM, got $actual)")
+    exit 1
+  }
+}
+
 Invoke-JBang -binaryPath $binaryPath -jarPath $jarPath -javaExec $JAVA_EXEC -args $args

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -196,7 +196,8 @@ if (-not $binaryPath -and -not $jarPath) {
     } else {
       $shaOk = Invoke-Download "${jburl}.sha256" "$TDIR\urls\jbang.zip.sha256"
       if ($shaOk) {
-        $expected = (Get-Content "$TDIR\urls\jbang.zip.sha256").Trim().ToLower()
+        $raw = Get-Content "$TDIR\urls\jbang.zip.sha256"
+        $expected = if ($raw) { $raw.Trim().ToLower() } else { '' }
       } else {
         $expected = ''
       }

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -178,6 +178,22 @@ if (-not $binaryPath -and -not $jarPath) {
       [Console]::Error.WriteLine("Error downloading JBang from $jburl to $TDIR\urls\jbang.zip")
       exit 1
     }
+    $actual = (Get-FileHash "$TDIR\urls\jbang.zip" -Algorithm SHA256).Hash.ToLower()
+    if (Test-Path env:JBANG_DOWNLOAD_CHECKSUM) {
+      $expected = $env:JBANG_DOWNLOAD_CHECKSUM
+    } else {
+      $shaOk = Invoke-Download "${jburl}.sha256" "$TDIR\urls\jbang.zip.sha256"
+      if ($shaOk) {
+        $expected = (Get-Content "$TDIR\urls\jbang.zip.sha256").Trim()
+      } else {
+        $expected = ''
+        [Console]::Error.WriteLine("Warning: could not download checksum file, skipping verification")
+      }
+    }
+    if ($expected -and $actual -ne $expected) {
+      [Console]::Error.WriteLine("Error: checksum mismatch for jbang.zip (expected $expected, got $actual)")
+      exit 1
+    }
     [Console]::Error.WriteLine("Installing JBang...")
     Remove-Item -LiteralPath "$TDIR\urls\jbang" -Force -Recurse -ErrorAction Ignore >$null 2>&1
     try { Expand-Archive -Path "$TDIR\urls\jbang.zip" -DestinationPath "$TDIR\urls"; $ok=$? } catch {

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -96,6 +96,18 @@ function Invoke-Download {
     }
 }
 
+function Assert-JarChecksum {
+  param([string]$checkFile)
+  if ((Test-Path env:JBANG_JAR_CHECKSUM) -and $env:JBANG_JAR_CHECKSUM) {
+    $actual = (Get-FileHash "$checkFile" -Algorithm SHA256).Hash.ToLower()
+    $expected = $env:JBANG_JAR_CHECKSUM.ToLower()
+    if ($actual -ne $expected) {
+      [Console]::Error.WriteLine("Error: checksum mismatch for $checkFile (expected $expected, got $actual)")
+      exit 1
+    }
+  }
+}
+
 # Function to execute jbang (either native binary or JAR) and handle output
 function Invoke-JBang {
     param([string]$binaryPath, [string]$jarPath, [string]$javaExec, [Parameter(ValueFromRemainingArguments=$true)]$args)
@@ -179,15 +191,17 @@ if (-not $binaryPath -and -not $jarPath) {
       exit 1
     }
     $actual = (Get-FileHash "$TDIR\urls\jbang.zip" -Algorithm SHA256).Hash.ToLower()
-    if (Test-Path env:JBANG_DOWNLOAD_CHECKSUM) {
-      $expected = $env:JBANG_DOWNLOAD_CHECKSUM
+    if ((Test-Path env:JBANG_DOWNLOAD_CHECKSUM) -and $env:JBANG_DOWNLOAD_CHECKSUM) {
+      $expected = $env:JBANG_DOWNLOAD_CHECKSUM.ToLower()
     } else {
       $shaOk = Invoke-Download "${jburl}.sha256" "$TDIR\urls\jbang.zip.sha256"
       if ($shaOk) {
-        $expected = (Get-Content "$TDIR\urls\jbang.zip.sha256").Trim()
+        $expected = (Get-Content "$TDIR\urls\jbang.zip.sha256").Trim().ToLower()
       } else {
         $expected = ''
-        [Console]::Error.WriteLine("Warning: could not download checksum file, skipping verification")
+      }
+      if (-not $expected) {
+        [Console]::Error.WriteLine("Warning: could not obtain checksum from server, skipping verification")
       }
     }
     if ($expected -and $actual -ne $expected) {
@@ -210,6 +224,8 @@ if (-not $binaryPath -and -not $jarPath) {
     Remove-Item -Path "$JBDIR\bin\jbang.*" -Force -ErrorAction Ignore >$null 2>&1
     Copy-Item -Path "$TDIR\urls\jbang\bin\*" -Destination "$JBDIR\bin" -Force >$null 2>&1
   }
+  $checkFile = if ($env:JBANG_USE_NATIVE -eq 'true') { "$JBDIR\bin\jbang.bin.exe" } else { "$JBDIR\bin\jbang.jar" }
+  Assert-JarChecksum $checkFile
   . "$JBDIR\bin\jbang.ps1" @args
   break
 }
@@ -265,6 +281,7 @@ if (-not $binaryPath) {
         # Activate the downloaded JDK giving it its proper name
         Rename-Item -Path "$TDIR\jdks\$javaVersion.tmp" -NewName "$javaVersion" >$null 2>&1
         # Set the current JDK
+        Assert-JarChecksum $jarPath
         & "$JAVA_EXEC" -jar "$jarPath" jdk default $javaVersion
       }
     }
@@ -272,13 +289,7 @@ if (-not $binaryPath) {
 }
 
 # Execute jbang
-if (Test-Path env:JBANG_JAR_CHECKSUM) {
-  $checkFile = if ($binaryPath) { $binaryPath } else { $jarPath }
-  $actual = (Get-FileHash "$checkFile" -Algorithm SHA256).Hash.ToLower()
-  if ($actual -ne $env:JBANG_JAR_CHECKSUM) {
-    [Console]::Error.WriteLine("Error: checksum mismatch for $checkFile (expected $env:JBANG_JAR_CHECKSUM, got $actual)")
-    exit 1
-  }
-}
+$checkFile = if ($binaryPath) { $binaryPath } else { $jarPath }
+Assert-JarChecksum $checkFile
 
 Invoke-JBang -binaryPath $binaryPath -jarPath $jarPath -javaExec $JAVA_EXEC -args $args

--- a/src/main/scripts/jbang.ps1
+++ b/src/main/scripts/jbang.ps1
@@ -96,15 +96,20 @@ function Invoke-Download {
     }
 }
 
-function Assert-JarChecksum {
-  param([string]$checkFile)
-  if ((Test-Path env:JBANG_JAR_CHECKSUM) -and $env:JBANG_JAR_CHECKSUM) {
-    $actual = (Get-FileHash "$checkFile" -Algorithm SHA256).Hash.ToLower()
+function Assert-ArtifactChecksum {
+  param([string]$checkFile, [string]$isBinary = $false)
+  # Use JBANG_BIN_CHECKSUM for native binaries, JBANG_JAR_CHECKSUM for JARs
+  if ($isBinary -and (Test-Path env:JBANG_BIN_CHECKSUM) -and $env:JBANG_BIN_CHECKSUM) {
+    $expected = $env:JBANG_BIN_CHECKSUM.ToLower()
+  } elseif ((Test-Path env:JBANG_JAR_CHECKSUM) -and $env:JBANG_JAR_CHECKSUM) {
     $expected = $env:JBANG_JAR_CHECKSUM.ToLower()
-    if ($actual -ne $expected) {
-      [Console]::Error.WriteLine("Error: checksum mismatch for $checkFile (expected $expected, got $actual)")
-      exit 1
-    }
+  } else {
+    return
+  }
+  $actual = (Get-FileHash "$checkFile" -Algorithm SHA256).Hash.ToLower()
+  if ($actual -ne $expected) {
+    [Console]::Error.WriteLine("Error: checksum mismatch for $checkFile (expected $expected, got $actual)")
+    exit 1
   }
 }
 
@@ -225,8 +230,9 @@ if (-not $binaryPath -and -not $jarPath) {
     Remove-Item -Path "$JBDIR\bin\jbang.*" -Force -ErrorAction Ignore >$null 2>&1
     Copy-Item -Path "$TDIR\urls\jbang\bin\*" -Destination "$JBDIR\bin" -Force >$null 2>&1
   }
-  $checkFile = if ($env:JBANG_USE_NATIVE -eq 'true') { "$JBDIR\bin\jbang.bin.exe" } else { "$JBDIR\bin\jbang.jar" }
-  Assert-JarChecksum $checkFile
+  $isBin = $env:JBANG_USE_NATIVE -eq 'true'
+  $checkFile = if ($isBin) { "$JBDIR\bin\jbang.bin.exe" } else { "$JBDIR\bin\jbang.jar" }
+  Assert-ArtifactChecksum $checkFile $isBin
   . "$JBDIR\bin\jbang.ps1" @args
   break
 }
@@ -282,7 +288,7 @@ if (-not $binaryPath) {
         # Activate the downloaded JDK giving it its proper name
         Rename-Item -Path "$TDIR\jdks\$javaVersion.tmp" -NewName "$javaVersion" >$null 2>&1
         # Set the current JDK
-        Assert-JarChecksum $jarPath
+        Assert-ArtifactChecksum $jarPath $false
         & "$JAVA_EXEC" -jar "$jarPath" jdk default $javaVersion
       }
     }
@@ -290,7 +296,8 @@ if (-not $binaryPath) {
 }
 
 # Execute jbang
+$isBin = [bool]$binaryPath
 $checkFile = if ($binaryPath) { $binaryPath } else { $jarPath }
-Assert-JarChecksum $checkFile
+Assert-ArtifactChecksum $checkFile $isBin
 
 Invoke-JBang -binaryPath $binaryPath -jarPath $jarPath -javaExec $JAVA_EXEC -args $args

--- a/src/test/java/dev/jbang/cli/TestScriptChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestScriptChecksum.java
@@ -197,7 +197,7 @@ class TestScriptChecksum extends AbstractScriptTest {
 
 			RunResult r = runProcess(bashCmd("version"), bashEnv("empty-sidecar"));
 
-			// The script should at minimum warn when the sidecar is empty
+			assertEquals(0, r.exitCode, "should succeed with empty sidecar, stderr: " + r.stderr);
 			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
 					"should warn about empty sidecar checksum, stderr: " + r.stderr);
 		}
@@ -288,12 +288,24 @@ class TestScriptChecksum extends AbstractScriptTest {
 					"should not fail on checksum, stderr: " + r.stderr);
 		}
 
-		// -- JBANG_JAR_CHECKSUM (CodeRabbit #5) -------------------------------
+		// -- JBANG_JAR_CHECKSUM / JBANG_BIN_CHECKSUM -------------------------
+
+		@Test
+		void jarChecksumMatchPasses() throws Exception {
+			Path jbdir = tempSubDir("jbdir-jar-ok");
+			byte[] jarContent = prePopulateJbdir(jbdir, true);
+
+			Map<String, String> env = baseBashEnv("jar-ok");
+			env.put("JBANG_DIR", jbdir.toString());
+			env.put("JBANG_JAR_CHECKSUM", sha256Hex(jarContent));
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertEquals(0, r.exitCode, "should pass with correct jar checksum, stderr: " + r.stderr);
+		}
 
 		@Test
 		void jarChecksumMismatchFails() throws Exception {
-			// Verifies jar checksum is checked before delegating to
-			// $JBDIR/bin/jbang on the pre-installed path.
 			Path jbdir = tempSubDir("jbdir-jar-bad");
 			prePopulateJbdir(jbdir, true);
 
@@ -420,7 +432,7 @@ class TestScriptChecksum extends AbstractScriptTest {
 
 			RunResult r = runProcess(psCmd("version"), psEnv("empty-sidecar"));
 
-			// Should NOT crash with InvalidOperation / NullReferenceException
+			assertEquals(0, r.exitCode, "should succeed with empty sidecar, stderr: " + r.stderr);
 			assertTrue(!r.stderr.contains("InvalidOperation"),
 					"should not crash on empty sidecar, stderr: " + r.stderr);
 			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
@@ -477,7 +489,7 @@ class TestScriptChecksum extends AbstractScriptTest {
 			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/jbang.zip.sha256")));
 		}
 
-		// -- JBANG_JAR_CHECKSUM (CodeRabbit #5) -------------------------------
+		// -- JBANG_JAR_CHECKSUM / JBANG_BIN_CHECKSUM -------------------------
 
 		@Test
 		void jarChecksumMatchPasses() throws Exception {

--- a/src/test/java/dev/jbang/cli/TestScriptChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestScriptChecksum.java
@@ -292,9 +292,8 @@ class TestScriptChecksum extends AbstractScriptTest {
 
 		@Test
 		void jarChecksumMismatchFails() throws Exception {
-			// BUG: when JBDIR/bin/jbang exists (pre-installed), the script
-			// delegates to $JBDIR/bin/jbang and exits BEFORE the
-			// JBANG_JAR_CHECKSUM check. A bad checksum silently passes.
+			// Verifies jar checksum is checked before delegating to
+			// $JBDIR/bin/jbang on the pre-installed path.
 			Path jbdir = tempSubDir("jbdir-jar-bad");
 			prePopulateJbdir(jbdir, true);
 
@@ -412,9 +411,7 @@ class TestScriptChecksum extends AbstractScriptTest {
 
 		@Test
 		void emptySidecarChecksumShouldWarnNotSilentlyContinue() throws Exception {
-			// BUG: empty .sha256 causes NullReferenceException in PS1 because
-			// Get-Content returns $null for empty file and .Trim() blows up.
-			// Expected: warn "could not obtain checksum" and continue.
+			// Empty .sha256 should be treated as unavailable: warn and continue.
 			byte[] zip = createJbangZip();
 			wm.stubFor(WireMock.get("/jbang.zip")
 				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));

--- a/src/test/java/dev/jbang/cli/TestScriptChecksum.java
+++ b/src/test/java/dev/jbang/cli/TestScriptChecksum.java
@@ -1,0 +1,516 @@
+package dev.jbang.cli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+/**
+ * Functional tests for SHA-256 checksum verification in JBang startup scripts.
+ *
+ * Covers: archive download checksums (sidecar and explicit override),
+ * JBANG_JAR_CHECKSUM for jar/binary verification, hash tool failure, empty
+ * sidecar handling, and case normalization.
+ */
+class TestScriptChecksum extends AbstractScriptTest {
+
+	private static String sha256Hex(byte[] data) throws Exception {
+		byte[] hash = MessageDigest.getInstance("SHA-256").digest(data);
+		StringBuilder sb = new StringBuilder(64);
+		for (byte b : hash) {
+			sb.append(String.format("%02x", b));
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Builds a PATH for bash script tests with only the commands the jbang bash
+	 * script needs, minus any excluded ones. PowerShell tests don't need this —
+	 * pwsh uses built-in cmdlets (Get-FileHash, Expand-Archive, etc.).
+	 *
+	 * Symlinks (required - excluded) from system PATH dirs into a temp dir.
+	 */
+	private static final java.util.Set<String> BASH_SCRIPT_COMMANDS = java.util.Set.of(
+			"bash", "cat", "chmod", "cp", "curl", "cut", "dirname",
+			"echo", "env", "grep", "head", "ls", "mkdir", "mktemp",
+			"mv", "printf", "readlink", "rm", "sed", "sha256sum", "shasum",
+			"sleep", "sort", "tar", "test", "touch", "tr", "uname",
+			"wc", "wget", "basename", "expr", "id", "tail", "tee", "xargs");
+
+	private String buildBashPath(Path binDir, String... excludes) throws Exception {
+		java.util.Set<String> excluded = java.util.Set.of(excludes);
+		java.util.Set<String> wanted = new java.util.HashSet<>(BASH_SCRIPT_COMMANDS);
+		wanted.removeAll(excluded);
+		for (String dir : System.getenv("PATH").split(java.io.File.pathSeparator)) {
+			Path dirPath = Path.of(dir);
+			if (!Files.isDirectory(dirPath)) {
+				continue;
+			}
+			for (String cmd : wanted) {
+				Path src = dirPath.resolve(cmd);
+				Path link = binDir.resolve(cmd);
+				if (Files.exists(src) && !Files.exists(link)) {
+					Files.createSymbolicLink(link, src);
+				}
+			}
+		}
+		return binDir.toString();
+	}
+
+	/**
+	 * Pre-populates JBDIR/bin with a dummy jbang script + jar so the download path
+	 * is skipped and the jar checksum path runs.
+	 *
+	 * @return the content of the dummy jbang.jar (for computing its checksum)
+	 */
+	private byte[] prePopulateJbdir(Path jbdir, boolean bash) throws Exception {
+		Path binDir = jbdir.resolve("bin");
+		Files.createDirectories(binDir);
+		byte[] jarContent = "fake-jar-content".getBytes();
+		Files.write(binDir.resolve("jbang.jar"), jarContent);
+		if (bash) {
+			Path script = binDir.resolve("jbang");
+			Files.writeString(script, "#!/bin/bash\nexit 0\n");
+			script.toFile().setExecutable(true);
+		} else {
+			Files.writeString(binDir.resolve("jbang.ps1"), "exit 0\n");
+			Files.writeString(binDir.resolve("jbang.cmd"), "@exit /b 0\r\n");
+		}
+		return jarContent;
+	}
+
+	// -------------------------------------------------------------------------
+	// Bash
+	// -------------------------------------------------------------------------
+
+	@Nested
+	class Bash {
+
+		@BeforeEach
+		void checkBash() {
+			requireBash();
+		}
+
+		private Map<String, String> bashEnv(String suffix) {
+			Map<String, String> env = baseBashEnv(suffix);
+			env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.tar"));
+			env.put("JBANG_DOWNLOAD_RETRY", "0");
+			return env;
+		}
+
+		@Test
+		void correctSidecarChecksumPasses() throws Exception {
+			byte[] tar = createJbangTar();
+			String checksum = sha256Hex(tar);
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			wm.stubFor(WireMock.get("/jbang.tar.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(checksum)));
+
+			RunResult r = runProcess(bashCmd("version"), bashEnv("sidecar-ok"));
+
+			assertEquals(0, r.exitCode, "should pass with correct sidecar checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void mismatchedSidecarChecksumFails() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			wm.stubFor(WireMock.get("/jbang.tar.sha256")
+				.willReturn(WireMock.aResponse()
+					.withStatus(200)
+					.withBody("0000000000000000000000000000000000000000000000000000000000000000")));
+
+			RunResult r = runProcess(bashCmd("version"), bashEnv("sidecar-bad"));
+
+			assertNotEquals(0, r.exitCode, "should fail on checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"), "stderr should say mismatch: " + r.stderr);
+		}
+
+		@Test
+		void explicitChecksumOverridePasses() throws Exception {
+			byte[] tar = createJbangTar();
+			String checksum = sha256Hex(tar);
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			// No sidecar stub — should not be fetched
+
+			Map<String, String> env = bashEnv("override-ok");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", checksum);
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertEquals(0, r.exitCode, "should pass with correct explicit checksum, stderr: " + r.stderr);
+			// Verify sidecar was NOT requested
+			wm.verify(0, WireMock.getRequestedFor(WireMock.urlEqualTo("/jbang.tar.sha256")));
+		}
+
+		@Test
+		void explicitChecksumOverrideMismatchFails() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			Map<String, String> env = bashEnv("override-bad");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", "badhash");
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertNotEquals(0, r.exitCode, "should fail on explicit checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"), "stderr should say mismatch: " + r.stderr);
+		}
+
+		@Test
+		void uppercaseChecksumMatchesLowercase() throws Exception {
+			byte[] tar = createJbangTar();
+			String checksum = sha256Hex(tar).toUpperCase();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			Map<String, String> env = bashEnv("upper");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", checksum);
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertEquals(0, r.exitCode, "uppercase checksum should match, stderr: " + r.stderr);
+		}
+
+		@Test
+		void emptySidecarChecksumShouldWarnNotSilentlyContinue() throws Exception {
+			// Security concern: empty .sha256 file should not silently skip verification
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			wm.stubFor(WireMock.get("/jbang.tar.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody("")));
+
+			RunResult r = runProcess(bashCmd("version"), bashEnv("empty-sidecar"));
+
+			// The script should at minimum warn when the sidecar is empty
+			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
+					"should warn about empty sidecar checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void missingSidecarChecksumWarnsAndContinues() throws Exception {
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			wm.stubFor(WireMock.get("/jbang.tar.sha256")
+				.willReturn(WireMock.aResponse().withStatus(404)));
+
+			RunResult r = runProcess(bashCmd("version"), bashEnv("no-sidecar"));
+
+			// Should warn about missing sidecar and proceed past checksum step.
+			// (exit code may be non-zero due to dummy archive extraction, but
+			// the important thing is it does NOT fail on checksum mismatch)
+			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
+					"should warn about missing sidecar, stderr: " + r.stderr);
+			assertTrue(!r.stderr.contains("checksum mismatch"),
+					"should not fail on checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void uppercaseSidecarChecksumNormalized() throws Exception {
+			// Security concern: sidecar checksum should be normalized before comparison
+			byte[] tar = createJbangTar();
+			String checksum = sha256Hex(tar).toUpperCase();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+			wm.stubFor(WireMock.get("/jbang.tar.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(checksum)));
+
+			RunResult r = runProcess(bashCmd("version"), bashEnv("upper-sidecar"));
+
+			assertEquals(0, r.exitCode,
+					"uppercase sidecar checksum should match after normalization, stderr: " + r.stderr);
+		}
+
+		// -- Hash tool failure (CodeRabbit #1) ---------------------------------
+
+		@Test
+		void hashToolUnavailableWithExplicitChecksumShouldFail() throws Exception {
+			// Security concern: when JBANG_DOWNLOAD_CHECKSUM is set but no hash
+			// tool exists, the script must fail — not silently skip verification.
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			Map<String, String> env = bashEnv("no-hash-tool");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", sha256Hex(tar));
+			// Shadow PATH so sha256sum and shasum are not found
+			Path emptyBin = tempSubDir("empty-bin");
+			Files.createDirectories(emptyBin);
+			// Provide only essential commands: need bash builtins + curl/wget
+			// plus tar, mkdir, cp, rm — but NOT sha256sum/shasum
+			env.put("PATH", buildBashPath(emptyBin, "sha256sum", "shasum"));
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertNotEquals(0, r.exitCode,
+					"should fail when hash tools unavailable with explicit checksum");
+			assertTrue(
+					r.stderr.contains("could not compute SHA-256")
+							|| r.stderr.contains("JBANG_DOWNLOAD_CHECKSUM"),
+					"stderr should mention hash failure, was: " + r.stderr);
+		}
+
+		@Test
+		void hashToolUnavailableWithoutChecksumShouldWarn() throws Exception {
+			// When no explicit checksum and no hash tool: warn and continue
+			byte[] tar = createJbangTar();
+			wm.stubFor(WireMock.get("/jbang.tar")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(tar)));
+
+			Map<String, String> env = bashEnv("no-hash-warn");
+			Path emptyBin = tempSubDir("empty-bin-warn");
+			Files.createDirectories(emptyBin);
+			env.put("PATH", buildBashPath(emptyBin, "sha256sum", "shasum"));
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			// Should warn but NOT fail on checksum
+			assertTrue(
+					r.stderr.contains("Warning") || r.stderr.contains("could not compute"),
+					"should warn about missing hash tool, stderr: " + r.stderr);
+			assertTrue(!r.stderr.contains("checksum mismatch"),
+					"should not fail on checksum, stderr: " + r.stderr);
+		}
+
+		// -- JBANG_JAR_CHECKSUM (CodeRabbit #5) -------------------------------
+
+		@Test
+		void jarChecksumMismatchFails() throws Exception {
+			// BUG: when JBDIR/bin/jbang exists (pre-installed), the script
+			// delegates to $JBDIR/bin/jbang and exits BEFORE the
+			// JBANG_JAR_CHECKSUM check. A bad checksum silently passes.
+			Path jbdir = tempSubDir("jbdir-jar-bad");
+			prePopulateJbdir(jbdir, true);
+
+			Map<String, String> env = baseBashEnv("jar-bad");
+			env.put("JBANG_DIR", jbdir.toString());
+			env.put("JBANG_JAR_CHECKSUM", "badhash");
+
+			RunResult r = runProcess(bashCmd("version"), env);
+
+			assertNotEquals(0, r.exitCode, "should fail on jar checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"),
+					"stderr should say mismatch: " + r.stderr);
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// PowerShell
+	// -------------------------------------------------------------------------
+
+	// Note: no hash-tool-unavailable tests for PowerShell. The PS1 script
+	// uses Get-FileHash which is a built-in PowerShell cmdlet — always
+	// available, cannot be removed via PATH. The bash script shells out to
+	// sha256sum/shasum which are external binaries and may be absent.
+
+	@Nested
+	class PowerShell {
+
+		@BeforeEach
+		void checkPowerShell() {
+			requirePowerShell();
+		}
+
+		private Map<String, String> psEnv(String suffix) {
+			Map<String, String> env = basePsEnv(suffix);
+			env.put("JBANG_DOWNLOAD_URL", wm.url("/jbang.zip"));
+			env.put("JBANG_DOWNLOAD_RETRY", "0");
+			return env;
+		}
+
+		@Test
+		void correctSidecarChecksumPasses() throws Exception {
+			byte[] zip = createJbangZip();
+			String checksum = sha256Hex(zip);
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(checksum)));
+
+			RunResult r = runProcess(psCmd("version"), psEnv("sidecar-ok"));
+
+			assertEquals(0, r.exitCode, "should pass with correct sidecar checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void mismatchedSidecarChecksumFails() throws Exception {
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse()
+					.withStatus(200)
+					.withBody("0000000000000000000000000000000000000000000000000000000000000000")));
+
+			RunResult r = runProcess(psCmd("version"), psEnv("sidecar-bad"));
+
+			assertNotEquals(0, r.exitCode, "should fail on checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"), "stderr should say mismatch: " + r.stderr);
+		}
+
+		@Test
+		void explicitChecksumOverridePasses() throws Exception {
+			byte[] zip = createJbangZip();
+			String checksum = sha256Hex(zip);
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			Map<String, String> env = psEnv("override-ok");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", checksum);
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			assertEquals(0, r.exitCode, "should pass with correct explicit checksum, stderr: " + r.stderr);
+			wm.verify(0, WireMock.getRequestedFor(WireMock.urlEqualTo("/jbang.zip.sha256")));
+		}
+
+		@Test
+		void explicitChecksumOverrideMismatchFails() throws Exception {
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			Map<String, String> env = psEnv("override-bad");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", "badhash");
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			assertNotEquals(0, r.exitCode, "should fail on explicit checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"), "stderr should say mismatch: " + r.stderr);
+		}
+
+		@Test
+		void uppercaseChecksumMatchesLowercase() throws Exception {
+			byte[] zip = createJbangZip();
+			String checksum = sha256Hex(zip).toUpperCase();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+
+			Map<String, String> env = psEnv("upper");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", checksum);
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			assertEquals(0, r.exitCode, "uppercase checksum should match, stderr: " + r.stderr);
+		}
+
+		@Test
+		void emptySidecarChecksumShouldWarnNotSilentlyContinue() throws Exception {
+			// BUG: empty .sha256 causes NullReferenceException in PS1 because
+			// Get-Content returns $null for empty file and .Trim() blows up.
+			// Expected: warn "could not obtain checksum" and continue.
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody("")));
+
+			RunResult r = runProcess(psCmd("version"), psEnv("empty-sidecar"));
+
+			// Should NOT crash with InvalidOperation / NullReferenceException
+			assertTrue(!r.stderr.contains("InvalidOperation"),
+					"should not crash on empty sidecar, stderr: " + r.stderr);
+			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
+					"should warn about empty sidecar checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void missingSidecarChecksumWarnsAndContinues() throws Exception {
+			byte[] zip = createJbangZip();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse().withStatus(404)));
+
+			RunResult r = runProcess(psCmd("version"), psEnv("no-sidecar"));
+
+			assertEquals(0, r.exitCode, "should succeed when sidecar is unavailable, stderr: " + r.stderr);
+			assertTrue(r.stderr.contains("Warning") || r.stderr.contains("skipping"),
+					"should warn about missing sidecar, stderr: " + r.stderr);
+		}
+
+		@Test
+		void uppercaseSidecarChecksumNormalized() throws Exception {
+			byte[] zip = createJbangZip();
+			String checksum = sha256Hex(zip).toUpperCase();
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(checksum)));
+
+			RunResult r = runProcess(psCmd("version"), psEnv("upper-sidecar"));
+
+			assertEquals(0, r.exitCode,
+					"uppercase sidecar checksum should match after normalization, stderr: " + r.stderr);
+		}
+
+		@Test
+		void emptyExplicitChecksumShouldFallbackToSidecar() throws Exception {
+			// Security concern: empty JBANG_DOWNLOAD_CHECKSUM should behave like unset
+			byte[] zip = createJbangZip();
+			String checksum = sha256Hex(zip);
+			wm.stubFor(WireMock.get("/jbang.zip")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(zip)));
+			wm.stubFor(WireMock.get("/jbang.zip.sha256")
+				.willReturn(WireMock.aResponse().withStatus(200).withBody(checksum)));
+
+			Map<String, String> env = psEnv("empty-override");
+			env.put("JBANG_DOWNLOAD_CHECKSUM", "");
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			// With empty override, should fall back to sidecar and verify
+			assertEquals(0, r.exitCode, "empty override should fall back to sidecar, stderr: " + r.stderr);
+			wm.verify(WireMock.getRequestedFor(WireMock.urlEqualTo("/jbang.zip.sha256")));
+		}
+
+		// -- JBANG_JAR_CHECKSUM (CodeRabbit #5) -------------------------------
+
+		@Test
+		void jarChecksumMatchPasses() throws Exception {
+			Path jbdir = tempSubDir("jbdir-jar-ok");
+			byte[] jarContent = prePopulateJbdir(jbdir, false);
+
+			Map<String, String> env = basePsEnv("jar-ok");
+			env.put("JBANG_DIR", jbdir.toString());
+			env.put("JBANG_JAR_CHECKSUM", sha256Hex(jarContent));
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			assertEquals(0, r.exitCode,
+					"should pass with correct jar checksum, stderr: " + r.stderr);
+		}
+
+		@Test
+		void jarChecksumMismatchFails() throws Exception {
+			Path jbdir = tempSubDir("jbdir-jar-bad");
+			prePopulateJbdir(jbdir, false);
+
+			Map<String, String> env = basePsEnv("jar-bad");
+			env.put("JBANG_DIR", jbdir.toString());
+			env.put("JBANG_JAR_CHECKSUM", "badhash");
+
+			RunResult r = runProcess(psCmd("version"), env);
+
+			assertNotEquals(0, r.exitCode, "should fail on jar checksum mismatch");
+			assertTrue(r.stderr.contains("checksum mismatch"),
+					"stderr should say mismatch: " + r.stderr);
+		}
+	}
+}


### PR DESCRIPTION
fwiw I've resisted adding this but I now have colleagues reporting they can't install jbang on their corporate locked down laptaps because the default install is not supporting checksum validation.

This attempts to fix it without breaking others. 

## Summary

Automatically verify the SHA-256 checksum of downloaded JBang archives and optionally verify the jar/binary before every execution.

## Two env vars, clean split

- **`JBANG_DOWNLOAD_CHECKSUM`** — override the expected archive checksum at download time. When unset, the server-side `.sha256` file is downloaded and used automatically.
- **`JBANG_JAR_CHECKSUM`** — verify `jbang.jar` (or native binary) before every execution, even when no download occurs. Always mandatory when set.

## Download verification behavior

| Scenario | `JBANG_DOWNLOAD_CHECKSUM` set | `JBANG_DOWNLOAD_CHECKSUM` unset |
|---|---|---|
| Hash tool available, checksum matches | ✅ continue | ✅ continue |
| Hash tool available, checksum mismatch | ❌ error + exit 1 | ❌ error + exit 1 |
| Hash tool available, `.sha256` download fails | n/a | ⚠️ warning, continue |
| No hash tool available | ❌ error + exit 1 | ⚠️ warning, continue |

## Jar/binary verification behavior

When `JBANG_JAR_CHECKSUM` is set, the jar or native binary is hashed before every invocation. Mismatch or missing hash tool → hard error.

## Changes

- **`src/main/scripts/jbang`** — archive checksum verification after download (sha256sum/shasum), jar/binary verification before execution
- **`src/main/scripts/jbang.ps1`** — same logic using `Get-FileHash` (built into PowerShell 4+)
- **`docs/modules/ROOT/pages/installation.adoc`** — new "Download checksum verification" section, `JBANG_DOWNLOAD_CHECKSUM` and `JBANG_JAR_CHECKSUM` in env var reference table

`jbang.cmd` delegates downloads to `jbang.ps1` — no CMD changes needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SHA-256 verification for downloaded JBang archives.
  * Added optional verification of JBang JARs and native binaries before execution and after installation.
  * Supports configured checksums and automatically retrieved checksum files.

* **Bug Fixes**
  * Improved handling of uppercase, empty, or unavailable checksums.
  * Provides consistent warnings or failures when verification cannot be completed.

* **Documentation**
  * Documented checksum settings, defaults, verification behavior, and installation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->