### PR TITLE
fix: set wrapper file timestamps to the current time instead of 1980

### DIFF
--- a/src/main/java/dev/jbang/cli/Wrapper.java
+++ b/src/main/java/dev/jbang/cli/Wrapper.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
@@ -84,6 +86,7 @@ public class Wrapper extends BaseCommand {
 		private void copyScripts(Path dir, Path dest) throws IOException {
 			for (String nm : SCRIPT_NAMES) {
 				Files.copy(dir.resolve(nm), dest.resolve(nm), COPY_ATTRIBUTES, REPLACE_EXISTING);
+				Files.setLastModifiedTime(dest.resolve(nm), FileTime.from(Instant.now()));
 			}
 		}
 
@@ -91,6 +94,7 @@ public class Wrapper extends BaseCommand {
 			Path jbdir = dest.resolve(DIR_NAME);
 			jbdir.toFile().mkdirs();
 			Files.copy(dir.resolve(JAR_NAME), jbdir.resolve(JAR_NAME), COPY_ATTRIBUTES, REPLACE_EXISTING);
+			Files.setLastModifiedTime(jbdir.resolve(JAR_NAME), FileTime.from(Instant.now()));
 		}
 	}
 }


### PR DESCRIPTION
`jbang wrapper install` copies the launcher scripts and the jar with COPY_ATTRIBUTES, which carries over the timestamps of the JBang installation they come from. For a released JBang those timestamps come out of its distribution archive, and since the build enables reproducible builds Gradle stamps every entry with its fixed 1980-02-01 constant. Every generated wrapper therefore looked like it was last modified in 1980.

Keep copying the attributes, so the scripts stay executable, and set the modification time of each copy to the current time right after.

Fixes #300
