### PR TITLE
feat: add "jbang.source" and "jbang.dir"

### DIFF
--- a/docs/modules/ROOT/pages/execution-options.adoc
+++ b/docs/modules/ROOT/pages/execution-options.adoc
@@ -90,6 +90,59 @@ public class RecordExample {
 
 The `//PREVIEW` directive automatically adds the necessary compile and runtime options.
 
+== Script Location Properties
+
+A script is compiled into JBang's jar cache and run from there, so the usual Java ways of asking
+"where am I?" answer about the cache, not about the script. `getProtectionDomain().getCodeSource()`
+points at `~/.jbang/cache/jars/...`, and a relative path resolves against the directory the caller
+happened to be in.
+
+JBang therefore sets two system properties for you:
+
+[cols="1,3"]
+|===
+| Property | Value
+
+| `jbang.source`
+| Absolute path of the script being run
+
+| `jbang.dir`
+| The directory that script is in
+|===
+
+[source,java]
+----
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+import java.nio.file.Path;
+
+public class LocationTest {
+    public static void main(String... args) {
+        Path script = Path.of(System.getProperty("jbang.source"));
+        Path dir = Path.of(System.getProperty("jbang.dir"));
+
+        System.out.println("script : " + script);
+        System.out.println("dir    : " + dir);
+    }
+}
+----
+
+The typical use is a script checked into a project that has to read or write files belonging to that
+project, wherever it is started from:
+
+[source,java]
+----
+Path root = Path.of(System.getProperty("jbang.dir")).getParent();
+Files.writeString(root.resolve("content/index.html"), html);
+----
+
+Both properties can be overridden on the command line — `jbang -Djbang.source=/elsewhere/x.java
+myscript.java` — because JBang adds them before your own `-D` options.
+
+NOTE: They are set for scripts that exist as a local file. Code piped in, code passed with
+`--code`, a remote source given as a URL, and a jar or Maven coordinate have no source file in a
+project, so neither property is set — check for `null` if your script may be run that way.
+
 == Environment Variables
 
 === Java Options

--- a/docs/modules/ROOT/pages/faq.adoc
+++ b/docs/modules/ROOT/pages/faq.adoc
@@ -13,6 +13,12 @@ ifdef::env-github[]
 endif::[]
 
 [qanda]
+How does my script find out where it is?::
+  Through the `jbang.source` and `jbang.dir` system properties, which JBang sets to the script's
+path and to the directory it is in. They are what a script needs to read or write files belonging to
+the project it is checked into, since the compiled script itself runs from the jar cache and
+`getCodeSource()` therefore points there. See xref:jbang:ROOT:execution-options.adoc#script-location-properties[Script Location Properties].
+
 Why the name j'bang?::
   I was reading up on how to use the new shebang (#!) feature support in Java 10 and came up with the idea of port `kscript` to Java and needed a name.
 From there came j'bang which is a "bad" spelling of how shebang is pronounced in French.

--- a/docs/modules/ROOT/pages/organizing.adoc
+++ b/docs/modules/ROOT/pages/organizing.adoc
@@ -16,6 +16,11 @@ toc::[]
 
 == Multiple source files
 
+TIP: A script that reads or writes files belonging to its project can find them with the
+`jbang.source` and `jbang.dir` system properties, rather than assuming the caller's working
+directory — see xref:jbang:ROOT:execution-options.adoc#script-location-properties[Script Location Properties].
+
+
 It is possible to use multiple source files just by having them in the same source directory. 
 To a limited extend, it also works with packages.
 

--- a/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/JarCmdGenerator.java
@@ -23,6 +23,7 @@ import org.jboss.jandex.Indexer;
 import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.devkitman.Jdk;
+import dev.jbang.resources.ResourceRef;
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.buildsteps.CompileBuildStep;
@@ -110,6 +111,7 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 					"--enable-native-access=");
 		}
 
