### PR TITLE
fix: migrate remaining deprecated BaseCommand.EXIT_* usages

### DIFF
--- a/src/main/java/dev/jbang/cli/BaseCommand.java
+++ b/src/main/java/dev/jbang/cli/BaseCommand.java
@@ -156,13 +156,13 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 			return CommandResult.valueOf(e.getStatus());
 		} catch (IOException e) {
 			Util.errorMsg(null, e);
-			return CommandResult.valueOf(EXIT_GENERIC_ERROR);
+			return CommandResult.valueOf(ExitException.EXIT_GENERIC_ERROR);
 		} catch (IllegalArgumentException e) {
 			Util.errorMsg(null, e);
-			return CommandResult.valueOf(EXIT_INVALID_INPUT);
+			return CommandResult.valueOf(ExitException.EXIT_INVALID_INPUT);
 		} catch (Exception e) {
 			Util.errorMsg(null, e);
-			return CommandResult.valueOf(EXIT_INTERNAL_ERROR);
+			return CommandResult.valueOf(ExitException.EXIT_INTERNAL_ERROR);
 		}
 	}
 
@@ -173,7 +173,7 @@ public abstract class BaseCommand implements Command<CommandInvocation>, Command
 		if (commandInvocation != null) {
 			System.err.println(commandInvocation.getHelpInfo());
 		}
-		return EXIT_INVALID_INPUT;
+		return ExitException.EXIT_INVALID_INPUT;
 	}
 
 	@Override

--- a/src/test/java/dev/jbang/cli/TestAlias.java
+++ b/src/test/java/dev/jbang/cli/TestAlias.java
@@ -385,14 +385,14 @@ public class TestAlias extends BaseTest {
 		Files.write(testFile2, "// Test file 2".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
 		int exitCode = JBang.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(exitCode, equalTo(ExitException.EXIT_OK));
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(true));
 		Alias alias = Alias.get("name");
 		assertThat(alias.scriptRef, is("test.java"));
 		exitCode = JBang.execute("alias", "add", "-f", cwd.toString(), "--name=name", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(exitCode, equalTo(ExitException.EXIT_INVALID_INPUT));
 		exitCode = JBang.execute("alias", "add", "-f", cwd.toString(), "--name=name", "--force", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(exitCode, equalTo(ExitException.EXIT_OK));
 		alias = Alias.get("name");
 		assertThat(alias.scriptRef, is("test2.java"));
 	}

--- a/src/test/java/dev/jbang/cli/TestApp.java
+++ b/src/test/java/dev/jbang/cli/TestApp.java
@@ -119,7 +119,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		testScripts();
 	}
@@ -143,7 +143,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		testNativeScripts();
 	}
@@ -156,7 +156,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 
 	}
@@ -170,7 +170,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 
 	}
@@ -183,7 +183,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 
 		String cwd = examplesTestFolder.getParent().toString();
