### PR TITLE
fix: allow {basename} sidecar files with different extensions

### DIFF
--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -205,9 +205,7 @@ public class Init extends BaseCommand {
 
 	static Path resolveBaseName(String refTarget, String refSource, String outName) {
 		String result = refTarget;
-		if (dev.jbang.cli.Template.TPL_FILENAME_PATTERN.matcher(refTarget).find()
-				|| dev.jbang.cli.Template.TPL_BASENAME_PATTERN.matcher(refTarget).find()) {
-			String baseName = Util.base(outName);
+		if (dev.jbang.cli.Template.TPL_FILENAME_PATTERN.matcher(refTarget).find()) {
 			String outExt = Util.extension(outName);
 			String targetExt = Util.extension(refTarget);
 			if (targetExt.isEmpty()) {
@@ -219,6 +217,9 @@ public class Init extends BaseCommand {
 						"Template expects " + targetExt + " extension, not " + outExt);
 			}
 			result = dev.jbang.cli.Template.TPL_FILENAME_PATTERN.matcher(result).replaceAll(outName);
+		}
+		if (dev.jbang.cli.Template.TPL_BASENAME_PATTERN.matcher(refTarget).find()) {
+			String baseName = Util.base(outName);
 			result = dev.jbang.cli.Template.TPL_BASENAME_PATTERN.matcher(result).replaceAll(baseName);
 		}
 		return Paths.get(result);

--- a/src/main/java/dev/jbang/cli/Init.java
+++ b/src/main/java/dev/jbang/cli/Init.java
@@ -116,6 +116,8 @@ public class Init extends BaseCommand {
 		propsMap.put("javaVersion", reqVersion);
 		propsMap.put("compactSourceFiles", reqVersion >= 25);
 
+		validateOutputExtension(tpl.fileRefs, outName);
+
 		List<RefTarget> refTargets = tpl.fileRefs.entrySet()
 			.stream()
 			.map(e -> entry(
@@ -201,6 +203,30 @@ public class Init extends BaseCommand {
 				}
 			}
 		}
+	}
+
+	static void validateOutputExtension(Map<String, String> fileRefs, String outName) {
+		String outExt = Util.extension(outName);
+		if (outExt.isEmpty() || fileRefs.keySet()
+			.stream()
+			.anyMatch(target -> dev.jbang.cli.Template.TPL_FILENAME_PATTERN.matcher(target).find())) {
+			return;
+		}
+		fileRefs.entrySet()
+			.stream()
+			.filter(entry -> dev.jbang.cli.Template.TPL_BASENAME_PATTERN.matcher(entry.getKey()).find())
+			.findFirst()
+			.ifPresent(entry -> {
+				String targetExt = Util.extension(entry.getKey());
+				if (targetExt.isEmpty()) {
+					targetExt = entry.getValue().endsWith(".qute") ? Util.extension(Util.base(entry.getValue()))
+							: Util.extension(entry.getValue());
+				}
+				if (!outExt.equals(targetExt)) {
+					throw new ExitException(ExitException.EXIT_INVALID_INPUT,
+							"Template expects " + targetExt + " extension, not " + outExt);
+				}
+			});
 	}
 
 	static Path resolveBaseName(String refTarget, String refSource, String outName) {

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -387,4 +387,24 @@ public class TestInit extends BaseTest {
 
 	}
 
+	@Test
+	void testResolveBaseNameShouldResolveFilenameOrBasename() {
+		// Use case when the {filename} should be resolved to the input name -
+		// result.java
+		String scriptName = "result.java";
+		Path path = Init.resolveBaseName("{filename}", "template-for-script.java", scriptName);
+		assertThat(path.toString(), containsString("result.java"));
+
+		// Use case when the {filename} can not be resolved because the input is
+		// result.java but the reference source has .tf extension not .java
+		ExitException exitException = assertThrows(ExitException.class,
+				() -> Init.resolveBaseName("{filename}", "template-for-script.tf", scriptName));
+		String exceptionMessage = "Template expects tf extension, not java";
+		assertThat(exitException.getMessage(), containsString(exceptionMessage));
+
+		// Use case when the {basename} is being used with prefix and with not .java
+		// extension, and the reference soure also has the .tf extension
+		path = Init.resolveBaseName("template-for-{basename}.tf", "template-for-script.tf", scriptName);
+		assertThat(path.toString(), containsString("template-for-result.tf"));
+	}
 }

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -356,4 +356,35 @@ public class TestInit extends BaseTest {
 
 	}
 
+	@Test
+	void testInitUsingTemplateWithFilenameAndBasename() throws IOException {
+		Path cwd = Util.getCwd();
+		Path javaFileQute = Files.write(cwd.resolve("file1.java.qute"), "Hello World".getBytes());
+		Path tfFileQute = Files.write(cwd.resolve("file2.tf.qute"), "Hello World from .tf file".getBytes());
+		Path outJava = cwd.resolve("result.java");
+		Path outTf = cwd.resolve("prefixed-result.tf");
+
+		JBang	.getCommandLine()
+				.execute("template", "add", "-f", cwd.toString(), "--name=template-with-more-files",
+						"{filename}" + "=" + javaFileQute.toAbsolutePath().toString(),
+						"prefixed-{basename}.tf" + "=" + tfFileQute.toAbsolutePath().toString());
+
+		assertThat(outJava.toFile().exists(), not(true));
+
+		int result = JBang	.getCommandLine()
+							.execute("init", "--verbose", "--template=template-with-more-files",
+									outJava.toAbsolutePath().toString());
+
+		assertThat(result, is(0));
+		assertThat(outJava.toFile().exists(), is(true));
+		assertThat(outTf.toFile().exists(), is(true));
+
+		String javaContent = Util.readString(outJava);
+		String tfContent = Util.readString(outTf);
+
+		assertThat(javaContent, containsString("Hello World"));
+		assertThat(tfContent, containsString("Hello World from .tf file"));
+
+	}
+
 }

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -369,16 +369,14 @@ public class TestInit extends BaseTest {
 		Path outJava = cwd.resolve("result.java");
 		Path outTf = cwd.resolve("prefixed-result.tf");
 
-		JBang	.getCommandLine()
-				.execute("template", "add", "-f", cwd.toString(), "--name=template-with-more-files",
-						"{filename}" + "=" + javaFileQute.toAbsolutePath().toString(),
-						"prefixed-{basename}.tf" + "=" + tfFileQute.toAbsolutePath().toString());
+		JBang.execute("template", "add", "-f", cwd.toString(), "--name=template-with-more-files",
+				"{filename}" + "=" + javaFileQute.toAbsolutePath().toString(),
+				"prefixed-{basename}.tf" + "=" + tfFileQute.toAbsolutePath().toString());
 
 		assertThat(outJava.toFile().exists(), not(true));
 
-		int result = JBang	.getCommandLine()
-							.execute("init", "--verbose", "--template=template-with-more-files",
-									outJava.toAbsolutePath().toString());
+		int result = JBang.execute("init", "--verbose", "--template=template-with-more-files",
+				outJava.toAbsolutePath().toString());
 
 		assertThat(result, is(0));
 		assertThat(outJava.toFile().exists(), is(true));

--- a/src/test/java/dev/jbang/cli/TestInit.java
+++ b/src/test/java/dev/jbang/cli/TestInit.java
@@ -218,6 +218,11 @@ public class TestInit extends BaseTest {
 		testFailMultipleFiles("{filename}", "edit.md", "edit.java", true, 2);
 	}
 
+	@Test
+	void testInitMultipleFilesWrongName2() throws IOException {
+		testFailMultipleFiles("{basename}.java", "edit.md", "edit.java", true, 2);
+	}
+
 	void testInitMultipleFiles(String targetName, String initName, String outName, boolean abs) throws IOException {
 		Path outFile = setupInitMultipleFiles(targetName, initName, abs);
 		int result = JBang.execute("init", "-t=name", outFile.toString());


### PR DESCRIPTION
Revives and rebases #1319 from @nandorholozsnyak onto current `main`.

Fixes #1318.

Templates may use `{filename}` for their primary output and `{basename}` for sidecar files with different extensions, for example:

```text
{filename}=aws-lambda.java.qute
lambda-{basename}.tf=lambda.tf.qute
```

Extension validation now applies to the primary template output rather than every `{basename}` sidecar. Templates containing only `{basename}` entries still validate against the first entry, preserving the behavior requested in the original review.

Also updates the original tests to use the current `JBang.execute()` API.

## Verification

- `./gradlew test --tests dev.jbang.cli.TestInit` — passes (31 tests, 1 skipped)
- `./gradlew spotlessApply` — passes
- Full `./gradlew build` reaches tests; the four failures in `TestScriptDownloadVersion` and `TestPlugins` reproduce unchanged on current `main` in this environment.