+		addSourceLocationFlags(project, optionalArgs);
 		addPropertyFlags(project.getProperties(), "-D", optionalArgs);
 
 		if (debugString != null) {
@@ -330,6 +332,54 @@ public class JarCmdGenerator extends BaseCmdGenerator<JarCmdGenerator> {
 
 	private static void addPropertyFlags(Map<String, String> properties, String def, List<String> result) {
 		properties.forEach((k, e) -> result.add(def + k + "=" + e));
+	}
+
+	/**
+	 * Tells the running code where its own source is, through {@code jbang.source}
+	 * and {@code jbang.dir}.
+	 *
+	 * <p>
+	 * A script is compiled into the jar cache and run from there, so
+	 * {@code getCodeSource()} points at {@code ~/.jbang/cache/jars/...} and the
+	 * script has no way of finding the project it is checked into. The JDK's own
+	 * single-file launcher ({@code java Foo.java}) does not have that problem, and
+	 * neither do bash, python or perl.
+	 *
+	 * <p>
+	 * These are added before the user's own {@code -D} flags, so an explicit
+	 * {@code -Djbang.source=...} still wins.
+	 *
+	 * @param project the project whose main source is being run
+	 * @param result  the argument list to add the flags to
+	 */
+	private static void addSourceLocationFlags(Project project, List<String> result) {
+		if (project.getMainSource() == null) {
+			// A jar or GAV is not a script: there is no source to point at.
+			return;
+		}
+		ResourceRef ref = project.getResourceRef();
+		String original = ref.getOriginalResource();
+		if (original == null || ref.isStdin() || ref.isURL() || ref.isClasspath()) {
+			// Deliberately limited to sources that exist as a file in a project. Code piped
+			// in or passed with --code has no location at all; a remote source has one, but
+			// reporting it means putting a URL on the command line, and its local copy
+			// lives in the download cache, which is not a project either. Left for a
+			// follow-up.
+			return;
+		}
+		Path source;
+		try {
+			source = ref.getFile().toAbsolutePath().normalize();
+		} catch (RuntimeException e) {
+			// A reference that cannot produce a file is not worth failing a run over.
+			Util.verboseMsg("Not setting jbang.source, no file for " + original + ": " + e.getMessage());
+			return;
+		}
+		result.add("-Djbang.source=" + source);
+		Path dir = source.getParent();
+		if (dir != null) {
+			result.add("-Djbang.dir=" + dir);
+		}
 	}
 
 }

--- a/src/test/java/dev/jbang/cli/TestRun.java
+++ b/src/test/java/dev/jbang/cli/TestRun.java
@@ -137,6 +137,57 @@ public class TestRun extends BaseTest {
 	}
 
 	@Test
+	void testSourceLocationProperties() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		Path script = examplesTestFolder.resolve("helloworld.java").toAbsolutePath();
+		Run run = JBang.parseCommand("run", script.toString());
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		String result = Project.codeBuilder(BuildContext.forProject(pb.build(script.toString())))
+			.build()
+			.build()
+			.generate();
+
+		assertThat(result, containsString(CommandBuffer.escapeShellArgument(
+				"-Djbang.source=" + script, Util.getShell())));
+		assertThat(result, containsString(CommandBuffer.escapeShellArgument(
+				"-Djbang.dir=" + script.getParent(), Util.getShell())));
+	}
+
+	@Test
+	void testNoSourceLocationPropertiesForUrl() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		String url = examplesTestFolder.resolve("helloworld.java").toUri().toString();
+		Run run = JBang.parseCommand("run", url);
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		String result = Project.codeBuilder(BuildContext.forProject(pb.build(url))).build().build().generate();
+
+		// A remote source is out of scope: its local copy is in the download cache,
+		// which is not a project, and reporting the URL would put it on the command
+		// line. See testURLPrepare, which asserts exactly that it does not appear.
+		assertThat(result, not(containsString("-Djbang.source")));
+		assertThat(result, not(containsString("-Djbang.dir")));
+	}
+
+	@Test
+	void testSourceLocationPropertyCanBeOverridden() throws IOException {
+		environmentVariables.clear("JAVA_HOME");
+		Path script = examplesTestFolder.resolve("helloworld.java").toAbsolutePath();
+		Run run = JBang.parseCommand("run", "-Djbang.source=/somewhere/else.java", script.toString());
+
+		ProjectBuilder pb = run.createProjectBuilderForRun();
+		String result = run.updateGeneratorForRun(pb.build(script.toString()).codeBuilder().build())
+			.build()
+			.generate();
+
+		// Both appear, the user's last, which is the one the JVM keeps.
+		assertThat(result, containsString("-Djbang.source="));
+		assertThat(result.lastIndexOf("-Djbang.source=/somewhere/else.java"),
+				greaterThan(result.indexOf("-Djbang.source=" + script)));
+	}
+
+	@Test
 	void testHelloWorldAlias() throws IOException {
 		environmentVariables.clear("JAVA_HOME");
 		Path cat = examplesTestFolder.resolve("jbang-catalog.json").toAbsolutePath();
@@ -768,7 +819,11 @@ public class TestRun extends BaseTest {
 		} else {
 			assertThat(result, containsString("'-Dquoted=see this'"));
 		}
-		String[] split = result.split("example.java");
+		// Split on the main class rather than on the script name: it is the actual
+		// boundary between JVM options and program arguments, and unlike the script
+		// name it
+		// appears exactly once now that -Djbang.source carries the script's path.
+		String[] split = result.split("fakemain");
 		assertEquals(2, split.length);
 		assertThat(split[0], not(containsString("after=wonka")));
 		assertThat(split[1], containsString("after=wonka"));


### PR DESCRIPTION
Fixes #2642

---

NOTE for the reviewer: I changed one existing test:
`testProperties()` used to split the generated command line on `example.java` and expect exactly 2 parts;
`-Djbang.source` legitimately puts the script path on the command line a second time, so the split now uses `fakemain`, the main class — the actual boundary between JVM options and program arguments, which appears exactly once.
