### PR TITLE
fix: pass system properties to native images

### DIFF
--- a/docs/modules/ROOT/pages/native-images.adoc
+++ b/docs/modules/ROOT/pages/native-images.adoc
@@ -111,6 +111,44 @@ Or from command line:
 jbang --native --native-option="-O2" --native-option="--no-fallback" app.java
 ----
 
+== System Properties and Runtime Options
+
+System properties reach a native binary the same way they reach a JVM: JBang passes them on the
+executable's command line, and the image runtime consumes them before your `main` method is called.
+
+[source,bash]
+----
+jbang --native -Dgreeting=hello myapp.java
+----
+
+This covers both properties given with `-D` on the command line and those set with a
+`//RUNTIME_OPTIONS` directive:
+
+[source,java]
+----
+//RUNTIME_OPTIONS -Dgreeting=hello
+----
+
+Other runtime options are *not* passed to a native binary, and JBang warns when you supply any:
+
+[source,bash]
+----
+$ jbang --native --runtime-option=-Xmx128m myapp.java
+[jbang] [WARN] Runtime options are not supported by a native image and are ignored: -Xmx128m
+----
+
+The reason is that a native image treats them very differently from a JVM. An unknown `-XX:` flag
+makes the binary refuse to start, while options it does not recognise at all — `-agentlib:`,
+`-verbose:gc` and similar — are left in the argument list and arrive in your program's `args` array.
+Passing them through would break the run or silently corrupt your arguments, so JBang reports them
+instead.
+
+If you need to tune the generated binary, do it at build time with `//NATIVE_OPTIONS` or
+`--native-option` rather than at run time.
+
+NOTE: The image runtime removes `-D` and `-X` arguments from anywhere on the command line, so a
+native script cannot receive a program argument that starts with either prefix.
+
 == Common Native Image Configurations
 
 === CLI Applications

