### PR TITLE
feat: upgrade embedded Gradle to 9.7.1

### DIFF
--- a/src/main/java/dev/jbang/cli/Export.java
+++ b/src/main/java/dev/jbang/cli/Export.java
@@ -725,7 +725,8 @@ public class Export extends BaseCommand {
 				.data("compilerArgs", compilerArgs)
 				.render();
 			Util.writeString(destination, result);
-			Util.writeString(projectDir.resolve("settings.gradle"), "");
+			Util.writeString(projectDir.resolve("settings.gradle"), "plugins {\n" + "  "
+					+ "id \"org.gradle.toolchains.foojay-resolver-convention\" version \"1.0.0\"\n" + "}");
 			Util.writeString(projectDir.resolve("gradle.properties"), "org.gradle.configuration-cache=true\n");
 		}
 

--- a/src/main/resources/dist/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/src/main/resources/dist/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/dist/gradle/update-version.sh
+++ b/src/main/resources/dist/gradle/update-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export GRADLE_VERSION=8.14.5
+export GRADLE_VERSION=9.7.1
 
 mv gradle/wrapper/gradle-wrapper-jar gradle/wrapper/gradle-wrapper.jar
 


### PR DESCRIPTION
`jbang export gradle hello.java` will now create a Gradle 9.7.1 build environment.