### PR TITLE
fix: migrate from deprecated BaseCommand.EXIT_* to ExitException.EXIT_*

### DIFF
--- a/src/main/java/dev/jbang/cli/Alias.java
+++ b/src/main/java/dev/jbang/cli/Alias.java
@@ -87,7 +87,7 @@ public class Alias extends BaseCommand {
 		public Integer doCall() throws IOException {
 			scriptMixin.validate();
 			if (name != null && !Catalog.isValidName(name)) {
-				throw new ExitException(EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Invalid alias name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 			}
 
@@ -117,10 +117,10 @@ public class Alias extends BaseCommand {
 				CatalogUtil.addAlias(catFile, name, alias);
 			} else {
 				Util.infoMsg("A script with name '" + name + "' already exists, use '--force' to add anyway.");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 			info(String.format("Alias '%s' added to '%s'", name, catFile));
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		ProjectBuilder createAliasProjectBuilder() {
@@ -194,7 +194,7 @@ public class Alias extends BaseCommand {
 			} else {
 				printAliases(out, catalogName, catalog, format);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static void printAliases(PrintStream out, String catalogName, Catalog catalog, OutputFormat format) {
@@ -341,7 +341,7 @@ public class Alias extends BaseCommand {
 			} else {
 				CatalogUtil.removeNearestAlias(name);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 }

--- a/src/main/java/dev/jbang/cli/App.java
+++ b/src/main/java/dev/jbang/cli/App.java
@@ -87,16 +87,17 @@ public class App extends BaseCommand {
 			try {
 				if ("jbang".equals(scriptMixin.scriptOrFile)) {
 					if (name != null && !"jbang".equals(name)) {
-						throw new ExitException(EXIT_INVALID_INPUT,
+						throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 								"It's not possible to install jbang with a different name");
 					}
 					installed = installJBang(force);
 				} else {
 					if ("jbang".equals(name)) {
-						throw new ExitException(EXIT_INVALID_INPUT, "jbang is a reserved name.");
+						throw new ExitException(ExitException.EXIT_INVALID_INPUT, "jbang is a reserved name.");
 					}
 					if (name != null && !CatalogUtil.isValidName(name)) {
-						throw new ExitException(EXIT_INVALID_INPUT, "Not a valid command name: '" + name + "'");
+						throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+								"Not a valid command name: '" + name + "'");
 					}
 					installed = install();
 				}
@@ -106,9 +107,9 @@ public class App extends BaseCommand {
 					}
 				}
 			} catch (IOException e) {
-				throw new ExitException(EXIT_INTERNAL_ERROR, "Could not install command", e);
+				throw new ExitException(ExitException.EXIT_INTERNAL_ERROR, "Could not install command", e);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private List<String> collectRunOptions() {
@@ -239,7 +240,8 @@ public class App extends BaseCommand {
 					// TODO: this is duplicated in Wrapper.java - should be more shared.
 					String jarName = jar.getFileName().toString();
 					if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
-						throw new ExitException(EXIT_GENERIC_ERROR, "Could not determine jbang location from " + jar);
+						throw new ExitException(ExitException.EXIT_GENERIC_ERROR,
+								"Could not determine jbang location from " + jar);
 					}
 					Path fromDir = jar.getParent();
 					if (fromDir.endsWith(".jbang")) {
@@ -276,7 +278,7 @@ public class App extends BaseCommand {
 						Files.copy(fromp, top, StandardCopyOption.REPLACE_EXISTING,
 								StandardCopyOption.COPY_ATTRIBUTES);
 					} catch (IOException e) {
-						throw new ExitException(EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);
+						throw new ExitException(ExitException.EXIT_GENERIC_ERROR, "Could not copy " + f.toString(), e);
 					}
 				});
 			if (Util.isWindows() && Util.getShell() != Util.Shell.cmd) {
@@ -322,7 +324,7 @@ public class App extends BaseCommand {
 			} else {
 				listCommandFiles().forEach(app -> System.out.println(app.name));
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static class AppOut {
@@ -367,10 +369,10 @@ public class App extends BaseCommand {
 			if (commandFilesExist(name)) {
 				App.deleteCommandFiles(name);
 				Util.infoMsg("Command removed: " + name);
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} else {
 				Util.infoMsg("Command not found: " + name);
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 		}
 
@@ -434,7 +436,7 @@ public class App extends BaseCommand {
 				Jdk defJdk = defaultJdkManager().getDefaultJdk();
 				if (defJdk == null) {
 					Util.infoMsg("No default JDK set, use 'jbang jdk default <version>' to set one.");
-					return EXIT_UNEXPECTED_STATE;
+					return ExitException.EXIT_UNEXPECTED_STATE;
 				}
 				jdkHome = Settings.getDefaultJdkDir();
 			}
@@ -515,7 +517,7 @@ public class App extends BaseCommand {
 				System.out.println(cmd);
 				return ExitException.EXIT_EXECUTE;
 			} else {
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 		}
 

--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -211,7 +211,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 		} else if (netrc != null) {
 			Path netrcPath = Paths.get(netrc);
 			if (!Files.isReadable(netrcPath)) {
-				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Netrc file does not exist or is not readable: " + netrcPath);
 			}
 			NetUtil.setNetrcFile(netrcPath);

--- a/src/main/java/dev/jbang/cli/Build.java
+++ b/src/main/java/dev/jbang/cli/Build.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.aesh.command.CommandDefinition;
 
+import dev.jbang.ExitException;
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.Project;
 import dev.jbang.source.ProjectBuilder;
@@ -19,7 +20,7 @@ public class Build extends BaseBuildCommand {
 		Project prj = pb.build(scriptMixin.scriptOrFile);
 		Project.codeBuilder(BuildContext.forProject(prj, getBuildDir())).build();
 
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 
 	ProjectBuilder createProjectBuilderForBuild() {

--- a/src/main/java/dev/jbang/cli/Cache.java
+++ b/src/main/java/dev/jbang/cli/Cache.java
@@ -1,13 +1,13 @@
 package dev.jbang.cli;
 
-import static dev.jbang.cli.BaseCommand.EXIT_OK;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
 
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
+
+import dev.jbang.ExitException;
 
 @CommandDefinition(name = "cache", description = "Manage compiled scripts in the local cache.", groupCommands = {
 		Cache.CacheClear.class }, generateHelp = true, helpGroup = "Caching")
@@ -88,7 +88,7 @@ public class Cache extends BaseCommand {
 
 			dev.jbang.Cache.CacheClass[] ccs = classes.toArray(new dev.jbang.Cache.CacheClass[0]);
 			dev.jbang.Cache.clearCache(ccs);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private void toggleCache(Boolean b, dev.jbang.Cache.CacheClass cache,

--- a/src/main/java/dev/jbang/cli/Catalog.java
+++ b/src/main/java/dev/jbang/cli/Catalog.java
@@ -61,7 +61,7 @@ public class Catalog extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			if (name != null && !dev.jbang.catalog.Catalog.isValidName(name)) {
-				throw new ExitException(EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Invalid catalog name, it should start with a letter followed by 0 or more letters, digits, underscores, hyphens or dots");
 			}
 			if (name == null) {
@@ -73,10 +73,10 @@ public class Catalog extends BaseCommand {
 				CatalogUtil.addCatalogRef(catFile, name, ref.catalogRef, ref.description, importItems);
 			} else {
 				Util.infoMsg("A catalog with name '" + name + "' already exists, use '--force' to add anyway.");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 			info(String.format("Catalog '%s' added to '%s'", name, catFile));
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -102,7 +102,7 @@ public class Catalog extends BaseCommand {
 						return null;
 					});
 				});
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -181,7 +181,7 @@ public class Catalog extends BaseCommand {
 					}
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static void printCatalogs(PrintStream out, String catalogName, dev.jbang.catalog.Catalog catalog,
@@ -326,7 +326,7 @@ public class Catalog extends BaseCommand {
 			} else {
 				CatalogUtil.removeNearestCatalogRef(name);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 }

--- a/src/main/java/dev/jbang/cli/CatalogFileOptionsMixin.java
+++ b/src/main/java/dev/jbang/cli/CatalogFileOptionsMixin.java
@@ -40,7 +40,7 @@ public class CatalogFileOptionsMixin {
 				cat = catPath;
 			}
 			if (strict && cat != null && !Files.isRegularFile(cat)) {
-				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Catalog file not found at: " + catalogFile);
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Catalog file not found at: " + catalogFile);
 			}
 		}
 		return cat;

--- a/src/main/java/dev/jbang/cli/Completion.java
+++ b/src/main/java/dev/jbang/cli/Completion.java
@@ -45,7 +45,7 @@ public class Completion extends BaseCommand {
 			shellType = detectShell();
 		}
 		if (shellType == null) {
-			throw new ExitException(EXIT_INVALID_INPUT,
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 					"Could not detect your shell. Please specify one, e.g.: jbang completion bash");
 		}
 		try {
@@ -53,11 +53,12 @@ public class Completion extends BaseCommand {
 			System.out.println(script);
 			System.out.println(usageHint(shellType));
 		} catch (Exception e) {
-			throw new ExitException(EXIT_INTERNAL_ERROR, "Failed to generate completion script: " + e.getMessage(),
+			throw new ExitException(ExitException.EXIT_INTERNAL_ERROR,
+					"Failed to generate completion script: " + e.getMessage(),
 					e);
 		}
 
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 
 	private static String usageHint(ShellType type) {

--- a/src/main/java/dev/jbang/cli/Config.java
+++ b/src/main/java/dev/jbang/cli/Config.java
@@ -77,7 +77,8 @@ public class Config extends BaseCommand {
 					cfg = cfgPath;
 				}
 				if (strict && cfg != null && !Files.isRegularFile(cfg)) {
-					throw new ExitException(EXIT_INVALID_INPUT, "Config file not found at: " + configFile);
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+							"Config file not found at: " + configFile);
 				}
 			}
 			return cfg;
@@ -95,10 +96,10 @@ public class Config extends BaseCommand {
 			if (cfg.containsKey(key)) {
 				String res = Objects.toString(cfg.get(key));
 				System.out.println(res);
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} else {
 				Util.infoMsg("No configuration option found with that name: " + key);
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 		}
 	}
@@ -124,7 +125,7 @@ public class Config extends BaseCommand {
 					key = keyOrKeyValue.substring(0, eqIdx);
 					val = keyOrKeyValue.substring(eqIdx + 1);
 				} else {
-					throw new ExitException(EXIT_INVALID_INPUT,
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 							"Expected key=value format or separate key and value arguments");
 				}
 			}
@@ -135,7 +136,7 @@ public class Config extends BaseCommand {
 				cfgFile = ConfigUtil.setNearestConfigValue(key, val);
 			}
 			Util.infoMsg("Option '" + key + "' set to '" + val + "' in " + cfgFile);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -159,10 +160,10 @@ public class Config extends BaseCommand {
 				} else {
 					Util.warnMsg("Cannot remove built-in option '" + key + "'");
 				}
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} else {
 				Util.infoMsg("No configuration option found with that name: " + key);
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 		}
 	}
@@ -182,7 +183,7 @@ public class Config extends BaseCommand {
 		public Integer doCall() throws IOException {
 			PrintStream out = System.out;
 			if (showAvailable && showOrigin) {
-				throw new ExitException(EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Options '--show-available' and '--show-origin' cannot be used together");
 			}
 			if (showAvailable) {
@@ -206,7 +207,7 @@ public class Config extends BaseCommand {
 					printConfig(out, cfg, format);
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		@SuppressWarnings("unchecked")

--- a/src/main/java/dev/jbang/cli/Deps.java
+++ b/src/main/java/dev/jbang/cli/Deps.java
@@ -52,7 +52,8 @@ public class Deps extends BaseCommand {
 
 		private void updateTarget(String a0) throws IOException {
 			if (target != null) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Cannot provide both target as as parameter and as option");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+						"Cannot provide both target as as parameter and as option");
 			} else {
 				target = a0;
 			}
@@ -60,7 +61,8 @@ public class Deps extends BaseCommand {
 
 		private void updateQuery(String a0) {
 			if (query != null) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Cannot provide both query as as parameter and as option");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+						"Cannot provide both query as as parameter and as option");
 			} else {
 				query = a0;
 			}
@@ -83,7 +85,7 @@ public class Deps extends BaseCommand {
 
 			Path targetPath = target != null ? Paths.get(target) : null;
 			if (targetPath != null && !Files.exists(targetPath)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Target file does not exist: " + targetPath);
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Target file does not exist: " + targetPath);
 			}
 
 			try {
@@ -99,9 +101,9 @@ public class Deps extends BaseCommand {
 					System.out.printf("%s:%s:%s%n", artifact.getGroupId(), artifact.getArtifactId(),
 							artifact.getVersion());
 				}
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} catch (IOError e) {
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 		}
 
@@ -119,7 +121,8 @@ public class Deps extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			if (parameters.size() < 2) {
-				throw new ExitException(EXIT_INVALID_INPUT, "At least one dependency and target file are required");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+						"At least one dependency and target file are required");
 			}
 
 			// Last parameter is the target file
@@ -127,24 +130,24 @@ public class Deps extends BaseCommand {
 			List<String> dependencies = parameters.subList(0, parameters.size() - 1);
 
 			if (!Files.exists(targetFile)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Target file does not exist: " + targetFile);
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Target file does not exist: " + targetFile);
 			}
 
 			updateFile(targetFile, dependencies);
 
 			info("Added dependencies to " + targetFile);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static public void updateFile(Path file, List<String> dependencies) throws IOException {
 			// Validate dependencies
 			for (String dep : dependencies) {
 				if (!DependencyUtil.looksLikeAGav(dep)) {
-					throw new ExitException(EXIT_INVALID_INPUT, "Invalid dependency format: " + dep);
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Invalid dependency format: " + dep);
 				}
 			}
 			if (!Files.exists(file)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "File does not exist: " + file);
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "File does not exist: " + file);
 			}
 
 			FileUpdateStrategy strategy = FileUpdaters.forFile(file);

--- a/src/main/java/dev/jbang/cli/Edit.java
+++ b/src/main/java/dev/jbang/cli/Edit.java
@@ -179,7 +179,7 @@ public class Edit extends BaseCommand {
 			final Project prj = pb.build(scriptMixin.scriptOrFile);
 
 			if (prj.isExecutableArchive() || prj.getMainSourceSet().getSources().isEmpty()) {
-				throw new ExitException(EXIT_INVALID_INPUT, "You can only edit source files");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "You can only edit source files");
 			}
 
 			Path project = createProjectForLinkedEdit(prj, Collections.emptyList(), false);
@@ -194,7 +194,7 @@ public class Edit extends BaseCommand {
 			} else {
 				Path orginalFile = prj.getResourceRef().getFile();
 				if (!Files.exists(orginalFile)) {
-					throw new ExitException(EXIT_UNEXPECTED_STATE,
+					throw new ExitException(ExitException.EXIT_UNEXPECTED_STATE,
 							"Cannot live edit " + prj.getResourceRef().getOriginalResource());
 				}
 				watchForChanges(orginalFile, () -> {
@@ -211,7 +211,7 @@ public class Edit extends BaseCommand {
 				});
 			}
 		}
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 
 	private void watchForChanges(Path orginalFile, Callable<Object> action) throws IOException {
@@ -234,7 +234,8 @@ public class Edit extends BaseCommand {
 							warn("Error when re-generating project. Ignoring it, but state might be undefined: "
 									+ ee.getMessage());
 						} catch (Exception e) {
-							throw new ExitException(EXIT_GENERIC_ERROR, "Exception when re-generating project. Exiting",
+							throw new ExitException(ExitException.EXIT_GENERIC_ERROR,
+									"Exception when re-generating project. Exiting",
 									e);
 						}
 					}
@@ -327,7 +328,7 @@ public class Edit extends BaseCommand {
 				showStartingMsg(ed, true);
 				return Optional.of(ed);
 			} else {
-				throw new ExitException(EXIT_GENERIC_ERROR,
+				throw new ExitException(ExitException.EXIT_GENERIC_ERROR,
 						"No default editor configured and no other option accepted.\n Please try again making a correct choice or use an explicit editor, i.e. `jbang edit --open=eclipse xyz.java`");
 			}
 		}
@@ -381,7 +382,7 @@ public class Edit extends BaseCommand {
 		try {
 			int exit = process.waitFor();
 			if (exit > 0) {
-				throw new ExitException(EXIT_INTERNAL_ERROR,
+				throw new ExitException(ExitException.EXIT_INTERNAL_ERROR,
 						"Could not install and setup extensions into VSCodium. Aborting.");
 			}
 		} catch (InterruptedException e) {
@@ -554,7 +555,8 @@ public class Edit extends BaseCommand {
 			throws IOException {
 		Template template = engine.getTemplate(templateRef);
 		if (template == null)
-			throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+					"Could not locate template named: '" + templateRef + "'");
 		String result = template
 			.data("repositories",
 					repositories.stream()

--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -123,7 +123,7 @@ public class Export extends BaseCommand {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			} else {
 				Util.mkdirs(outputPath.getParent());
@@ -141,7 +141,7 @@ public class Export extends BaseCommand {
 			}
 
 			Util.infoMsg("Exported to " + outputPath);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -160,7 +160,7 @@ public class Export extends BaseCommand {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			} else {
 				Util.mkdirs(outputPath.getParent());
@@ -189,7 +189,7 @@ public class Export extends BaseCommand {
 						getProjectJdk(prj));
 			}
 			Util.infoMsg("Exported to " + outputPath);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -217,13 +217,13 @@ public class Export extends BaseCommand {
 			if (!outPath.toFile().isDirectory()) {
 				if (outPath.toFile().exists()) {
 					Util.errorMsg("Cannot export as maven repository as " + outPath + " is not a directory.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 				if (force) {
 					Util.mkdirs(outPath);
 				} else {
 					Util.errorMsg("Cannot export as " + outPath + " does not exist. Use --force to create.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			}
 
@@ -244,7 +244,7 @@ public class Export extends BaseCommand {
 			if (group == null) {
 				Util.errorMsg(
 						"Cannot export as maven repository as no group specified. Add --group=<group id> and run again.");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 			Path groupdir = outPath.resolve(Paths.get(group.replace(".", "/")));
 
@@ -267,7 +267,7 @@ public class Export extends BaseCommand {
 					artifactFile.toFile().delete();
 				} else {
 					Util.errorMsg("Cannot export as " + artifactFile + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			}
 			Util.infoMsg("Writing " + artifactFile);
@@ -297,7 +297,7 @@ public class Export extends BaseCommand {
 			}
 
 			Util.infoMsg("Exported to " + outPath);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -314,7 +314,7 @@ public class Export extends BaseCommand {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			} else {
 				Util.mkdirs(outputPath.getParent());
@@ -322,7 +322,7 @@ public class Export extends BaseCommand {
 			Files.copy(source, outputPath);
 
 			Util.infoMsg("Exported to " + outputPath);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		@Override
@@ -354,7 +354,7 @@ public class Export extends BaseCommand {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + outputPath + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			} else {
 				Util.mkdirs(outputPath.getParent());
@@ -396,7 +396,7 @@ public class Export extends BaseCommand {
 			Util.infoMsg("Exported to " + outputPath);
 			Util.infoMsg("This is an experimental feature and might not to work for certain applications!");
 			Util.infoMsg("Help us improve by reporting any issue you find at https://github.com/jbangdev/jbang/issues");
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		public static void handleZipFile(ZipFile zipFile, ZipArchiveEntry zipEntry, Path outFile, Exception ex)
@@ -479,7 +479,7 @@ public class Export extends BaseCommand {
 					Util.deletePath(outputPath, false);
 				} else {
 					Util.errorMsg("Cannot export as " + relativeOP + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			}
 
@@ -517,7 +517,7 @@ public class Export extends BaseCommand {
 			String out = Util.runCommand(args.toArray(new String[] {}));
 			if (out == null) {
 				Util.errorMsg("Unable to export Jdk distribution.");
-				return EXIT_GENERIC_ERROR;
+				return ExitException.EXIT_GENERIC_ERROR;
 			}
 
 			Util.infoMsg("Exported to " + relativeOP);
@@ -525,7 +525,7 @@ public class Export extends BaseCommand {
 				Util.infoMsg(
 						"A launcher has been created which you can run using: " + relativeOP + "/bin/" + launcherName);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private Path getJlinkOutputPath() {
@@ -555,14 +555,14 @@ public class Export extends BaseCommand {
 					Util.deletePath(projectDir, false);
 				} else {
 					Util.errorMsg("Cannot export as " + projectDir + " already exists. Use --force to overwrite.");
-					return EXIT_INVALID_INPUT;
+					return ExitException.EXIT_INVALID_INPUT;
 				}
 			}
 
 			Project prj = ctx.getProject();
 			if (prj.isExecutableArchive() || prj.getMainSourceSet().getSources().isEmpty()) {
 				Util.errorMsg("You can only export source files");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 
 			if (prj.getGav().isPresent()) {
@@ -591,7 +591,7 @@ public class Export extends BaseCommand {
 			info("Exported as " + getType() + " project to " + projectDir);
 			info("Export to " + getType() + " is a best-effort to try match JBang build.");
 			info("If something can be improved please open issue at open an issue at https://github.com/jbangdev/jbang/issues with reproducer.");
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private void createProjectForExport(BuildContext ctx, Path projectDir) throws IOException {
@@ -694,10 +694,11 @@ public class Export extends BaseCommand {
 			TemplateEngine engine = TemplateEngine.instance();
 			Template template = engine.getTemplate(templateRef);
 			if (template == null)
-				throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+						"Could not locate template named: '" + templateRef + "'");
 			Source.Type srcType = prj.getMainSource().getType();
 			if (!supportedSourceTypes.contains(srcType)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
 			}
 			String kotlinVersion = srcType == Source.Type.kotlin
 					? ((KotlinSource) prj.getMainSource()).getKotlinVersion()
@@ -791,10 +792,11 @@ public class Export extends BaseCommand {
 			TemplateEngine engine = TemplateEngine.instance();
 			Template template = engine.getTemplate(templateRef);
 			if (template == null)
-				throw new ExitException(EXIT_INVALID_INPUT, "Could not locate template named: '" + templateRef + "'");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+						"Could not locate template named: '" + templateRef + "'");
 			Source.Type srcType = prj.getMainSource().getType();
 			if (!supportedSourceTypes.contains(srcType)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Unsupported source type: " + srcType.name());
 			}
 			String kotlinVersion = srcType == Source.Type.kotlin
 					? ((KotlinSource) prj.getMainSource()).getKotlinVersion()

--- a/src/main/java/dev/jbang/cli/Info.java
+++ b/src/main/java/dev/jbang/cli/Info.java
@@ -313,16 +313,17 @@ public class Info extends BaseCommand {
 						// any calling scripts can easily detect that
 						// situation instead of having to ambiguously
 						// compare against the string "null"
-						return EXIT_GENERIC_ERROR;
+						return ExitException.EXIT_GENERIC_ERROR;
 					}
 				} catch (NoSuchFieldException | IllegalAccessException e) {
-					throw new ExitException(EXIT_INVALID_INPUT, "Cannot return value of unknown field: " + select, e);
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+							"Cannot return value of unknown field: " + select, e);
 				}
 			} else {
 				parser.toJson(info, out);
 			}
 
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -346,7 +347,7 @@ public class Info extends BaseCommand {
 			cp.addAll(deps);
 			out.println(String.join(CP_SEPARATOR, cp));
 
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -357,7 +358,7 @@ public class Info extends BaseCommand {
 		public Integer doCall() throws IOException {
 			ScriptInfo info = getInfo(false);
 			out.println(info.applicationJar);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -398,15 +399,15 @@ public class Info extends BaseCommand {
 
 			if (toOpen[0] == null) {
 				Util.infoMsg("No documentation files found");
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 			if (!open) {
 				Util.infoMsg("Use --open to open the documentation file in the default browser.");
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 			if (GraphicsEnvironment.isHeadless()) {
 				Util.infoMsg("Cannot open documentation file in browser in headless mode");
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 			try {
 				Desktop.getDesktop().browse(getDocsUri(toOpen[0]));
@@ -414,7 +415,7 @@ public class Info extends BaseCommand {
 				Util.infoMsg("Documentation file to open not found: " + toOpen[0]);
 			}
 
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		URI getDocsUri(ProjectFile doc) {

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -65,7 +65,7 @@ public class Init extends BaseCommand {
 
 	public void requireScriptArgument() {
 		if (scriptOrFile == null) {
-			throw new ExitException(EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
 		}
 	}
 
@@ -91,7 +91,7 @@ public class Init extends BaseCommand {
 
 		dev.jbang.catalog.Template tpl = dev.jbang.catalog.Template.get(initTemplate);
 		if (tpl == null) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 					"Could not find init template named: " + initTemplate
 							+ ". Try run with --fresh to get latest catalog updates.");
 		}
@@ -131,7 +131,7 @@ public class Init extends BaseCommand {
 				Path target = refTarget.to(outDir);
 				if (Files.exists(target)) {
 					warn("File " + target + " already exists. Will not initialize.");
-					return EXIT_GENERIC_ERROR;
+					return ExitException.EXIT_GENERIC_ERROR;
 				}
 			}
 		}
@@ -151,7 +151,7 @@ public class Init extends BaseCommand {
 				} catch (IllegalStateException | IOException e) {
 					Util.errorMsg(
 							"Failed to generate code with " + provider.getName(), e);
-					return EXIT_INTERNAL_ERROR;
+					return ExitException.EXIT_INTERNAL_ERROR;
 				}
 			} else {
 				Util.warnMsg(
@@ -189,7 +189,7 @@ public class Init extends BaseCommand {
 					+ "'. If your IDE supports JBang, you can edit the directory instead: 'jbang edit . "
 					+ renderedScriptOrFile + "'. See https://jbang.dev/ide");
 		}
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 
 	private void applyTemplateProperties(dev.jbang.catalog.Template tpl, Map<String, Object> propsMap) {
@@ -214,7 +214,7 @@ public class Init extends BaseCommand {
 						: Util.extension(refSource);
 			}
 			if (!outExt.isEmpty() && !outExt.equals(targetExt)) {
-				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Template expects " + targetExt + " extension, not " + outExt);
 			}
 			result = dev.jbang.cli.Template.TPL_FILENAME_PATTERN.matcher(result).replaceAll(outName);
@@ -227,14 +227,14 @@ public class Init extends BaseCommand {
 			throws IOException {
 		Template template = TemplateEngine.instance().getTemplate(templateRef);
 		if (template == null) {
-			throw new ExitException(EXIT_INVALID_INPUT,
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 					"Could not find or load template: " + templateRef);
 		}
 
 		if (outFile.toString().endsWith(".java")) {
 			String basename = Util.getBaseName(outFile.getFileName().toString());
 			if (!SourceVersion.isIdentifier(basename)) {
-				throw new ExitException(EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"'" + basename + "' is not a valid class name in java. Remove the special characters");
 			}
 		}

--- a/src/main/java/dev/jbang/cli/JBang.java
+++ b/src/main/java/dev/jbang/cli/JBang.java
@@ -41,12 +41,12 @@ public class JBang extends BaseCommand {
 	public Integer doCall() throws IOException {
 		if (versionRequested) {
 			System.out.println(Util.getJBangVersion());
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 		if (commandInvocation != null) {
 			System.err.println(commandInvocation.getHelpInfo());
 		}
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 
 	public static int execute(String... args) {
@@ -57,7 +57,7 @@ public class JBang extends BaseCommand {
 				.args(newArgs)
 				.defaultValueProvider(new JBangDefaultValueProvider())
 				.execute();
-			return result != null ? result.getResultValue() : BaseCommand.EXIT_OK;
+			return result != null ? result.getResultValue() : ExitException.EXIT_OK;
 		} catch (ExitException e) {
 			return e.getStatus();
 		} catch (RuntimeException e) {

--- a/src/main/java/dev/jbang/cli/Jdk.java
+++ b/src/main/java/dev/jbang/cli/Jdk.java
@@ -153,7 +153,7 @@ public class Jdk extends BaseCommand {
 				Util.infoMsg("JDK is already installed: " + jdk);
 				Util.infoMsg("Use --force to install anyway");
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private boolean isValidInteger(String str) {
@@ -270,7 +270,7 @@ public class Jdk extends BaseCommand {
 					out.println("Available JDK Providers:");
 					providers.forEach(p -> out.println("   " + p.name()));
 				}
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} else if (listDistros) {
 				List<JdkDistroQuery.JdkDistro> distros = jdkMan.listDistros();
 				distros.sort(Comparator.comparing(JdkDistroQuery.JdkDistro::name));
@@ -281,7 +281,7 @@ public class Jdk extends BaseCommand {
 					out.println("Available JDK Distributions:");
 					distros.forEach(d -> out.println("   " + d.name()));
 				}
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 
 			List<JdkOut> jdkOuts;
@@ -354,7 +354,7 @@ public class Jdk extends BaseCommand {
 					out.printf("No JDKs %s%n", available ? "available" : "installed");
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -378,12 +378,13 @@ public class Jdk extends BaseCommand {
 				// If necessary we select JDKs from providers that can update JDKs
 				jdk = jdkMan.getInstalledJdk(versionOrId, JdkProvider.Predicates.canUpdate);
 				if (jdk == null) {
-					throw new ExitException(EXIT_INVALID_INPUT, "JDK " + versionOrId + " is not installed");
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+							"JDK " + versionOrId + " is not installed");
 				}
 			}
 			jdk.uninstall();
 			Util.infoMsg("Uninstalled JDK:\n  " + jdk.id());
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -405,7 +406,7 @@ public class Jdk extends BaseCommand {
 				String homeStr = Util.pathToString(home);
 				System.out.println(homeStr);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -465,7 +466,7 @@ public class Jdk extends BaseCommand {
 					break;
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -515,7 +516,7 @@ public class Jdk extends BaseCommand {
 				System.out.println(fullCmd);
 				return ExitException.EXIT_EXECUTE;
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -543,7 +544,7 @@ public class Jdk extends BaseCommand {
 			JdkManager jdkMan = jdkMixin.getJdkManager();
 			if (!jdkMan.hasDefaultProvider()) {
 				Util.warnMsg("Cannot perform operation, the 'default' provider was not found");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 			if (versionOrId != null) {
 				dev.jbang.devkitman.Jdk.InstalledJdk jdk = jdkMan.getOrInstallJdk(versionOrId);
@@ -597,7 +598,7 @@ public class Jdk extends BaseCommand {
 					}
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 }

--- a/src/main/java/dev/jbang/cli/Run.java
+++ b/src/main/java/dev/jbang/cli/Run.java
@@ -51,7 +51,7 @@ public class Run extends BaseBuildCommand {
 			if (commandInvocation != null) {
 				System.err.println(commandInvocation.getHelpInfo());
 			}
-			throw new ExitException(EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/ScriptMixin.java
+++ b/src/main/java/dev/jbang/cli/ScriptMixin.java
@@ -41,7 +41,7 @@ public class ScriptMixin {
 
 	public void validate() {
 		if (scriptOrFile == null) {
-			throw new ExitException(BaseCommand.EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
+			throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Missing required parameter: '<scriptOrFile>'");
 		}
 	}
 

--- a/src/main/java/dev/jbang/cli/Template.java
+++ b/src/main/java/dev/jbang/cli/Template.java
@@ -68,7 +68,7 @@ public class Template extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			if (name != null && !Catalog.isValidName(name)) {
-				throw new ExitException(EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"Invalid template name, it should start with a letter followed by 0 or more letters, digits, underscores or hyphens");
 			}
 
@@ -100,7 +100,7 @@ public class Template extends BaseCommand {
 					splitRefs.set(0, entry(target, firstRef.getValue()));
 					warn("No explicit target pattern was set, using first file: " + target + "=" + firstRef.getValue());
 				} else {
-					throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 							"A target pattern is required. Prefix at least one of the files with '{filename}=' or '{basename}.ext='");
 				}
 			}
@@ -124,10 +124,10 @@ public class Template extends BaseCommand {
 				CatalogUtil.addTemplate(catFile, name, fileRefsMap, description, propertiesMap);
 			} else {
 				Util.infoMsg("A template with name '" + name + "' already exists, use '--force' to add anyway.");
-				return EXIT_INVALID_INPUT;
+				return ExitException.EXIT_INVALID_INPUT;
 			}
 			info(String.format("Template '%s' added to '%s'", name, catFile));
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static Map<String, TemplateProperty> parseProperties(List<String> propStrings) {
@@ -184,11 +184,11 @@ public class Template extends BaseCommand {
 				target = ref[0];
 				Path t = Paths.get(target).normalize();
 				if (t.isAbsolute()) {
-					throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 							"Target name may not be absolute: '" + target + "'");
 				}
 				if (t.normalize().startsWith("..")) {
-					throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 							"Target may not refer to parent folders: '" + target + "'");
 				}
 			} else {
@@ -202,7 +202,7 @@ public class Template extends BaseCommand {
 			String source = splitRef.getValue();
 			ResourceRef resourceRef = ResourceRef.forResource(source);
 			if (resourceRef == null || !Files.isReadable(resourceRef.getFile())) {
-				throw new ExitException(BaseCommand.EXIT_INVALID_INPUT,
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT,
 						"File could not be found or read: '" + source + "'");
 			}
 			return true;
@@ -262,7 +262,7 @@ public class Template extends BaseCommand {
 				printTemplates(out, catalogName, catalog, showFiles,
 						showProperties, format);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		static void printTemplates(PrintStream out, String catalogName, Catalog catalog, boolean showFiles,
@@ -416,7 +416,7 @@ public class Template extends BaseCommand {
 			} else {
 				CatalogUtil.removeNearestTemplate(name);
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 }

--- a/src/main/java/dev/jbang/cli/Trust.java
+++ b/src/main/java/dev/jbang/cli/Trust.java
@@ -1,7 +1,5 @@
 package dev.jbang.cli;
 
-import static dev.jbang.cli.BaseCommand.EXIT_OK;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
@@ -14,6 +12,7 @@ import org.aesh.command.option.Option;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.net.TrustedSources;
 
@@ -36,7 +35,7 @@ public class Trust extends BaseCommand {
 		@Override
 		public Integer doCall() throws IOException {
 			TrustedSources.instance().add(rules);
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -58,7 +57,7 @@ public class Trust extends BaseCommand {
 					out.println(++idx + " = " + src);
 				}
 			}
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 	}
 
@@ -74,7 +73,7 @@ public class Trust extends BaseCommand {
 				.map(this::toDomain)
 				.collect(Collectors.toList());
 			TrustedSources.instance().remove(newrules, Settings.getTrustedSourcesFile().toFile());
-			return EXIT_OK;
+			return ExitException.EXIT_OK;
 		}
 
 		private String toDomain(String src) {

--- a/src/main/java/dev/jbang/cli/Version.java
+++ b/src/main/java/dev/jbang/cli/Version.java
@@ -28,7 +28,7 @@ public class Version extends BaseCommand {
 				try {
 					App.AppInstall.installJBang(true);
 				} catch (IOException e) {
-					throw new ExitException(EXIT_INTERNAL_ERROR, "Could not install command", e);
+					throw new ExitException(ExitException.EXIT_INTERNAL_ERROR, "Could not install command", e);
 				}
 			}
 		} else if (checkForUpdate) {
@@ -54,10 +54,10 @@ public class Version extends BaseCommand {
 			String cmdLauncherUpdate = App.AppInstall.cmdLauncherUpdateCommand();
 			if (cmdLauncherUpdate != null) {
 				System.out.println(cmdLauncherUpdate);
-				return EXIT_EXECUTE;
+				return ExitException.EXIT_EXECUTE;
 			}
 		}
 
-		return EXIT_OK;
+		return ExitException.EXIT_OK;
 	}
 }

--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -42,17 +42,18 @@ public class Wrapper extends BaseCommand {
 		public Integer doCall() {
 			Path destPath = dest != null ? dest : Paths.get(".");
 			if (!Files.isDirectory(destPath)) {
-				throw new ExitException(EXIT_INVALID_INPUT, "Destination folder does not exist");
+				throw new ExitException(ExitException.EXIT_INVALID_INPUT, "Destination folder does not exist");
 			}
 			if ((checkScripts(destPath) || checkJar(destPath.resolve(DIR_NAME))) && !force) {
 				Util.warnMsg("Wrapper already exists. Use --force to install anyway");
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			}
 			try {
 				Path jar = Util.getJarLocation();
 				String jarName = jar.getFileName().toString();
 				if (!jarName.endsWith(".jar") && !jarName.contains("jbang.bin")) {
-					throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't find JBang install location via " + jar);
+					throw new ExitException(ExitException.EXIT_GENERIC_ERROR,
+							"Couldn't find JBang install location via " + jar);
 				}
 				Path parent = jar.getParent();
 				if (checkScripts(parent) && checkJar(parent)) {
@@ -64,11 +65,11 @@ public class Wrapper extends BaseCommand {
 					copyScripts(parent.getParent(), destPath);
 					copyJar(parent, destPath);
 				} else {
-					throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't find JBang wrapper files");
+					throw new ExitException(ExitException.EXIT_GENERIC_ERROR, "Couldn't find JBang wrapper files");
 				}
-				return EXIT_OK;
+				return ExitException.EXIT_OK;
 			} catch (IOException e) {
-				throw new ExitException(EXIT_GENERIC_ERROR, "Couldn't copy JBang wrapper scripts", e);
+				throw new ExitException(ExitException.EXIT_GENERIC_ERROR, "Couldn't copy JBang wrapper scripts", e);
 			}
 		}
 


### PR DESCRIPTION
Replace all usages of the deprecated `EXIT_*` constants from `BaseCommand` with the non-deprecated versions from `ExitException`.

The constants in `BaseCommand` were deprecated in favor of the ones in `ExitException` to centralize exit code definitions.

### Changes
- Updated 22 files in `dev.jbang.cli` package
- Added `import dev.jbang.ExitException` where needed
- Changed bare `EXIT_*` and `BaseCommand.EXIT_*` references to `ExitException.EXIT_*`

### Testing
- `./gradlew compileJava` passes with no deprecation warnings for EXIT_* constants