--- a/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
+++ b/src/main/java/dev/jbang/source/CmdGeneratorBuilder.java
@@ -141,7 +141,8 @@ public class CmdGeneratorBuilder {
 
 	private NativeCmdGenerator createNativeCmdGenerator() {
 		return new NativeCmdGenerator(ctx, createJarCmdGenerator())
-			.arguments(arguments);
+			.arguments(arguments)
+			.runtimeOptions(runtimeOptions);
 	}
 
 	private void updateFromAlias(Alias alias) {

--- a/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
+++ b/src/main/java/dev/jbang/source/generators/NativeCmdGenerator.java
@@ -4,18 +4,28 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import dev.jbang.source.BuildContext;
 import dev.jbang.source.CmdGenerator;
+import dev.jbang.source.Project;
 import dev.jbang.util.Util;
 
 public class NativeCmdGenerator extends BaseCmdGenerator<NativeCmdGenerator> {
 	private final CmdGenerator fallback;
 
+	private List<String> runtimeOptions = Collections.emptyList();
+
 	public NativeCmdGenerator(BuildContext ctx, CmdGenerator fallback) {
 		super(ctx);
 		this.fallback = fallback;
+	}
+
+	public NativeCmdGenerator runtimeOptions(List<String> runtimeOptions) {
+		this.runtimeOptions = runtimeOptions != null ? runtimeOptions : Collections.emptyList();
+		return this;
 	}
 
 	@Override
@@ -34,6 +44,8 @@ public class NativeCmdGenerator extends BaseCmdGenerator<NativeCmdGenerator> {
 			return fallback.generate();
 		}
 
+		addPropertyFlags(fullArgs);
+
 		fullArgs.addAll(arguments);
 
 		return generateCommandLineString(fullArgs);
@@ -42,5 +54,52 @@ public class NativeCmdGenerator extends BaseCmdGenerator<NativeCmdGenerator> {
 	@Override
 	protected List<String> generateCommandLineList() throws IOException {
 		return null;
+	}
+
+	/**
+	 * Passes the system properties on to the native executable.
+	 *
+	 * <p>
+	 * A native image accepts <code>-Dkey=value</code> at run time just like a JVM
+	 * does, so properties set with <code>-D</code> or with a
+	 * <code>//RUNTIME_OPTIONS</code> directive can simply be handed to the binary.
+	 * They are consumed by the image runtime and never reach
+	 * <code>main(String[])</code>.
+	 *
+	 * <p>
+	 * Any other runtime option is deliberately <em>not</em> passed on, because for
+	 * a native image it either fails the run or silently corrupts the program's
+	 * arguments: an unknown <code>-XX:</code> flag makes the binary exit with
+	 * "Could not find option", while options the image runtime does not recognise
+	 * at all (<code>-agentlib:</code>, <code>-verbose:gc</code>, ...) are left in
+	 * place and arrive as program arguments. Since dropping them silently is what
+	 * made this hard to diagnose in the first place, we say so instead.
+	 *
+	 * @param result the argument list to add the flags to
+	 */
+	private void addPropertyFlags(List<String> result) {
+		Project project = ctx.getProject();
+		for (Map.Entry<String, String> entry : project.getProperties().entrySet()) {
+			result.add("-D" + entry.getKey() + "=" + entry.getValue());
+		}
+
+		List<String> ignored = new ArrayList<>();
+		for (String option : allRuntimeOptions(project)) {
+			if (option.startsWith("-D")) {
+				result.add(option);
+			} else {
+				ignored.add(option);
+			}
+		}
+		if (!ignored.isEmpty()) {
+			Util.warnMsg("Runtime options are not supported by a native image and are ignored: "
+					+ String.join(" ", ignored));
+		}
+	}
+
+	private List<String> allRuntimeOptions(Project project) {
+		List<String> options = new ArrayList<>(project.getRuntimeOptions());
+		options.addAll(runtimeOptions);
+		return options;
 	}
 }

--- a/src/test/java/dev/jbang/source/TestNativeCmdGenerator.java
+++ b/src/test/java/dev/jbang/source/TestNativeCmdGenerator.java
@@ -1,0 +1,94 @@
+package dev.jbang.source;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import dev.jbang.BaseTest;
+
+/**
+ * A native image is run directly, so anything JBang wants the program to see
+ * has to be on its command line. These tests pin what does and does not get
+ * passed.
+ */
+public class TestNativeCmdGenerator extends BaseTest {
+
+	/**
+	 * Builds the command line for a native run of the given script without actually
+	 * invoking the native image compiler: an empty file at the expected image
+	 * location is enough for the generator to take its normal path instead of
+	 * falling back to java mode.
+	 */
+	private String generateNativeCmd(Path script, java.util.Map<String, String> properties,
+			java.util.List<String> runtimeOptions) throws IOException {
+		ProjectBuilder pb = Project.builder().nativeImage(true);
+		if (properties != null) {
+			pb.setProperties(properties);
+		}
+		Project prj = pb.build(script.toString());
+		BuildContext ctx = BuildContext.forProject(prj);
+		Path image = ctx.getNativeImageFile();
+		Files.createDirectories(image.getParent());
+		Files.write(image, new byte[0]);
+		return CmdGenerator.builder(ctx)
+			.runtimeOptions(runtimeOptions)
+			.build()
+			.generate();
+	}
+
+	@Test
+	void testNativePassesProperties() throws IOException {
+		Path script = examplesTestFolder.resolve("quote.java").toAbsolutePath();
+		String cmd = generateNativeCmd(script, Collections.singletonMap("foo", "bar"), null);
+
+		assertThat(cmd, containsString("-Dfoo=bar"));
+	}
+
+	@Test
+	void testNativePassesPropertiesBeforeArguments() throws IOException {
+		Path script = examplesTestFolder.resolve("quote.java").toAbsolutePath();
+		ProjectBuilder pb = Project.builder().nativeImage(true);
+		pb.setProperties(Collections.singletonMap("foo", "bar"));
+		Project prj = pb.build(script.toString());
+		BuildContext ctx = BuildContext.forProject(prj);
+		Path image = ctx.getNativeImageFile();
+		Files.createDirectories(image.getParent());
+		Files.write(image, new byte[0]);
+
+		String cmd = CmdGenerator.builder(ctx)
+			.setArguments(Collections.singletonList("anarg"))
+			.build()
+			.generate();
+
+		// the image runtime consumes -D from anywhere, but keeping the flags in
+		// front of the user's arguments matches what the jar generator does
+		assertThat(cmd.indexOf("anarg"), greaterThan(cmd.indexOf("-Dfoo=bar")));
+		assertThat(cmd.indexOf("-Dfoo=bar"), greaterThan(cmd.indexOf(".bin")));
+	}
+
+	@Test
+	void testNativePassesDashDRuntimeOptions() throws IOException {
+		Path script = examplesTestFolder.resolve("quote.java").toAbsolutePath();
+		String cmd = generateNativeCmd(script, null, Collections.singletonList("-Dfrom=option"));
+
+		assertThat(cmd, containsString("-Dfrom=option"));
+	}
+
+	@Test
+	void testNativeIgnoresOtherRuntimeOptions() throws IOException {
+		Path script = examplesTestFolder.resolve("quote.java").toAbsolutePath();
+		String cmd = generateNativeCmd(script, null, Collections.singletonList("-Xmx128m"));
+
+		// a native image either rejects unknown JVM flags outright or leaves them in
+		// place, where they arrive as program arguments; neither is useful
+		assertThat(cmd, not(containsString("-Xmx128m")));
+	}
+}


### PR DESCRIPTION
Fixes #2649

A script run with --native never saw the -D properties given to JBang.
NativeCmdGenerator emitted only the image path and the user's arguments,
and NativeBuildStep does not hand them to native-image either, so nothing
was baked in at build time as a fallback. The properties were still applied
while building - for directive substitution and dependency resolution - so
`jbang --native -Dfoo=bar` could visibly change which dependencies were
resolved and then vanish before main() ran, without a warning.

A native image accepts -Dkey=value at run time just like a JVM does, so the
flags can simply be passed to the binary. Properties from -D and from a
//RUNTIME_OPTIONS directive are now forwarded.

Other runtime options are deliberately not forwarded, because a native image
treats them very differently: an unknown -XX: flag makes the binary exit with
"Could not find option", and options the image runtime does not recognise at
all (-agentlib:, -verbose:gc, ...) stay in the argument list and arrive as
program arguments. Since dropping them silently is what made this hard to
diagnose, JBang now warns instead.