@@ -231,7 +231,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		result = checkedRun("app", "install", "--no-build", src);
 		assertThat(result.err,
@@ -246,7 +246,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		result = checkedRun("app", "install", "--no-build", "--force", src);
 		assertThat(result.err, containsString("Command installed: helloworld"));
@@ -294,7 +294,7 @@ public class TestApp extends BaseTest {
 			assertThat(Settings.getConfigBinDir().resolve("hello.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("hello.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 			assertThat(Settings.getConfigBinDir().resolve("hello").toFile(), anExistingFile());
 		}
 	}
@@ -307,7 +307,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		result = checkedRun("app", "install", "--no-build", "--name=hello", src);
 		assertThat(result.err,
@@ -322,7 +322,7 @@ public class TestApp extends BaseTest {
 		if (Util.isWindows()) {
 			assertThat(result.result, equalTo(ExitException.EXIT_EXECUTE));
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		}
 		result = checkedRun("app", "install", "--no-build", "--force", "--name=hello", src);
 		assertThat(result.err, containsString("Command installed: hello"));
@@ -339,7 +339,7 @@ public class TestApp extends BaseTest {
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 			assertThat(Settings.getConfigBinDir().resolve("apptest").toFile(), anExistingFile());
 		}
 	}
@@ -357,7 +357,7 @@ public class TestApp extends BaseTest {
 			assertThat(Settings.getConfigBinDir().resolve("apptest.cmd").toFile(), anExistingFile());
 			assertThat(Settings.getConfigBinDir().resolve("apptest.ps1").toFile(), anExistingFile());
 		} else {
-			assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+			assertThat(result.result, equalTo(ExitException.EXIT_OK));
 			assertThat(Settings.getConfigBinDir().resolve("apptest").toFile(), anExistingFile());
 		}
 	}
@@ -390,7 +390,7 @@ public class TestApp extends BaseTest {
 		checkedRun("app", "install", "--no-build", "--name=hello2", src);
 		checkedRun("app", "install", "--no-build", "--name=hello3", src);
 		CaptureResult<Integer> result = checkedRun("app", "list");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(result.normalizedOut(), equalTo("hello1\nhello2\nhello3\n"));
 	}
 
@@ -405,7 +405,7 @@ public class TestApp extends BaseTest {
 			assertThat(Settings.getConfigBinDir().resolve("helloworld").toFile(), anExistingFile());
 		}
 		CaptureResult<Integer> result = checkedRun("app", "uninstall", "helloworld");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(result.err, containsString("Command removed: helloworld"));
 		assertThat(Settings.getConfigBinDir().resolve("helloworld").toFile(), not(anExistingFile()));
 		assertThat(Settings.getConfigBinDir().resolve("helloworld.cmd").toFile(), not(anExistingFile()));
@@ -415,7 +415,7 @@ public class TestApp extends BaseTest {
 	@Test
 	void testAppUninstallUnknown() throws Exception {
 		CaptureResult<Integer> result = checkedRun("app", "uninstall", "hello");
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(result.result, equalTo(ExitException.EXIT_INVALID_INPUT));
 		assertThat(result.err, containsString("Command not found: hello"));
 	}
 

--- a/src/test/java/dev/jbang/cli/TestConfig.java
+++ b/src/test/java/dev/jbang/cli/TestConfig.java
@@ -13,10 +13,11 @@ import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
 import dev.jbang.Configuration;
+import dev.jbang.ExitException;
 
 public class TestConfig extends BaseTest {
 
-	private static final int SUCCESS_EXIT = BaseCommand.EXIT_OK;
+	private static final int SUCCESS_EXIT = ExitException.EXIT_OK;
 
 	static final String testConfig = "" +
 			"one=footop\n" +

--- a/src/test/java/dev/jbang/cli/TestExport.java
+++ b/src/test/java/dev/jbang/cli/TestExport.java
@@ -132,7 +132,7 @@ public class TestExport extends BaseTest {
 		// outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "mavenrepo", "-O", outFile.toString(),
 				"--group=my.thing.right", examplesTestFolder.resolve("helloworld.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(result.result, equalTo(ExitException.EXIT_INVALID_INPUT));
 
 	}
 
@@ -142,7 +142,7 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "mavenrepo", "--force", "-O",
 				outFile.toString(), examplesTestFolder.resolve("helloworld.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(result.result, equalTo(ExitException.EXIT_INVALID_INPUT));
 		assertThat(result.err, containsString("Add --group=<group id> and run again"));
 	}
 
@@ -151,7 +151,7 @@ public class TestExport extends BaseTest {
 		Path outFile = mavenTempDir;
 		CaptureResult<Integer> result = checkedRun("export", "mavenrepo", "--force",
 				"--group=g.a.v", examplesTestFolder.resolve("classpath_log.java").toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.jar").toFile(),
 				anExistingFile());
 		assertThat(outFile.resolve("g/a/v/classpath_log/999-SNAPSHOT/classpath_log-999-SNAPSHOT.pom").toFile(),
@@ -203,7 +203,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -222,7 +222,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/groovy/classpath_log.groovy");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -241,7 +241,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/kotlin/classpath_log.kt");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -260,7 +260,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/kotlin/classpath_main.kt");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -279,7 +279,7 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(),
 				"-g", "dev.jbang.test", "-a", "app", "-v", "1.2.3", src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -299,7 +299,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve(
 					"src/main/java/classpath_log_bom.java");
@@ -322,7 +322,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "gradle", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/exporttags.java");
@@ -373,7 +373,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -403,7 +403,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/RootOne.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -429,7 +429,7 @@ public class TestExport extends BaseTest {
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "maven", "--force", "-O", outFile.toString(),
 				"-g", "dev.jbang.test", "-a", "app", "-v", "1.2.3", src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/classpath_log.java");
 		assertThat(targetSrcPath.toFile(), anExistingFile());
@@ -459,7 +459,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		Path targetSrcPath = outFile.toPath()
 			.resolve(
 					"src/main/java/classpath_log_bom.java");
@@ -493,7 +493,7 @@ public class TestExport extends BaseTest {
 		File outFile = jbangTempDir.resolve("target").toFile();
 		outFile.mkdirs();
 		CaptureResult<Integer> result = checkedRun("export", "maven", "--force", "-O", outFile.toString(), src);
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 
 		Path targetSrcPath = outFile.toPath()
 			.resolve("src/main/java/exporttags.java");
@@ -557,7 +557,7 @@ public class TestExport extends BaseTest {
 		Path src = temp.resolve("test.java");
 		Util.writeString(src, code);
 		CaptureResult<Integer> result = checkedRun("export", "fatjar", src.toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(result.err, containsString("[WARN] Skipping conflicting duplicate file vs directory:"));
 	}
 
@@ -572,7 +572,7 @@ public class TestExport extends BaseTest {
 		Path src = temp.resolve("test.java");
 		Util.writeString(src, code);
 		CaptureResult<Integer> result = checkedRun("export", "fatjar", src.toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(result.err, containsString("[WARN] Skipping conflicting duplicate file vs directory:"));
 	}
 
@@ -588,7 +588,7 @@ public class TestExport extends BaseTest {
 		Path src = temp.resolve("test.java");
 		Util.writeString(src, code2);
 		CaptureResult<Integer> result = checkedRun("--verbose", "export", "fatjar", src.toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 		assertThat(result.err, containsString("Removing signature file:"));
 		assertThat(result.err, containsString("DUMMY.SF"));
 		assertThat(result.err, containsString("DUMMY.DSA"));
@@ -622,7 +622,7 @@ public class TestExport extends BaseTest {
 		Util.writeString(src, code);
 
 		CaptureResult<Integer> result = checkedRun("export", "fatjar", src.toString());
-		assertThat(result.result, equalTo(BaseCommand.EXIT_OK));
+		assertThat(result.result, equalTo(ExitException.EXIT_OK));
 
 		// Verify the merged service file contains both implementations
 		Path fatjar = cwdDir.resolve("svctest-fatjar.jar");

--- a/src/test/java/dev/jbang/cli/TestJdk.java
+++ b/src/test/java/dev/jbang/cli/TestJdk.java
@@ -36,7 +36,7 @@ import dev.jbang.util.Util;
 
 public class TestJdk extends BaseTest {
 
-	private static final int SUCCESS_EXIT = BaseCommand.EXIT_OK;
+	private static final int SUCCESS_EXIT = ExitException.EXIT_OK;
 	private static final String[] DEFAULT_PROVIDERS = { "--jdk-providers", "default,jbang,linked" };
 
 	@BeforeEach

--- a/src/test/java/dev/jbang/cli/TestTemplate.java
+++ b/src/test/java/dev/jbang/cli/TestTemplate.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import dev.jbang.BaseTest;
+import dev.jbang.ExitException;
 import dev.jbang.Settings;
 import dev.jbang.catalog.Catalog;
 import dev.jbang.catalog.Template;
@@ -152,7 +153,7 @@ public class TestTemplate extends BaseTest {
 		Files.write(testFile2, "// Test file 2".getBytes());
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)), is(false));
 		int exitCode = JBang.execute("template", "add", "-f", cwd.toString(), "--name=name", testFile.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(exitCode, equalTo(ExitException.EXIT_OK));
 		assertThat(Files.isRegularFile(Paths.get(cwd.toString(), Catalog.JBANG_CATALOG_JSON)),
 				is(true));
 		Template name = Template.get("name");
@@ -160,10 +161,10 @@ public class TestTemplate extends BaseTest {
 		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));
 		assertThat(name.fileRefs.values(), hasItems("test.java"));
 		exitCode = JBang.execute("template", "add", "-f", cwd.toString(), "--name=name", testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_INVALID_INPUT));
+		assertThat(exitCode, equalTo(ExitException.EXIT_INVALID_INPUT));
 		exitCode = JBang.execute("template", "add", "-f", cwd.toString(), "--name=name", "--force",
 				testFile2.toString());
-		assertThat(exitCode, equalTo(BaseCommand.EXIT_OK));
+		assertThat(exitCode, equalTo(ExitException.EXIT_OK));
 		name = Template.get("name");
 		assertThat(name.fileRefs, aMapWithSize(1));
 		assertThat(name.fileRefs.keySet(), hasItems("{basename}.java"));


### PR DESCRIPTION
Follow-up to #2644 - fixes remaining usages of deprecated `BaseCommand.EXIT_*` constants.

### Changes
- Test files: `TestApp.java`, `TestAlias.java`, `TestConfig.java`, `TestExport.java`, `TestJdk.java`, `TestTemplate.java`
- `BaseCommand.java` internal usages that were missed in the original PR